### PR TITLE
fix is_fair_deleverage criteria

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -287,7 +287,7 @@ $$ {TR}\_{new} \lt {TR\_{old}} $$
 
 checks if the deleverage is fair.
 
-$$ \frac{TV\_{new}-1e^{-6}USDC}{TR\_{new}} \leq \frac{TV}{TR}\_{old} \leq \frac{TV\_{new}}{TR}\_{new} $$
+$$ \frac{TV\_{new}-1e^{-6}USDC}{TR\_{new}} \leq \frac{TV}{TR}\_{old} \leq \frac{TV\_{new}}{{TR}\_{new}} $$
 
 Deleveragerer should be [healthy](#healthy) or [healthier](#is-healthier).
 Deleveragree should be ([healthy](#healthy) or [healthier](#is-healthier)) **and** [is fair deleverage](#is-fair-deleverage)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -287,7 +287,7 @@ $$ {TR}\_{new} \lt {TR\_{old}} $$
 
 checks if the deleverage is fair.
 
-$$ \frac{TV\_{new}-1e^{-6}USDC}{TR\_{new}} \leq \frac{TV}{TR}\_{old} \leq \frac{TV}{TR}\_{new} $$
+$$ \frac{TV\_{new}-1e^{-6}USDC}{TR\_{new}} \leq \frac{TV}{TR}\_{old} \leq \frac{TV\_{new}}{TR}\_{new} $$
 
 Deleveragerer should be [healthy](#healthy) or [healthier](#is-healthier).
 Deleveragree should be ([healthy](#healthy) or [healthier](#is-healthier)) **and** [is fair deleverage](#is-fair-deleverage)


### PR DESCRIPTION
**Before**

$$ \frac{TV\_{new}-1e^{-6}USDC}{TR\_{new}} \leq \frac{TV}{TR}\_{old} \leq \frac{TV}{TR}\_{new} $$

**After**

$$ \frac{TV\_{new}-1e^{-6}USDC}{TR\_{new}} \leq \frac{TV}{TR}\_{old} \leq \frac{TV\_{new}}{{TR}\_{new}} $$

**Reasoning**

Since $TV < 0$ and $0 \le TR_{new} < TR_{old}$, the following inequality holds:

$$\frac{TV}{TR}\_{old} > \frac{TV}{TR}\_{new} $$

, which implies that **Before** condition can never hold.

Also, `is_fair_deleverage` check is to maintain the original $TV/TR$ ratio, so **After** condition makes more sense.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/3)
<!-- Reviewable:end -->
