### PR TITLE
feat(vault-perp): add hash impl for withdraw from vault

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -908,10 +908,10 @@ impl StructHashImpl of StructHash<DepositIntoVaultArgs> {
 pub struct WithdrawFromVaultUserArgs {
     pub position_id: PositionId,
     pub vault_position_id: PositionId,
-    pub collateral_id: AssetId, 
+    pub collateral_id: AssetId,
     pub number_of_shares: u64
-    pub minimum_quantized_amount: u64,
-    pub expiration: Timestamp, 
+    pub minimum_received_total_amount: u64,
+    pub expiration: Timestamp,
     pub salt: felt
 }
 
@@ -919,17 +919,13 @@ pub struct WithdrawFromVaultUserArgs {
 ///   "\"WithdrawFromVaultUserArgs\"(
 ///    \"position_id\":\"PositionId\",
 ///    \"vault_position_id\":\"PositionId\",
-///    \"collateral_id\":\"AssetId\",
 ///    \"number_of_shares\":\"u64\",
-///    \"minimum_quantized_amount\":\"u64\",
+///    \"minimum_received_total_amount\":\"u64\",
 ///    \"expiration\":\"Timestamp\",
 ///    \"salt\":\"felt\"
 ///    )
 ///    \"PositionId\"(
 ///    \"value\":\"u32\"
-///    )"
-///    \"AssetId\"(
-///    \"value\":\"felt\"
 ///    )"
 ///    \"Timestamp\"(
 ///    \"seconds\":\"u64\"
@@ -950,7 +946,7 @@ impl StructHashImpl of StructHash<WithdrawFromVaultUserArgs> {
 
 ```rust
 pub struct WithdrawFromVaultOwnerArgs {
-    user_hash: HashType, 
+    user_hash: HashType,
     vault_share_execution_price: Price
 }
 
@@ -2349,13 +2345,13 @@ Only the Operator can execute.
 **Validations:**
 
 1. `asset_id` is not registered.
-2. 
-3. 
+2.
+3.
 
 **Logic:**
 
-1. 
-2. 
+1.
+2.
 
 **Errors:**
 
@@ -2941,7 +2937,7 @@ pub struct WithdrawnFromVault {
     #[key]
     pub collateral_id: AssetId,
     pub number_of_shares: u64,
-    pub minimum_quantized_amount: u64,
+    pub minimum_received_total_amount: u64,
     pub vault_share_execution_price: Price,
     pub expiration: Timestamp,
     pub salt: felt252,
@@ -2960,7 +2956,7 @@ pub struct LiquidatedFromVault {
     #[key]
     pub collateral_id: AssetId,
     pub number_of_shares: u64,
-    pub minimum_quantized_amount: u64,
+    pub minimum_received_total_amount: u64,
     pub vault_share_execution_price: Price,
     pub expiration: Timestamp,
     pub salt: felt252,
@@ -3322,8 +3318,8 @@ Only the Operator can execute.
 
 #### Multi Trade
 
-Executes multiple trades in a single operation.  
-Each trade is validated and executed using the same logic as a single trade.  
+Executes multiple trades in a single operation.
+Each trade is validated and executed using the same logic as a single trade.
 All trades are processed within one transaction.
 
 ```rust
@@ -3658,9 +3654,8 @@ fn withdraw_from_vault(
     operator_nonce: u64,
     position_id: PositionId,
     vault_position_id: PositionId,
-    collateral_id: AssetId,
     number_of_shares: u64,
-    minimum_quantized_amount: u64,
+    minimum_received_total_amount: u64,
     vault_share_execution_price: Price,
     expiration: Timestamp,
     salt: felt252,
@@ -3690,11 +3685,11 @@ Only the Operator can execute.
 7. `vault_position_id` is a registered vault position.
 8. position id is not a vault position and exists.
 9. number_of_shares is non zero.
-10. minimum_quantized_amount is non zero.
+10. minimum_received_total_amount is non zero.
 11. vault_share_execution_price is non zero.
 12. Caller is the operator.
 13. Request is new (check user payload hash not exists in the fulfillment map).
-14. `number_of_shares * vault_share_execution_price >= minimum_quantized_amount`
+14. `number_of_shares * vault_share_execution_price >= minimum_received_total_amount`
 
 **Logic:**
 

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -40,7 +40,7 @@ pub mod Core {
         Position, PositionDiff, PositionDiffEnriched, PositionId, PositionTrait,
         SyntheticEnrichedPositionDiff,
     };
-    use perpetuals::core::types::price::PriceMulTrait;
+    use perpetuals::core::types::price::{Price, PriceMulTrait};
     use perpetuals::core::types::register_vault::RegisterVaultArgs;
     use perpetuals::core::types::transfer::TransferArgs;
     use perpetuals::core::types::withdraw::WithdrawArgs;
@@ -927,7 +927,7 @@ pub mod Core {
         /// Validations:
         /// - Ensures the contract is not paused.
         /// - Validates the operator nonce.
-        /// - Checks asset integrity.
+        /// - Checks price integrity.
         /// - Retrieves the vault share asset ID associated with the vault position.
         /// - Validates the deposit parameters including position IDs, amount, expiration,
         ///   and signature. Refer to `_validate_deposit_into_vault` for detailed validation steps.
@@ -952,7 +952,8 @@ pub mod Core {
             /// Validations:
             self.pausable.assert_not_paused();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
-            self.assets.validate_assets_integrity();
+            let current_time = Time::now();
+            self.assets.validate_price_interval_integrity(:current_time);
 
             let vault_share_asset_id = self.vault_positions_to_assets.read(vault_position_id);
             self
@@ -1034,6 +1035,27 @@ pub mod Core {
                         vault_position_id, vault_contract_address, vault_asset_id, expiration,
                     },
                 )
+        }
+
+        fn withdraw_from_vault(
+            ref self: ContractState,
+            operator_nonce: u64,
+            position_id: PositionId,
+            vault_position_id: PositionId,
+            number_of_shares: u64,
+            minimum_received_total_amount: u64,
+            vault_share_execution_price: Price,
+            expiration: Timestamp,
+            salt: felt252,
+            user_signature: Signature,
+            vault_owner_signature: Signature,
+        ) {
+            /// Validations:
+            self.pausable.assert_not_paused();
+            self.operator_nonce.use_checked_nonce(:operator_nonce);
+            let current_time = Time::now();
+            self.assets.validate_price_interval_integrity(:current_time);
+            /// Executions:
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -1,6 +1,7 @@
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::order::Order;
 use perpetuals::core::types::position::PositionId;
+use perpetuals::core::types::price::Price;
 use starknet::ContractAddress;
 use starkware_utils::signature::stark::Signature;
 use starkware_utils::time::time::Timestamp;
@@ -106,7 +107,6 @@ pub trait ICore<TContractState> {
         salt: felt252,
         signature: Signature,
     );
-
     fn register_vault(
         ref self: TContractState,
         operator_nonce: u64,
@@ -115,5 +115,18 @@ pub trait ICore<TContractState> {
         vault_asset_id: AssetId,
         expiration: Timestamp,
         signature: Signature,
+    );
+    fn withdraw_from_vault(
+        ref self: TContractState,
+        operator_nonce: u64,
+        position_id: PositionId,
+        vault_position_id: PositionId,
+        number_of_shares: u64,
+        minimum_received_total_amount: u64,
+        vault_share_execution_price: Price,
+        expiration: Timestamp,
+        salt: felt252,
+        user_signature: Signature,
+        vault_owner_signature: Signature,
     );
 }

--- a/workspace/apps/perpetuals/contracts/src/core/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types.cairo
@@ -11,3 +11,4 @@ pub mod set_owner_account;
 pub mod set_public_key;
 pub mod transfer;
 pub mod withdraw;
+pub mod withdraw_from_vault;

--- a/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
@@ -21,7 +21,7 @@ const ORACLE_SCALE_SN_PERPS_RATIO: u128 = ORACLE_SCALE / SN_PERPS_SCALE;
 
 const MAX_PRICE_ERROR: felt252 = 'Value must be < 2^56';
 
-#[derive(Copy, Debug, Default, Drop, PartialEq, Serde, starknet::Store)]
+#[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde, starknet::Store)]
 /// Price is the price of a synthetic asset in the Perps system.
 /// The price is the price of the minimal unit of the asset in 10^-6 USD.
 pub struct Price {

--- a/workspace/apps/perpetuals/contracts/src/core/types/withdraw_from_vault.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/withdraw_from_vault.cairo
@@ -1,0 +1,96 @@
+use core::hash::{HashStateExTrait, HashStateTrait};
+use core::poseidon::PoseidonTrait;
+use openzeppelin::utils::snip12::StructHash;
+use perpetuals::core::types::position::PositionId;
+use perpetuals::core::types::price::Price;
+use starkware_utils::signature::stark::HashType;
+use starkware_utils::time::time::Timestamp;
+
+#[derive(Copy, Drop, Hash, Serde)]
+pub struct VaultWithdrawUserArgs {
+    pub position_id: PositionId,
+    pub vault_position_id: PositionId,
+    pub number_of_shares: u64,
+    pub minimum_received_total_amount: u64,
+    pub expiration: Timestamp,
+    pub salt: felt252,
+}
+
+/// selector!(
+///   "\"VaultWithdrawUserArgs\"(
+///    \"position_id\":\"PositionId\",
+///    \"vault_position_id\":\"PositionId\",
+///    \"number_of_shares\":\"u64\",
+///    \"minimum_received_total_amount\":\"u64\",
+///    \"expiration\":\"Timestamp\",
+///    \"salt\":\"felt\"
+///    )
+///    \"PositionId\"(
+///    \"value\":\"u32\"
+///    )"
+///    \"Timestamp\"(
+///    \"seconds\":\"u64\"
+///    )
+/// );
+const VAULT_WITHDRAW_USER_ARGS_TYPE_HASH: HashType =
+    0x024a7af4be650a8ef7493afece1209f2deff67a1aeb72125e67eb460254f8db0;
+
+impl UserStructHashImpl of StructHash<VaultWithdrawUserArgs> {
+    fn hash_struct(self: @VaultWithdrawUserArgs) -> HashType {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(VAULT_WITHDRAW_USER_ARGS_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
+#[derive(Copy, Drop, Hash, Serde)]
+pub struct VaultWithdrawOwnerArgs {
+    pub vault_withdraw_user_hash: HashType,
+    pub vault_share_execution_price: Price,
+}
+
+/// selector!(
+///   "\"VaultWithdrawOwnerArgs\"(
+///    \"vault_withdraw_user_hash\":\"HashType\",
+///    \"vault_share_execution_price\":\"Price\",
+///    )
+///    \"Price\"(
+///    \"value\":\"u64\"
+///    )"
+/// );
+const VAULT_WITHDRAW_OWNER_ARGS_TYPE_HASH: HashType =
+    0x037f85f245c0b515ca413672793e5ee960312c38c98891898f8ad23ba3f60b38;
+
+impl OwnerStructHashImpl of StructHash<VaultWithdrawOwnerArgs> {
+    fn hash_struct(self: @VaultWithdrawOwnerArgs) -> HashType {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(VAULT_WITHDRAW_OWNER_ARGS_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starkware_utils::math::utils::to_base_16_string;
+    use super::{VAULT_WITHDRAW_OWNER_ARGS_TYPE_HASH, VAULT_WITHDRAW_USER_ARGS_TYPE_HASH};
+
+    #[test]
+    fn test_vault_withdraw_user_args_type_hash() {
+        let expected = selector!(
+            "\"VaultWithdrawUserArgs\"(\"position_id\":\"PositionId\",\"vault_position_id\":\"PositionId\",\"number_of_shares\":\"u64\",\"minimum_received_total_amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"Timestamp\"(\"seconds\":\"u64\")",
+        );
+        assert_eq!(
+            to_base_16_string(VAULT_WITHDRAW_USER_ARGS_TYPE_HASH), to_base_16_string(expected),
+        );
+    }
+
+
+    #[test]
+    fn test_vault_withdraw_owner_args_type_hash() {
+        let expected = selector!(
+            "\"VaultWithdrawOwnerArgs\"(\"vault_withdraw_user_hash\":\"HashType\",\"vault_share_execution_price\":\"Price\")\"Price\"(\"value\":\"u64\")",
+        );
+        assert_eq!(
+            to_base_16_string(VAULT_WITHDRAW_OWNER_ARGS_TYPE_HASH), to_base_16_string(expected),
+        );
+    }
+}
+


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/72)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds withdraw-from-vault typed args and interface, refactors assets price validation usage, and renames minimum field to minimum_received_total_amount across code and docs.
> 
> - **Core/Interface**:
>   - Add `withdraw_from_vault(...)` to `ICore` and stub implementation in `core.cairo` using price-interval validation.
>   - `deposit_into_vault` now validates only price interval (`validate_price_interval_integrity`) instead of full assets integrity.
> - **Assets Component**:
>   - Extract and expose `validate_price_interval_integrity(...)`; update callers (`funding_tick`, `validate_assets_integrity`) and remove private `_validate_price_interval_integrity`.
> - **Types**:
>   - New module `types/withdraw_from_vault.cairo` with `VaultWithdrawUserArgs` and `VaultWithdrawOwnerArgs` SNIP-12 hashes and tests.
>   - Derive `Hash` for `Price`; export new module in `types.cairo`.
> - **Docs/Spec**:
>   - Rename `minimum_quantized_amount` to `minimum_received_total_amount` in withdraw-from-vault args, events, validations, and inequality; remove `collateral_id` from function signature; minor formatting tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 178c97f077c99547b99f33771c91ad556ba17913. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->