### PR TITLE
chore(perps): update deps versions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -12,11 +12,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: "0.48.1"
+          starknet-foundry-version: "0.49.0"
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.1"
+          scarb-version: "2.12.2"
 
       - name: Build Contracts
         run: scarb build
@@ -27,7 +27,6 @@ jobs:
 
       - name: Run test and coverage
         run: scarb test -w --coverage
-
 
       - name: Check formatting
         run: scarb fmt -w --check

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-scarb 2.12.1
-starknet-foundry 0.48.1
+scarb 2.12.2
+starknet-foundry 0.49.0

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -3,14 +3,14 @@ version = 1
 
 [[package]]
 name = "openzeppelin"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:5e4fdecc957cfca7854d95912dc72d9f725517c063b116512900900add29fd77"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_finance",
  "openzeppelin_governance",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_merkle_tree",
  "openzeppelin_presets",
@@ -22,67 +22,73 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_access"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:511681dd26d814ee2bc996d44ff8cb4aaa5ae9d14272130def7eb901cf004850"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
 ]
 
 [[package]]
 name = "openzeppelin_account"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:fb3381c50d68b028d3801feb43df378e2bd62137b6884844f8f60aefe796188b"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_finance"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:e9456ef69502a87c4c99bf50145351b50950f8b11244847d92935c466c4ba787"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
+ "openzeppelin_interfaces",
  "openzeppelin_token",
 ]
 
 [[package]]
 name = "openzeppelin_governance"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:056e6d6f3d48193b53f06283884f8a9675f986fc85425f6a40e8c1aeb3b3ecfa"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_utils",
 ]
 
 [[package]]
+name = "openzeppelin_interfaces"
+version = "2.1.0"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
+
+[[package]]
 name = "openzeppelin_introspection"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:87773ed6cd2318f169283ecbbb161890d1996260a80302d81ec45b70ee5e54c1"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "openzeppelin_merkle_tree"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:47f80c9ce59557774243214f8e75c5e866f30f3d8daa755855f6ffd01c89ca89"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_presets"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:36c761ee923f1dc0887c0eab8c224b49ac242dbfe9163fbb0b08562042ab3d98"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_finance",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_token",
  "openzeppelin_upgrades",
@@ -91,33 +97,36 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_security"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:902932ec296c2f400e0ac7c579edeaafd6067b6ce6d9854c1191de28e396ffe3"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "openzeppelin_token"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:6fe61f63b5a6706018265fb7373b6e5bd3ff829bdc760b2b90296b1e708d180c"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
+ "openzeppelin_interfaces",
  "openzeppelin_introspection",
  "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_upgrades"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:560d57a9c3f3ec5a476e82fec8963c93c8df63a4ff9ff134f64ab8383bde3c61"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_utils"
-version = "2.0.0"
-source = "registry+https://scarbs.xyz/"
-checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc505"
+version = "3.0.0-alpha.2"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts/?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
+dependencies = [
+ "openzeppelin_interfaces",
+]
 
 [[package]]
 name = "perpetuals"
@@ -131,15 +140,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:2dd27e8215eea8785b3930e9f452e11b429ca262b1c1fbb071bfc173b9ebc125"
+checksum = "sha256:903150f0e9542e4277d417029eea4c03af0db398b581f9f7ae3ebbdac9afc657"
 
 [[package]]
 name = "snforge_std"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:89f759fa685d48ed0ba7152d2ac2eb168da08dfa8b84b2bee96e203dc5b2413e"
+checksum = "sha256:73d73653cc4356ec51b92a6bec9d8385b20318170c2f2ade7891e5185a0e7e64"
 dependencies = [
  "snforge_scarb_plugin",
 ]
@@ -147,7 +156,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=main#a8bfc260e603a2768b9c8fd94dabfd292adc69ca"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#f1273496b5c121b2927ad63110368fa809771818"
 dependencies = [
  "openzeppelin",
 ]
@@ -155,7 +164,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils_testing"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=main#a8bfc260e603a2768b9c8fd94dabfd292adc69ca"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#f1273496b5c121b2927ad63110368fa809771818"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,12 +2,12 @@
 members = ["workspace/apps/perpetuals/contracts"]
 
 [workspace.dependencies]
-starknet = "2.12.1"
-assert_macros = "2.12.1"
-openzeppelin = "2.0.0"
-snforge_std = "0.48.1"
-starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "main" }
-starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "main" }
+starknet = "2.12.2"
+assert_macros = "2.12.2"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts/", rev = "0e51722f231c0913915945d3df89e43cbb5cfc38" }
+snforge_std = "0.49.0"
+starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
+starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
 
 [scripts]
 test = "snforge test"
@@ -16,6 +16,7 @@ test = "snforge test"
 unstable-add-statements-code-locations-debug-info = true
 unstable-add-statements-functions-debug-info = true
 inlining-strategy = "avoid"
+panic-backtrace = true
 
 [workspace.tool.scarb]
 allow-prebuilt-plugins = ["snforge_std"]

--- a/workspace/apps/perpetuals/contracts/Scarb.toml
+++ b/workspace/apps/perpetuals/contracts/Scarb.toml
@@ -29,6 +29,7 @@ scarb.workspace = true
 unstable-add-statements-code-locations-debug-info = true
 unstable-add-statements-functions-debug-info = true
 inlining-strategy = "avoid"
+panic-backtrace = true
 
 [[test]]
 name = "perpetuals_unittest"

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -5,8 +5,8 @@ pub mod AssetsComponent {
     use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use openzeppelin::interfaces::token::erc20::IERC20Dispatcher;
     use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc20::interface::IERC20Dispatcher;
     use perpetuals::core::components::assets::errors::{
         ALREADY_INITIALIZED, ASSET_NAME_TOO_LONG, ASSET_REGISTERED_AS_COLLATERAL,
         COLLATERAL_NOT_REGISTERED, FUNDING_EXPIRED, FUNDING_TICKS_NOT_SORTED, INACTIVE_ASSET,

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -1,4 +1,4 @@
-use openzeppelin::token::erc20::interface::IERC20Dispatcher;
+use openzeppelin::interfaces::token::erc20::IERC20Dispatcher;
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::asset::synthetic::{SyntheticConfig, SyntheticTimelyData};
 use perpetuals::core::types::funding::FundingTick;

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit.cairo
@@ -5,8 +5,8 @@ pub(crate) mod Deposit {
     use core::panic_with_felt252;
     use core::pedersen::PedersenTrait;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use openzeppelin::interfaces::token::erc20::IERC20DispatcherTrait;
     use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc20::interface::IERC20DispatcherTrait;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::interface::{DepositStatus, IDeposit};

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -5,11 +5,9 @@ pub mod Core {
     use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
+    use openzeppelin::interfaces::token::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
     use openzeppelin::introspection::src5::SRC5Component;
-    use openzeppelin::token::erc20::extensions::erc4626::interface::{
-        IERC4626Dispatcher, IERC4626DispatcherTrait,
-    };
-    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::utils::snip12::SNIP12Metadata;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalTrait as AssetsInternal;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade to OpenZeppelin cairo-contracts 3.0.0-alpha.2 and StarkNet toolchain (scarb 2.12.2, snforge/std 0.49.0, foundry 0.49.0), updating contract imports to new OZ interfaces.
> 
> - **Dependencies/Tooling**:
>   - Bump `scarb` to `2.12.2`, `starknet-foundry` to `0.49.0`, `snforge_std` to `0.49.0`.
>   - Switch `openzeppelin` to git `cairo-contracts` `3.0.0-alpha.2` and add `openzeppelin_interfaces`; update `starkware_utils*` to `oz-3.0.0-alpha.2` branch.
>   - Update CI workflow and `.tool-versions` to new versions.
> - **Contracts**:
>   - Migrate ERC interfaces to new OZ paths:
>     - Use `openzeppelin::interfaces::token::erc20::{IERC20Dispatcher, IERC20DispatcherTrait}`.
>     - Use `openzeppelin::interfaces::token::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait}`.
>   - Apply across `assets`, `assets/interface`, `deposit`, and `core` modules.
> - **Config**:
>   - Enable `panic-backtrace = true` in dev `cairo` profiles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4946ee8773e512fe1f46931bda8559c49882d0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/75)
<!-- Reviewable:end -->
