### PR TITLE
feat(perp-vault): edit synthetic config

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/types/asset/synthetic.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/asset/synthetic.cairo
@@ -3,13 +3,22 @@ use perpetuals::core::types::balance::Balance;
 use perpetuals::core::types::funding::FundingIndex;
 use perpetuals::core::types::price::Price;
 use perpetuals::core::types::risk_factor::RiskFactor;
-use starknet::SyscallResultTrait;
 use starknet::storage::StoragePointer0Offset;
 use starknet::storage_access::storage_address_from_base_and_offset;
 use starknet::syscalls::storage_read_syscall;
+use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils::time::time::Timestamp;
 
 const VERSION: u8 = 1;
+
+#[derive(Copy, Drop, Serde, starknet::Store)]
+pub enum AssetType {
+    #[default]
+    SYNTHETIC,
+    SPOT_COLLATERAL,
+    VAULT_SHARE_COLLATERAL,
+}
+
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct SyntheticConfig {
@@ -21,6 +30,9 @@ pub struct SyntheticConfig {
     pub quorum: u8,
     // Smallest unit of a synthetic asset in the system.
     pub resolution_factor: u64,
+    pub quantum: u64,
+    pub token_contract: Option<ContractAddress>,
+    pub asset_type: AssetType,
 }
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
@@ -80,7 +92,7 @@ pub struct SyntheticDiffEnriched {
 
 #[generate_trait]
 pub impl SyntheticImpl of SyntheticTrait {
-    fn config(
+    fn synthetic(
         status: AssetStatus,
         risk_factor_first_tier_boundary: u128,
         risk_factor_tier_size: u128,
@@ -94,8 +106,56 @@ pub impl SyntheticImpl of SyntheticTrait {
             risk_factor_tier_size,
             quorum,
             resolution_factor,
+            quantum: 0,
+            token_contract: None,
+            asset_type: AssetType::SYNTHETIC,
         }
     }
+
+    fn spot(
+        status: AssetStatus,
+        risk_factor_first_tier_boundary: u128,
+        risk_factor_tier_size: u128,
+        quorum: u8,
+        resolution_factor: u64,
+        quantum: u64,
+        token_contract: ContractAddress,
+    ) -> SyntheticConfig {
+        SyntheticConfig {
+            version: VERSION,
+            status,
+            risk_factor_first_tier_boundary,
+            risk_factor_tier_size,
+            quorum,
+            resolution_factor,
+            quantum: quantum,
+            token_contract: Some(token_contract),
+            asset_type: AssetType::SPOT_COLLATERAL,
+        }
+    }
+
+    fn vault_share(
+        status: AssetStatus,
+        risk_factor_first_tier_boundary: u128,
+        risk_factor_tier_size: u128,
+        quorum: u8,
+        resolution_factor: u64,
+        quantum: u64,
+        token_contract: ContractAddress,
+    ) -> SyntheticConfig {
+        SyntheticConfig {
+            version: VERSION,
+            status,
+            risk_factor_first_tier_boundary,
+            risk_factor_tier_size,
+            quorum,
+            resolution_factor,
+            quantum: quantum,
+            token_contract: Some(token_contract),
+            asset_type: AssetType::VAULT_SHARE_COLLATERAL,
+        }
+    }
+
     fn timely_data(
         price: Price, last_price_update: Timestamp, funding_index: FundingIndex,
     ) -> SyntheticTimelyData {

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -3578,7 +3578,7 @@ fn test_failed_deposit_into_vault_scenarios() {
 
             state.vault_positions_to_assets.write(vault_user.position_id, asset_id);
 
-            let synthetic_config = SyntheticTrait::config(
+            let synthetic_config = SyntheticTrait::synthetic(
                 status: AssetStatus::PENDING,
                 risk_factor_first_tier_boundary: Default::default(),
                 risk_factor_tier_size: Default::default(),
@@ -3611,7 +3611,7 @@ fn test_failed_deposit_into_vault_scenarios() {
         || {
             let mut state = Core::contract_state_for_testing();
 
-            let synthetic_config = SyntheticTrait::config(
+            let synthetic_config = SyntheticTrait::synthetic(
                 status: AssetStatus::ACTIVE,
                 risk_factor_first_tier_boundary: Default::default(),
                 risk_factor_tier_size: Default::default(),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend `SyntheticConfig` with asset type, token contract, and quantum; add constructors for synthetic/spot/vault-share assets and update tests to new API.
> 
> - **Core types** (`core/types/asset/synthetic.cairo`):
>   - Add `AssetType` enum and extend `SyntheticConfig` with `quantum`, `token_contract: Option<ContractAddress>`, and `asset_type`.
>   - Replace `config(...)` with `synthetic(...)`; add `spot(...)` and `vault_share(...)` constructors to initialize config for different asset types.
>   - Import `ContractAddress`; minor import consolidation.
> - **Tests** (`tests/unit_tests/unit_tests.cairo`):
>   - Update calls from `SyntheticTrait::config(...)` to `SyntheticTrait::synthetic(...)` in vault tokenisation tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a21b8959878e454ebb93cce5e388c8ee239187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/77)
<!-- Reviewable:end -->
