### PR TITLE
feat(perps-vault): add vault params in asset config

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -201,7 +201,7 @@ pub mod AssetsComponent {
             assert(quorum.is_non_zero(), INVALID_ZERO_QUORUM);
             assert(resolution_factor.is_non_zero(), INVALID_ZERO_RESOLUTION_FACTOR);
 
-            let asset_config = AssetTrait::config(
+            let asset_config = AssetTrait::synthetic_config(
                 // It'll be active in the next price tick.
                 status: AssetStatus::PENDING,
                 // It validates the range of the risk factor.
@@ -209,8 +209,6 @@ pub mod AssetsComponent {
                 :risk_factor_tier_size,
                 :quorum,
                 :resolution_factor,
-                quantum: Zero::zero(),
-                asset_type: AssetType::SYNTHETIC,
             );
 
             synthetic_entry.write(Option::Some(asset_config));

--- a/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
@@ -72,6 +72,7 @@ pub const COLLATERAL_BALANCE_AMOUNT: i64 = 2000;
 pub const SYNTHETIC_BALANCE_AMOUNT: i64 = 20;
 pub const CONTRACT_INIT_BALANCE: u128 = 1_000_000_000;
 pub const USER_INIT_BALANCE: u128 = 10_000_000_000;
+pub const VAULT_SHARE_QUANTUM: u64 = 1_000;
 
 pub const POSITION_ID_1: PositionId = PositionId { value: 2 };
 pub const POSITION_ID_2: PositionId = PositionId { value: 3 };

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -23,7 +23,7 @@ use perpetuals::core::core::Core::SNIP12MetadataImpl;
 use perpetuals::core::errors::SIGNED_TX_EXPIRED;
 use perpetuals::core::events;
 use perpetuals::core::interface::{ICore, ICoreSafeDispatcher, ICoreSafeDispatcherTrait};
-use perpetuals::core::types::asset::{AssetStatus, AssetTrait, AssetType};
+use perpetuals::core::types::asset::{AssetStatus, AssetTrait};
 use perpetuals::core::types::funding::{FUNDING_SCALE, FundingIndex, FundingTick};
 use perpetuals::core::types::order::Order;
 use perpetuals::core::types::position::{POSITION_VERSION, PositionId, PositionMutableTrait};
@@ -3575,14 +3575,14 @@ fn test_failed_deposit_into_vault_scenarios() {
 
             state.vault_positions_to_assets.write(vault_user.position_id, asset_id);
 
-            let asset_config = AssetTrait::config(
+            let asset_config = AssetTrait::vault_share_collateral_config(
                 status: AssetStatus::PENDING,
                 risk_factor_first_tier_boundary: Default::default(),
                 risk_factor_tier_size: Default::default(),
                 quorum: Default::default(),
                 resolution_factor: Default::default(),
-                quantum: Zero::zero(),
-                asset_type: AssetType::SYNTHETIC,
+                quantum: VAULT_SHARE_QUANTUM,
+                token_contract: VAULT_CONTRACT_ADDRESS_1(),
             );
 
             state.assets.asset_config.write(asset_id, Some(asset_config));
@@ -3610,14 +3610,14 @@ fn test_failed_deposit_into_vault_scenarios() {
         || {
             let mut state = Core::contract_state_for_testing();
 
-            let asset_config = AssetTrait::config(
+            let asset_config = AssetTrait::vault_share_collateral_config(
                 status: AssetStatus::ACTIVE,
                 risk_factor_first_tier_boundary: Default::default(),
                 risk_factor_tier_size: Default::default(),
                 quorum: Default::default(),
                 resolution_factor: Default::default(),
-                quantum: Zero::zero(),
-                asset_type: AssetType::SYNTHETIC,
+                quantum: VAULT_SHARE_QUANTUM,
+                token_contract: VAULT_CONTRACT_ADDRESS_1(),
             );
 
             state.assets.asset_config.write(asset_id, Some(asset_config));
@@ -3703,14 +3703,14 @@ fn test_register_vault_successful() {
         f: || {
             let mut state = Core::contract_state_for_testing();
 
-            let asset_config = AssetTrait::config(
+            let asset_config = AssetTrait::vault_share_collateral_config(
                 status: AssetStatus::PENDING,
                 risk_factor_first_tier_boundary: Default::default(),
                 risk_factor_tier_size: Default::default(),
                 quorum: Default::default(),
                 resolution_factor: Default::default(),
-                quantum: Zero::zero(),
-                asset_type: AssetType::SYNTHETIC,
+                quantum: VAULT_SHARE_QUANTUM,
+                token_contract: VAULT_CONTRACT_ADDRESS_1(),
             );
 
             state.assets.asset_config.write(vault_asset_id, Some(asset_config));
@@ -3773,14 +3773,14 @@ fn test_register_vault_negative_scenarios() {
         f: || {
             let mut state = Core::contract_state_for_testing();
 
-            let asset_config = AssetTrait::config(
+            let asset_config = AssetTrait::vault_share_collateral_config(
                 status: AssetStatus::PENDING,
                 risk_factor_first_tier_boundary: Default::default(),
                 risk_factor_tier_size: Default::default(),
                 quorum: Default::default(),
                 resolution_factor: Default::default(),
-                quantum: Zero::zero(),
-                asset_type: AssetType::SYNTHETIC,
+                quantum: VAULT_SHARE_QUANTUM,
+                token_contract: VAULT_CONTRACT_ADDRESS_1(),
             );
 
             state.assets.asset_config.write(SYNTHETIC_ASSET_ID_2(), Some(asset_config));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce AssetConfig v2 with token_contract and quantum, add synthetic/vault config constructors, update asset creation and vault-related tests.
> 
> - **Core Types (`core/types/asset.cairo`)**:
>   - **AssetConfig v2**: bump `VERSION` to `2`; add `token_contract: ContractAddress`; mark `quantum` and `asset_type` as V2 fields; retain existing V1 fields.
>   - **Constructors**: add `AssetTrait::synthetic_config(...)` and `AssetTrait::vault_share_collateral_config(..., quantum, token_contract)`; keep `timely_data(...)`.
>   - **Imports**: include `ContractAddress` in uses.
> - **Assets Component (`core/components/assets/assets.cairo`)**:
>   - Use `AssetTrait::synthetic_config(...)` in `add_synthetic_asset`.
> - **Tests**:
>   - Add `VAULT_SHARE_QUANTUM` constant.
>   - Update vault tests to use `AssetTrait::vault_share_collateral_config(..., quantum, token_contract)` and remove explicit `AssetType` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c211ea2c3d14b79d6a19adf8e57ea4b0ef0acf9d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/78)
<!-- Reviewable:end -->
