### PR TITLE
feat: use direct access

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -514,6 +514,24 @@ pub mod AssetsComponent {
             }
         }
 
+        /// Returns the stored price directly without checking whether it exists.
+        fn get_asset_price_unsafe(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> Price {
+            let entry = self.asset_timely_data.pointer(asset_id);
+            AssetTrait::at_price(entry)
+        }
+
+
+        /// Returns both the stored price and funding index directly without checking their
+        /// existence.
+        fn get_price_and_funding_index(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> (Price, FundingIndex) {
+            let entry = self.asset_timely_data.pointer(asset_id);
+            (AssetTrait::at_price(entry), AssetTrait::at_funding_index(entry))
+        }
+
         /// Get the risk factor of a synthetic asset.
         ///   - synthetic_value = |price * balance|
         ///   - If the synthetic value is less than or equal to the first tier boundary, return the
@@ -558,6 +576,14 @@ pub mod AssetsComponent {
                 Option::None => panic_with_felt252(ASSET_NOT_EXISTS),
                 Option::Some(funding_index) => funding_index,
             }
+        }
+
+        /// Returns the stored funding index directly without checking whether it exists.
+        fn get_funding_index_unsafe(
+            self: @ComponentState<TContractState>, synthetic_id: AssetId,
+        ) -> FundingIndex {
+            let entry = self.asset_timely_data.pointer(synthetic_id);
+            AssetTrait::at_funding_index(entry)
         }
 
         fn validate_active_asset(self: @ComponentState<TContractState>, asset_id: AssetId) {

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -457,7 +457,7 @@ pub(crate) mod Positions {
                 if synthetic.balance.is_zero() {
                     continue;
                 }
-                let global_funding_index = assets.get_funding_index(synthetic_id);
+                let global_funding_index = assets.get_funding_index_unsafe(synthetic_id);
                 collateral_provisional_balance +=
                     calculate_funding(
                         old_funding_index: synthetic.funding_index,
@@ -490,17 +490,18 @@ pub(crate) mod Positions {
                 if balance.is_zero() {
                     continue;
                 }
+                let (price, funding_index) = assets
+                    .get_price_and_funding_index(asset_id: synthetic_id);
+
                 provisional_delta +=
                     calculate_funding(
                         old_funding_index: synthetic.funding_index,
-                        new_funding_index: assets.get_funding_index(synthetic_id),
+                        new_funding_index: funding_index,
                         balance: synthetic.balance,
                     );
                 if synthetic_diff_id == synthetic_id {
                     continue;
                 }
-
-                let price = assets.get_asset_price(asset_id: synthetic_id);
                 let risk_factor = assets.get_asset_risk_factor(synthetic_id, balance, price);
                 unchanged_synthetics
                     .append(Asset { id: synthetic_id, balance, price, risk_factor });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds unsafe direct getters for price/funding index and updates positions logic to use them, including a combined price+funding accessor.
> 
> - **AssetsComponent**:
>   - Add `get_asset_price_unsafe` to read stored price without existence checks.
>   - Add `get_funding_index_unsafe` to read stored funding index without checks.
>   - Add `get_price_and_funding_index` to fetch both values in one call.
> - **Positions**:
>   - Replace `get_funding_index` with `get_funding_index_unsafe` in `get_collateral_provisional_balance`.
>   - Use `get_price_and_funding_index` in `derive_funding_delta_and_unchanged_synthetics` to compute funding and risk factor, removing separate `get_asset_price`/`get_funding_index` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c339d31250cd99f24c63bcc383e08334390dece1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/80)
<!-- Reviewable:end -->
