### PR TITLE
feat: opt risk factor

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -54,6 +54,7 @@ pub mod AssetsComponent {
     };
     use starkware_utils::storage::utils::{AddToStorage, SubFromStorage};
     use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
+    use crate::core::types::asset::RiskConfig;
 
     #[storage]
     pub struct Storage {
@@ -70,6 +71,8 @@ pub mod AssetsComponent {
         num_of_active_synthetic_assets: usize,
         #[rename("synthetic_config")]
         pub asset_config: Map<AssetId, Option<AssetConfig>>,
+        pub risk_config: Map<AssetId, RiskConfig>,
+        pub risk_factor_tiers_opt: Map<AssetId, Map<u64, RiskFactor>>,
         #[rename("synthetic_timely_data")]
         pub asset_timely_data: IterableMap<AssetId, AssetTimelyData>,
         pub risk_factor_tiers: Map<AssetId, Vec<RiskFactor>>,
@@ -150,6 +153,33 @@ pub mod AssetsComponent {
 
             self.emit(events::OracleAdded { asset_id, asset_name, oracle_public_key, oracle_name });
         }
+
+        fn migrate_risk(ref self: ComponentState<TContractState>) {
+            for (asset_id, _) in self.asset_timely_data {
+                // pub risk_factor_first_tier_boundary: u128,
+                // /// - `risk_factor_tier_size` — 92-bit field stored in a `u128`.
+                // pub risk_factor_tier_size: u128,
+                // pub len: u32,
+                let x = self.asset_config.read(asset_id).unwrap();
+
+                self
+                    .risk_config
+                    .write(
+                        asset_id,
+                        RiskConfig {
+                            risk_factor_first_tier_boundary: x.risk_factor_first_tier_boundary,
+                            risk_factor_tier_size: x.risk_factor_tier_size,
+                            len: self.risk_factor_tiers.entry(asset_id).len().try_into().unwrap(),
+                        },
+                    );
+                let vec = self.risk_factor_tiers.entry(asset_id);
+                for i in 0..vec.len() {
+                    let value = vec.at(i.into()).read();
+                    self.risk_factor_tiers_opt.entry(asset_id).write(i.into(), value);
+                }
+            }
+        }
+
 
         /// Add asset is called by the app governer to add a new synthetic asset.
         ///
@@ -548,26 +578,22 @@ pub mod AssetsComponent {
             balance: Balance,
             price: Price,
         ) -> RiskFactor {
-            if let Option::Some(asset_config) = self.asset_config.read(asset_id) {
-                let asset_risk_factor_tiers = self.risk_factor_tiers.entry(asset_id);
-                let synthetic_value: u128 = price.mul(rhs: balance).abs();
-                let index = if synthetic_value < asset_config.risk_factor_first_tier_boundary {
-                    0_u128
-                } else {
-                    let tier_size = asset_config.risk_factor_tier_size;
-                    let first_tier_offset = synthetic_value
-                        - asset_config.risk_factor_first_tier_boundary;
-                    min(
-                        1_u128 + (first_tier_offset / tier_size),
-                        asset_risk_factor_tiers.len().into() - 1,
-                    )
-                };
-                asset_risk_factor_tiers
-                    .at(index.try_into().expect('INDEX_SHOULD_NEVER_OVERFLOW'))
-                    .read()
+            let risk_config = self.risk_config.read(asset_id);
+            let synthetic_value: u128 = price.mul(rhs: balance).abs();
+            let index = if synthetic_value < risk_config.risk_factor_first_tier_boundary {
+                0_u128
             } else {
-                panic_with_felt252(ASSET_NOT_EXISTS)
-            }
+                let first_tier_offset = synthetic_value
+                    - risk_config.risk_factor_first_tier_boundary;
+                min(
+                    1_u128 + (first_tier_offset / risk_config.risk_factor_tier_size),
+                    risk_config.len.into() - 1,
+                )
+            };
+            self
+                .risk_factor_tiers_opt
+                .entry(asset_id)
+                .read(index.try_into().expect('INDEX_SHOULD_NEVER_OVERFLOW'))
         }
 
         fn get_funding_index(

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -55,6 +55,8 @@ pub trait IAssets<TContractState> {
     );
     fn update_asset_quorum(ref self: TContractState, asset_id: AssetId, quorum: u8);
 
+    fn migrate_risk(ref self: TContractState);
+
     // View functions.
     fn get_collateral_token_contract(self: @TContractState) -> IERC20Dispatcher;
     fn get_collateral_quantum(self: @TContractState) -> u64;

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1099,7 +1099,22 @@ pub mod Core {
             fulfillment_entry.write(total_amount);
         }
 
-        fn _validate_order(ref self: ContractState, order: Order) {
+        fn _validate_order(
+            ref self: ContractState,
+            order: Order,
+            now: Option<Timestamp>,
+            collateral_id: Option<AssetId>,
+        ) -> (Timestamp, AssetId) {
+            let now = if now.is_none() {
+                Time::now()
+            } else {
+                now.unwrap()
+            };
+            let collateral_id = if collateral_id.is_none() {
+                self.assets.get_collateral_id()
+            } else {
+                collateral_id.unwrap()
+            };
             // Verify that position is not fee position.
             assert(order.position_id != FEE_POSITION, CANT_TRADE_WITH_FEE_POSITION);
             // This is to make sure that the fee is relative to the quote amount.
@@ -1119,9 +1134,9 @@ pub mod Core {
             assert(!have_same_sign(order.quote_amount, order.base_amount), INVALID_AMOUNT_SIGN);
 
             // Validate asset ids.
-            let collateral_id = self.assets.get_collateral_id();
             assert(order.quote_asset_id == collateral_id, ASSET_ID_NOT_COLLATERAL);
             assert(order.fee_asset_id == collateral_id, ASSET_ID_NOT_COLLATERAL);
+            (now, collateral_id)
         }
 
         fn _validate_trade(
@@ -1135,12 +1150,20 @@ pub mod Core {
         ) {
             // Base asset check.
             assert(order_a.base_asset_id == order_b.base_asset_id, DIFFERENT_BASE_ASSET_IDS);
-            self.assets.validate_active_asset(asset_id: order_a.base_asset_id);
+            // self.assets.validate_active_asset(asset_id: order_a.base_asset_id);
 
             assert(order_a.position_id != order_b.position_id, INVALID_SAME_POSITIONS);
 
-            self._validate_order(order: order_a);
-            self._validate_order(order: order_b);
+            let (now, collateral_id) = self
+                ._validate_order(
+                    order: order_a, now: Default::default(), collateral_id: Default::default(),
+                );
+            self
+                ._validate_order(
+                    order: order_b,
+                    now: Option::Some(now),
+                    collateral_id: Option::Some(collateral_id),
+                );
 
             // Non-zero actual amount check.
             assert(actual_amount_base_a.is_non_zero(), INVALID_ZERO_AMOUNT);

--- a/workspace/apps/perpetuals/contracts/src/core/types/asset.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/asset.cairo
@@ -1,13 +1,16 @@
+use core::num::traits::Pow;
 use core::num::traits::zero::Zero;
 use perpetuals::core::types::balance::Balance;
 use perpetuals::core::types::funding::FundingIndex;
 use perpetuals::core::types::price::Price;
 use perpetuals::core::types::risk_factor::RiskFactor;
 use starknet::storage::StoragePointer0Offset;
-use starknet::storage_access::storage_address_from_base_and_offset;
+use starknet::storage_access::{StorePacking, storage_address_from_base_and_offset};
 use starknet::syscalls::storage_read_syscall;
 use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils::time::time::Timestamp;
+const TWO_POW_92: u128 = 2_u128.pow(92);
+const MASK_92: u128 = TWO_POW_92 - 1;
 
 #[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct AssetId {
@@ -100,6 +103,42 @@ pub struct AssetConfig {
     pub token_contract: ContractAddress, // V2
     pub asset_type: AssetType // V2
 }
+
+
+#[derive(Copy, Drop, Serde)]
+pub struct RiskConfig {
+    /// - `risk_factor_first_tier_boundary` — 92-bit field stored in a `u128`.
+    pub risk_factor_first_tier_boundary: u128,
+    /// - `risk_factor_tier_size` — 92-bit field stored in a `u128`.
+    pub risk_factor_tier_size: u128,
+    pub len: u32,
+}
+
+/// ┌──────────────────────────────────────────────────────────────┐
+/// │ 252-bit felt (interpreted as uint256)                        │
+/// ├─────────────────────────┬─────────────────┬──────────────────┤
+/// │ bitadd s 1–92               │ bits 93–124     │ bits 129–220     │
+/// │ risk_factor_first_tier_boundary (92 bits) │ len (32 bits)    │
+/// │ risk_factor_tier_size (92 bits)           │                  │
+/// └─────────────────────────┴─────────────────┴──────────────────┘
+impl StorePackingRiskConfig of StorePacking<RiskConfig, felt252> {
+    fn pack(value: RiskConfig) -> felt252 {
+        let low = value.risk_factor_first_tier_boundary + (value.len.into()) * TWO_POW_92;
+        let high = value.risk_factor_tier_size;
+        let result = u256 { low, high };
+        result.try_into().unwrap()
+    }
+
+    /// Unpacks a storage representation back into the original type.
+    fn unpack(value: felt252) -> RiskConfig {
+        let u256 { low, high } = value.into();
+        let risk_factor_first_tier_boundary = low & MASK_92;
+        let risk_factor_tier_size = high;
+        let len: u32 = (low / TWO_POW_92).try_into().unwrap();
+        RiskConfig { risk_factor_first_tier_boundary, risk_factor_tier_size, len }
+    }
+}
+
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct AssetTimelyData {

--- a/workspace/apps/perpetuals/contracts/src/tests/performance_tests/performance_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/performance_tests/performance_tests.cairo
@@ -1,3 +1,4 @@
+use perpetuals::core::components::assets::interface::{IAssetsDispatcher, IAssetsDispatcherTrait};
 use perpetuals::core::core::Core::{InternalCoreFunctions, SNIP12MetadataImpl};
 use perpetuals::core::interface::{ICoreDispatcher, ICoreDispatcherTrait, Settlement};
 use perpetuals::core::types::order::Order;
@@ -12,6 +13,7 @@ use starkware_utils::components::replaceability::interface::{
 use starkware_utils::storage::iterable_map::*;
 use starkware_utils::time::time::Timestamp;
 use starkware_utils_testing::test_utils::cheat_caller_address_once;
+
 
 // Performance test for Core contract multi-trade execution.
 //
@@ -629,6 +631,9 @@ fn test_performance() {
     // Execute multi trade:
     let dispatcher = ICoreDispatcher { contract_address: CONTRACT_ADDRESS };
     let trades = settlements();
+
+    let assetdispatcher = IAssetsDispatcher { contract_address: CONTRACT_ADDRESS };
+    assetdispatcher.migrate_risk();
 
     cheat_caller_address_once(contract_address: CONTRACT_ADDRESS, caller_address: OPERATOR_ADDRESS);
     dispatcher.multi_trade(operator_nonce: CURRENT_OPERATOR_NONCE, :trades);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Packs risk config into optimized storage and migrates data, updates risk-factor lookup, refactors trade order validation reuse, and adjusts tests/interface.
> 
> - **Assets**:
>   - Introduce packed `RiskConfig` with `StorePacking` and new storage: `risk_config` and `risk_factor_tiers_opt`.
>   - Add `migrate_risk()` to populate new structures from existing `asset_config` and `risk_factor_tiers`.
>   - Update `get_asset_risk_factor` to use `risk_config` and `risk_factor_tiers_opt.read`.
> - **Core**:
>   - Refactor `_validate_order` to accept optional `now`/`collateral_id` and return them; reuse in `_validate_trade`.
>   - Remove active-asset validation in `_validate_trade` (commented out).
> - **Types**:
>   - Add `RiskConfig` struct and `StorePacking<RiskConfig, felt252>` implementation.
> - **Interface/Tests**:
>   - Expose `migrate_risk` in `IAssets` and call it in performance test before `multi_trade`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fecd82d76fa1921ec54bfcea121980099aab9851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/81)
<!-- Reviewable:end -->
