### PR TITLE
chore(perpetuals): rename withdraw from vault argument

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -950,19 +950,16 @@ impl StructHashImpl of StructHash<WithdrawFromVaultUserArgs> {
 ```rust
 pub struct WithdrawFromVaultOwnerArgs {
     user_hash: HashType,
-    vault_share_execution_price: Price
+    collateral_asset_amount: u64
 }
 
 /// selector!(
 ///   "\"WithdrawFromVaultOwnerArgs\"(
 ///    \"user_hash\":\"HashType\",
-///    \"vault_share_execution_price\":\"Price\",
+///    \"collateral_asset_amount\":\"u64\",
 ///    )
 ///    \"HashType\"(
 ///    \"value\":\"felt\"
-///    )"
-///    \"vault_share_execution_price\"(
-///    \"value\":\"u64\"
 ///    )"
 /// );
 
@@ -980,7 +977,7 @@ impl StructHashImpl of StructHash<WithdrawFromVaultOwnerArgs> {
 
 ```rust
 pub struct LiquidateVaultSharesArgs {
-    vault_share_execution_price: Price,
+    collateral_asset_amount: u64,
     vault_position_id: PositionId,
     collateral_id: AssetId,
     number_of_shares: u64,
@@ -990,7 +987,7 @@ pub struct LiquidateVaultSharesArgs {
 
 /// selector!(
 ///   "\"LiquidateVaultSharesArgs\"(
-///    \"vault_share_execution_price\":\"Price\",
+///    \"collateral_asset_amount\":\"Price\",
 ///    \"vault_position_id\":\"PositionId\",
 ///    \"collateral_id\":\"AssetId\",
 ///    \"number_of_shares\":\"u64\",
@@ -2940,7 +2937,7 @@ pub struct WithdrawnFromVault {
     pub collateral_id: AssetId,
     pub number_of_shares: u64,
     pub minimum_received_total_amount: u64,
-    pub vault_share_execution_price: Price,
+    pub collateral_asset_amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
 }
@@ -2959,7 +2956,7 @@ pub struct LiquidatedFromVault {
     pub collateral_id: AssetId,
     pub number_of_shares: u64,
     pub minimum_received_total_amount: u64,
-    pub vault_share_execution_price: Price,
+    pub collateral_asset_amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
 }
@@ -3658,7 +3655,7 @@ fn withdraw_from_vault(
     vault_position_id: PositionId,
     number_of_shares: u64,
     minimum_received_total_amount: u64,
-    vault_share_execution_price: Price,
+    collateral_asset_amount: u64,
     expiration: Timestamp,
     salt: felt252,
     user_signature: Signature,
@@ -3688,20 +3685,20 @@ Only the Operator can execute.
 8. position id is not a vault position and exists.
 9. number_of_shares is non zero.
 10. minimum_received_total_amount is non zero.
-11. vault_share_execution_price is non zero.
+11. collateral_asset_amount is non zero.
 12. Caller is the operator.
 13. Request is new (check user payload hash not exists in the fulfillment map).
-14. `number_of_shares * vault_share_execution_price >= minimum_received_total_amount`
+14. `number_of_shares * collateral_asset_amount >= minimum_received_total_amount`
 
 **Logic:**
 
 1. Run validations
 2. transfer vault_asset_id: number_of_shares from the perps contract to the vault contract (for burning the vault shares)
 3. reduce the position id vault share balance by number_of_shares
-4. transfer collateral_id: vault_share_execution_price*number_of_shares from the perps contract to the vault contract (for transferring back the shares value)
+4. transfer collateral_id: collateral_asset_amount*number_of_shares from the perps contract to the vault contract (for transferring back the shares value)
 5. call the new redeem function of the vault contract (a version where the price of a vault share is dicateded by the operator) which burns the vault shares and transfers the assets from the vault contract to the perps contract
-6. increase the position_id collateral_id balance by vault_share_execution_price*number_of_shares
-7. reduce the vault_position_id collateral_id balance by vault_share_execution_price*number_of_shares
+6. increase the position_id collateral_id balance by collateral_asset_amount*number_of_shares
+7. reduce the vault_position_id collateral_id balance by collateral_asset_amount*number_of_shares
 
 **Emits:**
 
@@ -3721,7 +3718,7 @@ fn liquidate_vault_shares(
     vault_position_id: PositionId,
     collateral_id: AssetId,
     number_of_shares: u64,
-    vault_share_execution_price: Price,
+    collateral_asset_amount: u64,
     expiration: Timestamp,
     salt: felt252,
     vault_owner_signature: Signature,
@@ -3748,7 +3745,7 @@ Only the Operator can execute.
 8. position id is not a vault position and exists.
 9. number_of_shares is non zero.
 10. position id is liquidatable.
-11. vault_share_execution_price is non zero.
+11. collateral_asset_amount is non zero.
 12. Caller is the operator.
 
 **Logic:**
@@ -3756,10 +3753,10 @@ Only the Operator can execute.
 1. Run validations
 2. transfer vault_asset_id: number_of_shares from the perps contract to the vault contract (for burning the vault shares)
 3. reduce the position id vault share balance by number_of_shares
-4. transfer collateral_id: vault_share_execution_price*number_of_shares from the perps contract to the vault contract (for transferring back the shares value)
+4. transfer collateral_id: collateral_asset_amount*number_of_shares from the perps contract to the vault contract (for transferring back the shares value)
 5. call the new redeem function of the vault contract (a version where the price of a vault share is dicateded by the operator) which burns the vault shares and transfers the assets from the vault contract to the perps contract
-6. increase the position_id collateral_id balance by vault_share_execution_price*number_of_shares
-7. reduce the vault_position_id collateral_id balance by vault_share_execution_price*number_of_shares
+6. increase the position_id collateral_id balance by collateral_asset_amount*number_of_shares
+7. reduce the vault_position_id collateral_id balance by collateral_asset_amount*number_of_shares
 8. position id is healthier
 
 **Emits:**

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1085,7 +1085,7 @@ pub mod Core {
             vault_position_id: PositionId,
             number_of_shares: u64,
             minimum_received_total_amount: u64,
-            vault_share_execution_price: Price,
+            collateral_asset_amount: u64,
             expiration: Timestamp,
             salt: felt252,
             user_signature: Signature,

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -1,7 +1,6 @@
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::order::Order;
 use perpetuals::core::types::position::PositionId;
-use perpetuals::core::types::price::Price;
 use starknet::ContractAddress;
 use starkware_utils::signature::stark::Signature;
 use starkware_utils::time::time::Timestamp;
@@ -123,7 +122,7 @@ pub trait ICore<TContractState> {
         vault_position_id: PositionId,
         number_of_shares: u64,
         minimum_received_total_amount: u64,
-        vault_share_execution_price: Price,
+        collateral_asset_amount: u64,
         expiration: Timestamp,
         salt: felt252,
         user_signature: Signature,

--- a/workspace/apps/perpetuals/contracts/src/core/types/withdraw_from_vault.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/withdraw_from_vault.cairo
@@ -2,7 +2,6 @@ use core::hash::{HashStateExTrait, HashStateTrait};
 use core::poseidon::PoseidonTrait;
 use openzeppelin::utils::snip12::StructHash;
 use perpetuals::core::types::position::PositionId;
-use perpetuals::core::types::price::Price;
 use starkware_utils::signature::stark::HashType;
 use starkware_utils::time::time::Timestamp;
 
@@ -45,20 +44,17 @@ impl UserStructHashImpl of StructHash<VaultWithdrawUserArgs> {
 #[derive(Copy, Drop, Hash, Serde)]
 pub struct VaultWithdrawOwnerArgs {
     pub vault_withdraw_user_hash: HashType,
-    pub vault_share_execution_price: Price,
+    pub collateral_asset_amount: u64,
 }
 
 /// selector!(
 ///   "\"VaultWithdrawOwnerArgs\"(
 ///    \"vault_withdraw_user_hash\":\"HashType\",
-///    \"vault_share_execution_price\":\"Price\",
+///    \"collateral_asset_amount\":\"u64\",
 ///    )
-///    \"Price\"(
-///    \"value\":\"u64\"
-///    )"
 /// );
 const VAULT_WITHDRAW_OWNER_ARGS_TYPE_HASH: HashType =
-    0x037f85f245c0b515ca413672793e5ee960312c38c98891898f8ad23ba3f60b38;
+    0x008e71c2a345df58451e82f585a92b717ebc0df7335af831ed356573df04c639;
 
 impl OwnerStructHashImpl of StructHash<VaultWithdrawOwnerArgs> {
     fn hash_struct(self: @VaultWithdrawOwnerArgs) -> HashType {
@@ -86,7 +82,7 @@ mod tests {
     #[test]
     fn test_vault_withdraw_owner_args_type_hash() {
         let expected = selector!(
-            "\"VaultWithdrawOwnerArgs\"(\"vault_withdraw_user_hash\":\"HashType\",\"vault_share_execution_price\":\"Price\")\"Price\"(\"value\":\"u64\")",
+            "\"VaultWithdrawOwnerArgs\"(\"vault_withdraw_user_hash\":\"HashType\",\"collateral_asset_amount\":\"u64\")",
         );
         assert_eq!(
             to_base_16_string(VAULT_WITHDRAW_OWNER_ARGS_TYPE_HASH), to_base_16_string(expected),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces vault share price with a per-share collateral amount (u64) in withdraw/liquidation APIs, structs, events, hashes, tests, and docs.
> 
> - **Core API/Interface**:
>   - Rename `vault_share_execution_price: Price` → `collateral_asset_amount: u64` in `withdraw_from_vault` (contract and `ICore` interface).
> - **Types/Hashing**:
>   - Update `VaultWithdrawOwnerArgs` to use `collateral_asset_amount: u64`; adjust selector/type hash and tests.
> - **Events**:
>   - `WithdrawnFromVault` and `LiquidatedFromVault`: replace `vault_share_execution_price` with `collateral_asset_amount`.
> - **Docs/Spec**:
>   - Reflect new arg/field names and types in `WithdrawFromVaultOwnerArgs`, `LiquidateVaultSharesArgs`, events, validations, and computation (`number_of_shares * collateral_asset_amount`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7ca2dcd47025b99d9c715ace93f02afe34f0ad0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/84)
<!-- Reviewable:end -->
