### PR TITLE
doc(perpetuals): add doc for withdraw from vault

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1052,6 +1052,26 @@ pub mod Core {
                 )
         }
 
+        /// Withdraws vault shares into collateral.
+        ///
+        /// Validations:
+        /// - Ensures the contract is not paused.
+        /// - Validates the operator nonce.
+        /// - Checks price integrity.
+        /// - Non-zero `number_of_shares`, `minimum_received_total_amount`,
+        /// `vault_share_execution_price`.
+        /// - Retrieves the vault share asset ID associated with the vault position.
+        /// - Validates the withdraw parameters including position IDs, amount, expiration,
+        ///   and signature.
+        ///
+        /// Execution:
+        /// - Redeem shares from the vault; convert unquantized to quantized using collateral
+        /// quantum.
+        /// - Apply diffs: `position_id` (+collateral, −shares), `vault_position_id`
+        /// (−collateral).
+        /// - Validate both positions remain healthy or healthier; enforce vault collateral safety
+        /// limit.
+        /// - Emit `WithdrawFromVault`.
         fn withdraw_from_vault(
             ref self: ContractState,
             operator_nonce: u64,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new withdraw_from_vault function in the Core contract with validation scaffolding and extensive documentation (execution not yet implemented).
> 
> - **Contracts/Core (`core.cairo`)**:
>   - **New entrypoint**: `withdraw_from_vault(...)` added with initial validations (not paused, operator nonce, price integrity) and parameters for shares, minimum received, execution price, expiration, salts, and signatures.
>   - **Docs**: Adds detailed documentation for `withdraw_from_vault` describing validations and intended execution flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac5381af14ce70d5e490a13415cfdae3bc1d3a33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/86)
<!-- Reviewable:end -->
