### PR TITLE
feat: opt error handling

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
@@ -1,9 +1,9 @@
 use core::num::traits::{Pow, Zero};
+use core::panics::panic_with_byte_array;
 use perpetuals::core::errors::invalid_funding_rate_err;
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::balance::{Balance, BalanceTrait};
 use perpetuals::core::types::price::{Price, PriceMulTrait};
-use starkware_utils::errors::assert_with_byte_array;
 use starkware_utils::math::utils::mul_wide_and_floor_div;
 
 pub const FUNDING_SCALE: i64 = 2_i64.pow(32);
@@ -115,11 +115,12 @@ pub fn validate_funding_rate(
     time_diff: u64,
     synthetic_price: Price,
 ) {
-    assert_with_byte_array(
-        condition: index_diff.into() <= synthetic_price.mul(rhs: max_funding_rate)
-            * time_diff.into(),
-        err: invalid_funding_rate_err(:synthetic_id),
-    );
+    let condition = index_diff.into() <= synthetic_price.mul(rhs: max_funding_rate)
+        * time_diff.into();
+    if (!condition) {
+        let err = @invalid_funding_rate_err(:synthetic_id);
+        panic_with_byte_array(:err);
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
@@ -1,10 +1,10 @@
 use core::hash::{HashStateExTrait, HashStateTrait};
+use core::panics::panic_with_byte_array;
 use core::poseidon::PoseidonTrait;
 use openzeppelin::utils::snip12::StructHash;
 use perpetuals::core::errors::{illegal_base_to_quote_ratio_err, illegal_fee_to_quote_ratio_err};
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::position::PositionId;
-use starkware_utils::errors::assert_with_byte_array;
 use starkware_utils::math::abs::Abs;
 use starkware_utils::math::fraction::FractionTrait;
 use starkware_utils::signature::stark::HashType;
@@ -81,10 +81,10 @@ pub impl OrderImpl of OrderTrait {
         let actual_base_to_quote_ratio = FractionTrait::new(
             numerator: actual_amount_base.into(), denominator: actual_amount_quote.abs().into(),
         );
-        assert_with_byte_array(
-            order_base_to_quote_ratio <= actual_base_to_quote_ratio,
-            illegal_base_to_quote_ratio_err(*self.position_id),
-        );
+        if (order_base_to_quote_ratio > actual_base_to_quote_ratio) {
+            let err = @illegal_base_to_quote_ratio_err(*self.position_id);
+            panic_with_byte_array(:err);
+        }
 
         // Validating the fee-to-quote ratio enables increasing in both the user's quote and the
         // operator's fee.
@@ -94,10 +94,10 @@ pub impl OrderImpl of OrderTrait {
         let order_fee_to_quote_ratio = FractionTrait::new(
             numerator: (*self.fee_amount).into(), denominator: (*self.quote_amount).abs().into(),
         );
-        assert_with_byte_array(
-            actual_fee_to_quote_ratio <= order_fee_to_quote_ratio,
-            illegal_fee_to_quote_ratio_err(*self.position_id),
-        );
+        if (actual_fee_to_quote_ratio > order_fee_to_quote_ratio) {
+            let err = @illegal_fee_to_quote_ratio_err(*self.position_id);
+            panic_with_byte_array(:err);
+        }
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches validation paths to explicit conditionals that call panic_with_byte_array instead of assert_with_byte_array across core, funding, order, and value-risk logic.
> 
> - **Core (`core.cairo`)**:
>   - Replace `assert_with_byte_array` with explicit checks + `panic_with_byte_array` in `'_update_fulfillment'` and order expiration validation in `'_validate_order'`.
>   - Import `panic_with_byte_array` and drop `assert_with_byte_array`.
> - **Types**:
>   - **Funding (`types/funding.cairo`)**: Convert `validate_funding_rate` to conditional + `panic_with_byte_array`; update imports accordingly.
>   - **Order (`types/order.cairo`)**: Use conditional + `panic_with_byte_array` for base-to-quote and fee-to-quote ratio checks; update imports.
> - **Risk/TVTR (`value_risk_calculator.cairo`)**:
>   - Replace assertions with conditional `panic_with_byte_array` in `assert_healthy_or_healthier`, `liquidated_position_validations`, and `deleveraged_position_validations` (including fair deleverage check).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e11acdd24e8e6a8489dfd56cfe37f5dec1bd85f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/87)
<!-- Reviewable:end -->
