### PR TITLE
test(perp-vault): test add vault share fn

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
@@ -77,6 +77,7 @@ pub const SYNTHETIC_BALANCE_AMOUNT: i64 = 20;
 pub const CONTRACT_INIT_BALANCE: u128 = 1_000_000_000;
 pub const USER_INIT_BALANCE: u128 = 10_000_000_000;
 pub const VAULT_SHARE_QUANTUM: u64 = 1_000;
+pub const DEFAULT_DECIMALS: u8 = 18;
 
 pub const POSITION_ID_100: PositionId = PositionId { value: 100 };
 pub const POSITION_ID_200: PositionId = PositionId { value: 200 };
@@ -104,14 +105,12 @@ pub fn SYNTHETIC_ASSET_ID_2() -> AssetId {
 pub fn SYNTHETIC_ASSET_ID_3() -> AssetId {
     AssetIdTrait::new(value: selector!("SYNTHETIC_ASSET_ID_3"))
 }
-
 pub fn VAULT_ASSET_ID_1() -> AssetId {
     AssetIdTrait::new(value: selector!("VAULT_ASSET_ID_1"))
 }
 pub fn VAULT_ASSET_ID_2() -> AssetId {
     AssetIdTrait::new(value: selector!("VAULT_ASSET_ID_2"))
 }
-
 
 /// Assets' metadata
 pub fn COLLATERAL_NAME() -> ByteArray {

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -1,5 +1,14 @@
-use core::num::traits::Zero;
-use perpetuals::core::components::assets::errors::ASSET_NOT_EXISTS;
+use core::num::traits::{Pow, Zero};
+use openzeppelin::interfaces::token::erc20::{
+    IERC20MetadataDispatcher, IERC20MetadataDispatcherTrait,
+};
+use perpetuals::core::components::assets::errors::{
+    ASSET_ALREADY_EXISTS, ASSET_NOT_ACTIVE, ASSET_NOT_EXISTS, ASSET_REGISTERED_AS_COLLATERAL,
+    INVALID_ZERO_ASSET_ID, INVALID_ZERO_QUANTUM, INVALID_ZERO_QUORUM,
+    INVALID_ZERO_RESOLUTION_FACTOR, INVALID_ZERO_RF_FIRST_BOUNDRY, INVALID_ZERO_RF_TIERS_LEN,
+    INVALID_ZERO_RF_TIER_SIZE, INVALID_ZERO_TOKEN_ADDRESS, MISMATCHED_RESOLUTION,
+    UNSORTED_RISK_FACTOR_TIERS,
+};
 use perpetuals::core::components::assets::interface::{
     IAssets, IAssetsDispatcher, IAssetsDispatcherTrait, IAssetsSafeDispatcher,
     IAssetsSafeDispatcherTrait,
@@ -18,13 +27,16 @@ use perpetuals::core::components::positions::interface::{
     IPositions, IPositionsDispatcher, IPositionsDispatcherTrait, IPositionsSafeDispatcher,
     IPositionsSafeDispatcherTrait,
 };
-use perpetuals::core::components::vault::errors::VAULT_POSITION_HAS_SHARES;
+use perpetuals::core::components::vault::errors::{
+    INVALID_VAULT_CONTRACT_ADDRESS, VAULT_CONTRACT_ALREADY_EXISTS, VAULT_POSITION_ALREADY_EXISTS,
+    VAULT_POSITION_HAS_SHARES,
+};
 use perpetuals::core::components::vault::interface::{
     IVault, IVaultSafeDispatcher, IVaultSafeDispatcherTrait,
 };
 use perpetuals::core::core::Core;
 use perpetuals::core::core::Core::SNIP12MetadataImpl;
-use perpetuals::core::errors::SIGNED_TX_EXPIRED;
+use perpetuals::core::errors::{INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED};
 use perpetuals::core::events;
 use perpetuals::core::interface::{ICore, ICoreSafeDispatcher, ICoreSafeDispatcherTrait};
 use perpetuals::core::types::asset::{AssetStatus, AssetTrait};
@@ -3628,7 +3640,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'ASSET_NOT_EXISTS');
+    assert_panic_with_felt_error(:result, expected_error: ASSET_NOT_EXISTS);
 
     // Add the vault asset, without activating it.
     interact_with_state(
@@ -3665,7 +3677,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'ASSET_NOT_ACTIVE');
+    assert_panic_with_felt_error(:result, expected_error: ASSET_NOT_ACTIVE);
 
     // Activate the vault asset.
     interact_with_state(
@@ -3700,7 +3712,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'POSITION_DOESNT_EXIST');
+    assert_panic_with_felt_error(:result, expected_error: POSITION_DOESNT_EXIST);
 
     // Add vault position, and user position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
@@ -3733,7 +3745,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'INVALID_ZERO_AMOUNT');
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_AMOUNT);
 }
 
 // Register vault tests.
@@ -3888,7 +3900,7 @@ fn test_register_vault_negative_scenarios() {
             :vault_asset_id,
             :expiration,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'INVALID_VAULT_CONTRACT_ADDRESS');
+    assert_panic_with_felt_error(:result, expected_error: INVALID_VAULT_CONTRACT_ADDRESS);
 
     // Setup parameters with zero asset id:
     let vault_position_id = vault.position_id;
@@ -3941,7 +3953,7 @@ fn test_register_vault_negative_scenarios() {
             :vault_asset_id,
             :expiration,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'POSITION_DOESNT_EXIST');
+    assert_panic_with_felt_error(:result, expected_error: POSITION_DOESNT_EXIST);
 
     // Setup parameters:
     let vault_position_id = vault.position_id;
@@ -3990,7 +4002,7 @@ fn test_register_vault_negative_scenarios() {
             :vault_asset_id,
             :expiration,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'VAULT_POSITION_ALREADY_EXISTS');
+    assert_panic_with_felt_error(:result, expected_error: VAULT_POSITION_ALREADY_EXISTS);
 
     // Setup for registration with same contract address but different position:
     let vault2 = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
@@ -4023,7 +4035,7 @@ fn test_register_vault_negative_scenarios() {
             :vault_asset_id,
             :expiration,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'VAULT_CONTRACT_ALREADY_EXISTS');
+    assert_panic_with_felt_error(:result, expected_error: VAULT_CONTRACT_ALREADY_EXISTS);
 
     // Test 6: register vault position that already holds vault shares from another vault.
     // Setup: Create a third position that will hold shares from the first vault.
@@ -4100,5 +4112,321 @@ fn test_register_vault_negative_scenarios() {
             :expiration,
         );
     assert_panic_with_felt_error(:result, expected_error: VAULT_POSITION_HAS_SHARES);
+}
+
+// Add vault collateral asset tests.
+
+#[test]
+fn test_successful_add_vault_collateral_asset() {
+    // Setup state and token:
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
+    let mut spy = snforge_std::spy_events();
+
+    // Setup test parameters:
+    let vault_asset_id = VAULT_ASSET_ID_1();
+    let erc20_contract_address = token_state.address;
+    let quantum = VAULT_SHARE_QUANTUM;
+    let erc20_dispatcher = IERC20MetadataDispatcher { contract_address: erc20_contract_address };
+    let decimals = erc20_dispatcher.decimals();
+    let resolution_factor: u64 = (10_u256.pow(decimals.into()) / quantum.into())
+        .try_into()
+        .unwrap();
+    let risk_factor_tiers = array![10, 20, 30].span();
+    let risk_factor_first_tier_boundary = 10_000_u128;
+    let risk_factor_tier_size = 20_000_u128;
+    let quorum = 2_u8;
+
+    // Test:
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
+    state
+        .add_vault_collateral_asset(
+            asset_id: vault_asset_id,
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            :risk_factor_tiers,
+            :risk_factor_first_tier_boundary,
+            :risk_factor_tier_size,
+            :quorum,
+        );
+
+    // Catch the event.
+    let events = spy.get_events().emitted_by(test_address()).events;
+    assert_eq!(events.len(), 1);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    test_address(),
+                    perpetuals::core::components::assets::AssetsComponent::Event::VaultShareCollateralAdded(
+                        perpetuals::core::components::assets::events::VaultShareCollateralAdded {
+                            asset_id: vault_asset_id,
+                            risk_factor_tiers,
+                            risk_factor_first_tier_boundary,
+                            risk_factor_tier_size,
+                            resolution_factor,
+                            quorum,
+                            erc20_contract_address,
+                            quantum,
+                        },
+                    ),
+                ),
+            ],
+        );
+
+    const EXPECTED_RESOLUTION_FACTOR: u64 = 10_u64.pow(DEFAULT_DECIMALS.into())
+        / VAULT_SHARE_QUANTUM;
+    // Check asset configuration.
+    let asset_config = state.assets.get_asset_config(vault_asset_id);
+    assert_eq!(asset_config.status, AssetStatus::PENDING);
+    assert_eq!(asset_config.quorum, 2);
+    assert_eq!(asset_config.resolution_factor, EXPECTED_RESOLUTION_FACTOR);
+    assert_eq!(asset_config.quantum, VAULT_SHARE_QUANTUM);
+    assert_eq!(asset_config.token_contract, erc20_contract_address);
+    assert_eq!(asset_config.risk_factor_first_tier_boundary, 10_000_u128);
+    assert_eq!(asset_config.risk_factor_tier_size, 20_000_u128);
+
+    // Check asset timely data is initialized to default.
+    let asset_timely_data = state.assets.get_asset_timely_data(vault_asset_id);
+    assert_eq!(asset_timely_data.price.value(), 0);
+    assert_eq!(asset_timely_data.funding_index.value, 0);
+    assert_eq!(asset_timely_data.last_price_update.seconds, 0);
+
+    // Check risk factor tiers.
+    let stored_tiers = state.assets.get_risk_factor_tiers(vault_asset_id);
+    assert_eq!(stored_tiers.len(), 3);
+}
+
+#[test]
+#[feature("safe_dispatcher")]
+fn test_add_vault_collateral_asset_negative_scenarios() {
+    // Setup:
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
+    let dispatcher = IAssetsSafeDispatcher { contract_address };
+
+    // Common setup parameters:
+    let erc20_contract_address = token_state.address;
+    let quantum = VAULT_SHARE_QUANTUM;
+    let erc20_dispatcher_meta = IERC20MetadataDispatcher {
+        contract_address: erc20_contract_address,
+    };
+    let decimals = erc20_dispatcher_meta.decimals();
+    let resolution_factor: u64 = (10_u256.pow(decimals.into()) / quantum.into())
+        .try_into()
+        .unwrap();
+
+    // Test 1: Not app governor.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_1(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_error(:result, expected_error: "ONLY_APP_GOVERNOR");
+
+    // Test 2: Zero quantum.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_1(),
+            :erc20_contract_address,
+            quantum: 0,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_QUANTUM);
+
+    // Test 3: Zero token address.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_1(),
+            erc20_contract_address: Zero::zero(),
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_TOKEN_ADDRESS);
+
+    // Test 4: Mismatched resolution.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_1(),
+            :erc20_contract_address,
+            :quantum,
+            resolution_factor: resolution_factor + 1,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: MISMATCHED_RESOLUTION);
+
+    // Test 5: Asset already exists - first add it successfully.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_1(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        )
+        .unwrap();
+
+    // Now try to add the same asset again.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_1(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: ASSET_ALREADY_EXISTS);
+
+    // Test 6: Using collateral ID.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: cfg.collateral_cfg.collateral_id,
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: ASSET_REGISTERED_AS_COLLATERAL);
+
+    // Test 7: Zero asset ID.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: Zero::zero(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_ASSET_ID);
+
+    // Test 8: Empty risk factor tiers.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_2(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_RF_TIERS_LEN);
+
+    // Test 9: Zero first tier boundary.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_2(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 0,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_RF_FIRST_BOUNDRY);
+
+    // Test 10: Zero tier size.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_2(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 0,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_RF_TIER_SIZE);
+
+    // Test 11: Zero quorum.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_2(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 0,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_QUORUM);
+
+    // Test 12: Zero resolution factor.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_2(),
+            :erc20_contract_address,
+            quantum: (10_u256.pow(decimals.into()) + 1).try_into().unwrap(),
+            resolution_factor: 0,
+            risk_factor_tiers: array![10].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: INVALID_ZERO_RESOLUTION_FACTOR);
+
+    // Test 13: Unsorted risk factor tiers.
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
+    let result = dispatcher
+        .add_vault_collateral_asset(
+            asset_id: VAULT_ASSET_ID_2(),
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            risk_factor_tiers: array![30, 10, 20].span(),
+            risk_factor_first_tier_boundary: 10_000_u128,
+            risk_factor_tier_size: 1,
+            quorum: 1,
+        );
+    assert_panic_with_felt_error(:result, expected_error: UNSORTED_RISK_FACTOR_TIERS);
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add comprehensive tests for `add_vault_collateral_asset` and switch vault-related tests to use typed error constants instead of string literals, with minor constants/import updates.
> 
> - **Tests**:
>   - **Vault collateral asset**:
>     - Add success test for `add_vault_collateral_asset`, deriving `resolution_factor` from ERC20 `decimals`, asserting event emission and stored config/timely data/tier lengths.
>     - Add negative scenario tests covering permissions, zero/mismatched params (`quantum`, `resolution_factor`, `quorum`, token address, asset id), empty/unsorted risk tiers, duplicate asset, and using collateral ID.
>   - **Vault ops**:
>     - Update existing tests (`deposit_into_vault`, `register_vault`) to assert with error constants (`ASSET_NOT_EXISTS`, `ASSET_NOT_ACTIVE`, `POSITION_DOESNT_EXIST`, `INVALID_ZERO_AMOUNT`, `INVALID_VAULT_CONTRACT_ADDRESS`, `VAULT_POSITION_ALREADY_EXISTS`, `VAULT_CONTRACT_ALREADY_EXISTS`, `VAULT_POSITION_HAS_SHARES`).
> - **Constants**:
>   - Add `DEFAULT_DECIMALS: u8 = 18` in `tests/constants.cairo` (used for expected `resolution_factor`).
> - **Imports**:
>   - Add ERC20 metadata dispatcher and error constants; minor import cleanups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f6cec5d755d173395a43ca1baf00dc46cf289d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/94)
<!-- Reviewable:end -->
