### PR TITLE
test(perp-vault): test no vault shares in register vault

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
@@ -50,6 +50,9 @@ pub fn VAULT_CONTRACT_ADDRESS_1() -> ContractAddress {
 pub fn VAULT_CONTRACT_ADDRESS_2() -> ContractAddress {
     'VAULT_CONTRACT_ADDRESS_2'.try_into().unwrap()
 }
+pub fn VAULT_CONTRACT_ADDRESS_3() -> ContractAddress {
+    'VAULT_CONTRACT_ADDRESS_3'.try_into().unwrap()
+}
 
 pub const UPGRADE_DELAY: u64 = 5_u64;
 /// 1 day in seconds.
@@ -76,6 +79,9 @@ pub const VAULT_SHARE_QUANTUM: u64 = 1_000;
 
 pub const POSITION_ID_1: PositionId = PositionId { value: 2 };
 pub const POSITION_ID_2: PositionId = PositionId { value: 3 };
+pub fn POSITION_ID_3() -> PositionId {
+    PositionId { value: 4 }
+}
 
 pub const ORACLE_A_NAME: felt252 = 'ORCLA';
 pub const ORACLE_B_NAME: felt252 = 'ORCLB';
@@ -98,6 +104,13 @@ pub fn SYNTHETIC_ASSET_ID_2() -> AssetId {
 }
 pub fn SYNTHETIC_ASSET_ID_3() -> AssetId {
     AssetIdTrait::new(value: selector!("SYNTHETIC_ASSET_ID_3"))
+}
+
+pub fn VAULT_ASSET_ID_1() -> AssetId {
+    AssetIdTrait::new(value: selector!("VAULT_ASSET_ID_1"))
+}
+pub fn VAULT_ASSET_ID_2() -> AssetId {
+    AssetIdTrait::new(value: selector!("VAULT_ASSET_ID_2"))
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
@@ -79,9 +79,7 @@ pub const VAULT_SHARE_QUANTUM: u64 = 1_000;
 
 pub const POSITION_ID_1: PositionId = PositionId { value: 2 };
 pub const POSITION_ID_2: PositionId = PositionId { value: 3 };
-pub fn POSITION_ID_3() -> PositionId {
-    PositionId { value: 4 }
-}
+pub const POSITION_ID_3: PositionId = PositionId { value: 4 };
 
 pub const ORACLE_A_NAME: felt252 = 'ORCLA';
 pub const ORACLE_B_NAME: felt252 = 'ORCLB';

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -18,12 +18,13 @@ use perpetuals::core::components::positions::interface::{
     IPositions, IPositionsDispatcher, IPositionsDispatcherTrait, IPositionsSafeDispatcher,
     IPositionsSafeDispatcherTrait,
 };
+use perpetuals::core::components::vault::errors::VAULT_POSITION_HAS_SHARES;
 use perpetuals::core::components::vault::interface::{
     IVault, IVaultSafeDispatcher, IVaultSafeDispatcherTrait,
 };
 use perpetuals::core::core::Core;
 use perpetuals::core::core::Core::SNIP12MetadataImpl;
-use perpetuals::core::errors::{SIGNED_TX_EXPIRED, VAULT_POSITION_HAS_SHARES};
+use perpetuals::core::errors::SIGNED_TX_EXPIRED;
 use perpetuals::core::events;
 use perpetuals::core::interface::{ICore, ICoreSafeDispatcher, ICoreSafeDispatcherTrait};
 use perpetuals::core::types::asset::{AssetStatus, AssetTrait};
@@ -4002,7 +4003,7 @@ fn test_register_vault_negative_scenarios() {
 
     // Test 6: register vault position that already holds vault shares from another vault.
     // Setup: Create a third position that will hold shares from the first vault.
-    let position_with_shares = UserTrait::new(position_id: POSITION_ID_3(), key_pair: KEY_PAIR_3());
+    let position_with_shares = UserTrait::new(position_id: POSITION_ID_3, key_pair: KEY_PAIR_3());
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     position_dispatcher
         .new_position(
@@ -4068,11 +4069,11 @@ fn test_register_vault_negative_scenarios() {
     let result = dispatcher
         .register_vault(
             operator_nonce: 9,
+            :signature,
             vault_position_id: position_with_shares.position_id,
             vault_contract_address: vault_contract_address_3,
             vault_asset_id: vault_asset_id_3,
             :expiration,
-            :signature,
         );
     assert_panic_with_felt_error(:result, expected_error: VAULT_POSITION_HAS_SHARES);
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -23,7 +23,7 @@ use perpetuals::core::components::vault::interface::{
 };
 use perpetuals::core::core::Core;
 use perpetuals::core::core::Core::SNIP12MetadataImpl;
-use perpetuals::core::errors::SIGNED_TX_EXPIRED;
+use perpetuals::core::errors::{SIGNED_TX_EXPIRED, VAULT_POSITION_HAS_SHARES};
 use perpetuals::core::events;
 use perpetuals::core::interface::{ICore, ICoreSafeDispatcher, ICoreSafeDispatcherTrait};
 use perpetuals::core::types::asset::{AssetStatus, AssetTrait};
@@ -3728,7 +3728,7 @@ fn test_register_vault_successful() {
     // Setup parameters:
     let vault_position_id = vault.position_id;
     let vault_contract_address = VAULT_CONTRACT_ADDRESS_1();
-    let vault_asset_id = SYNTHETIC_ASSET_ID_2();
+    let vault_asset_id = VAULT_ASSET_ID_1();
     let expiration = Time::now().add(Time::days(1));
 
     let register_vault_args = RegisterVaultArgs {
@@ -3829,7 +3829,7 @@ fn test_register_vault_negative_scenarios() {
                 token_contract: VAULT_CONTRACT_ADDRESS_1(),
             );
 
-            state.assets.asset_config.write(SYNTHETIC_ASSET_ID_2(), Some(asset_config));
+            state.assets.asset_config.write(VAULT_ASSET_ID_1(), Some(asset_config));
         },
     );
 
@@ -3846,7 +3846,7 @@ fn test_register_vault_negative_scenarios() {
     // Setup parameters with zero contract address:
     let vault_position_id = vault.position_id;
     let vault_contract_address = Zero::zero();
-    let vault_asset_id = SYNTHETIC_ASSET_ID_2();
+    let vault_asset_id = VAULT_ASSET_ID_1();
     let expiration = Time::now().add(Time::days(1));
 
     let register_vault_args = RegisterVaultArgs {
@@ -3896,7 +3896,7 @@ fn test_register_vault_negative_scenarios() {
     // Setup parameters:
     let non_existent_vault_position_id = PositionId { value: 100 };
     let vault_contract_address = VAULT_CONTRACT_ADDRESS_1();
-    let vault_asset_id = SYNTHETIC_ASSET_ID_2();
+    let vault_asset_id = VAULT_ASSET_ID_1();
     let expiration = Time::now().add(Time::days(1));
 
     let register_vault_args = RegisterVaultArgs {
@@ -3924,7 +3924,7 @@ fn test_register_vault_negative_scenarios() {
     // Setup parameters:
     let vault_position_id = vault.position_id;
     let vault_contract_address = VAULT_CONTRACT_ADDRESS_1();
-    let vault_asset_id = SYNTHETIC_ASSET_ID_2();
+    let vault_asset_id = VAULT_ASSET_ID_1();
     let expiration = Time::now().add(Time::days(1));
 
     let register_vault_args = RegisterVaultArgs {
@@ -3999,5 +3999,81 @@ fn test_register_vault_negative_scenarios() {
             :expiration,
         );
     assert_panic_with_felt_error(:result, expected_error: 'VAULT_CONTRACT_ALREADY_EXISTS');
+
+    // Test 6: register vault position that already holds vault shares from another vault.
+    // Setup: Create a third position that will hold shares from the first vault.
+    let position_with_shares = UserTrait::new(position_id: POSITION_ID_3(), key_pair: KEY_PAIR_3());
+    cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
+    position_dispatcher
+        .new_position(
+            operator_nonce: 8,
+            position_id: position_with_shares.position_id,
+            owner_public_key: position_with_shares.get_public_key(),
+            owner_account: Zero::zero(),
+        );
+
+    // Give this position some vault shares from the first vault by directly modifying state.
+    interact_with_state(
+        :contract_address,
+        f: || {
+            let mut state = Core::contract_state_for_testing();
+            // Add vault shares balance to the position.
+            use perpetuals::core::types::position::AssetBalance;
+            let asset_balance = AssetBalance {
+                version: POSITION_VERSION, balance: 100_i64.into(), funding_index: Zero::zero(),
+            };
+            state
+                .positions
+                .get_position_mut(position_id: position_with_shares.position_id)
+                .assets_balance
+                .write(vault_asset_id, asset_balance);
+        },
+    );
+
+    // Now try to register this position as a vault - it should fail.
+    let vault_asset_id_3 = VAULT_ASSET_ID_2();
+    let vault_contract_address_3 = VAULT_CONTRACT_ADDRESS_3();
+
+    // Add the third vault asset.
+    interact_with_state(
+        :contract_address,
+        f: || {
+            let mut state = Core::contract_state_for_testing();
+
+            let asset_config = AssetTrait::vault_share_collateral_config(
+                status: AssetStatus::PENDING,
+                risk_factor_first_tier_boundary: Default::default(),
+                risk_factor_tier_size: Default::default(),
+                quorum: Default::default(),
+                resolution_factor: Default::default(),
+                quantum: VAULT_SHARE_QUANTUM,
+                token_contract: vault_contract_address_3,
+            );
+
+            state.assets.asset_config.write(vault_asset_id_3, Some(asset_config));
+        },
+    );
+
+    let register_vault_args_3 = RegisterVaultArgs {
+        vault_position_id: position_with_shares.position_id,
+        vault_contract_address: vault_contract_address_3,
+        vault_asset_id: vault_asset_id_3,
+        expiration,
+    };
+    let msg_hash = register_vault_args_3
+        .get_message_hash(public_key: position_with_shares.get_public_key());
+    let signature = position_with_shares.sign_message(msg_hash);
+
+    cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
+    let result = dispatcher
+        .register_vault(
+            operator_nonce: 9,
+            vault_position_id: position_with_shares.position_id,
+            vault_contract_address: vault_contract_address_3,
+            vault_asset_id: vault_asset_id_3,
+            :expiration,
+            :signature,
+        );
+    assert_panic_with_felt_error(:result, expected_error: VAULT_POSITION_HAS_SHARES);
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce vault-specific asset ID/address constants and extend register_vault tests to reject positions that already hold vault shares.
> 
> - **Tests (vault registration)**:
>   - Add negative case asserting `register_vault` fails with `VAULT_POSITION_HAS_SHARES` when the position already holds vault shares.
>   - Update tests to use vault-specific asset IDs (`VAULT_ASSET_ID_1`, `VAULT_ASSET_ID_2`) and add a third vault address (`VAULT_CONTRACT_ADDRESS_3`).
>   - Replace usages of `SYNTHETIC_ASSET_ID_2` with `VAULT_ASSET_ID_1` where appropriate for vault assets.
> - **Test constants**:
>   - Add `VAULT_CONTRACT_ADDRESS_3`, `POSITION_ID_3`, and new asset IDs `VAULT_ASSET_ID_1`, `VAULT_ASSET_ID_2` for vault shares.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 355bdc22c5d64a2486c3a784122bf0e682af5427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/95)
<!-- Reviewable:end -->
