### PR TITLE
fix(perps): deposit/withdraw vault quantums

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -3602,7 +3602,7 @@ fn deposit_into_vault(
     position_id: PositionId,
     vault_position_id: PositionId,
     collateral_id: AssetId,
-    quantized_amount: u64,
+    collateral_quantized_amount: u64,
     expiration: Timestamp,
     salt: felt252,
     signature: Signature,

--- a/workspace/apps/perpetuals/contracts/src/core/components/vault/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vault/interface.cairo
@@ -14,7 +14,7 @@ pub trait IVault<TContractState> {
         signature: Signature,
         position_id: PositionId,
         vault_position_id: PositionId,
-        quantized_amount: u64,
+        collateral_quantized_amount: u64,
         expiration: Timestamp,
         salt: felt252,
     );

--- a/workspace/apps/perpetuals/contracts/src/core/types/deposit_into_vault.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/deposit_into_vault.cairo
@@ -9,7 +9,7 @@ use starkware_utils::time::time::Timestamp;
 pub struct VaultDepositArgs {
     pub position_id: PositionId,
     pub vault_position_id: PositionId,
-    pub quantized_amount: u64,
+    pub collateral_quantized_amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
 }
@@ -20,7 +20,7 @@ pub struct VaultDepositArgs {
 ///   "\"VaultDepositArgs\"(
 ///    \"position_id\":\"PositionId\",
 ///    \"vault_position_id\":\"PositionId\",
-///    \"quantized_amount\":\"u64\",
+///    \"collateral_quantized_amount\":\"u64\",
 ///    \"expiration\":\"Timestamp\",
 ///    \"salt\":\"felt\"
 ///    )
@@ -32,7 +32,7 @@ pub struct VaultDepositArgs {
 ///    )
 /// );
 const VAULT_DEPOSIT_ARGS_TYPE_HASH: HashType =
-    0x0261990c673bdf6a616b6b550e1196c85bfbb8ee72fe3abe478633cb3adb3231;
+    0x0159d929b2c1c81a4c7ef04c80f05e4e2cd2c0e08844fa772c38b9a69230a47d;
 
 impl StructHashImpl of StructHash<VaultDepositArgs> {
     fn hash_struct(self: @VaultDepositArgs) -> HashType {
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn test_vault_deposit_args_type_hash() {
         let expected = selector!(
-            "\"VaultDepositArgs\"(\"position_id\":\"PositionId\",\"vault_position_id\":\"PositionId\",\"quantized_amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"Timestamp\"(\"seconds\":\"u64\")",
+            "\"VaultDepositArgs\"(\"position_id\":\"PositionId\",\"vault_position_id\":\"PositionId\",\"collateral_quantized_amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"Timestamp\"(\"seconds\":\"u64\")",
         );
         assert_eq!(to_base_16_string(VAULT_DEPOSIT_ARGS_TYPE_HASH), to_base_16_string(expected));
     }

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -3602,7 +3602,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             signature: array![].span(),
             position_id: user.position_id,
             vault_position_id: non_vault_position,
-            quantized_amount: DEPOSIT_AMOUNT,
+            collateral_quantized_amount: DEPOSIT_AMOUNT,
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
@@ -3639,7 +3639,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             signature: array![].span(),
             position_id: user.position_id,
             vault_position_id: non_active_vault_position,
-            quantized_amount: DEPOSIT_AMOUNT,
+            collateral_quantized_amount: DEPOSIT_AMOUNT,
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
@@ -3674,7 +3674,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             signature: array![].span(),
             position_id: unregistered_user,
             vault_position_id: vault_user.position_id,
-            quantized_amount: DEPOSIT_AMOUNT,
+            collateral_quantized_amount: DEPOSIT_AMOUNT,
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );
@@ -3707,7 +3707,7 @@ fn test_failed_deposit_into_vault_scenarios() {
             signature: array![].span(),
             position_id: user.position_id,
             vault_position_id: vault_user.position_id,
-            quantized_amount: 0,
+            collateral_quantized_amount: 0,
             expiration: Time::now().add(delta: Time::days(1)),
             salt: 0,
         );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames deposit arg to collateral_quantized_amount and fixes vault share/collateral quantization in deposit/withdraw flows, updating events, hashing, and tests.
> 
> - **Contracts (Vault)**:
>   - Rename `quantized_amount` to `collateral_quantized_amount` in `deposit_into_vault` (interface, impl, events) and propagate through validation/execute paths and emitted fields.
>   - Fix quantization math:
>     - Deposit: compute and return actual vault share amounts; clarify vars (`actual_quantized_vault_shares_amount`).
>     - Withdraw: rework to compute collateral in quantized units; update `_withdraw_from_vault_contract` to approve both collateral and shares, derive amounts using `collateral_quantum`/`vault_share_quantum`, validate balances, and return `u64` collateral amount.
>   - Adjust balance diffs and event payloads to use corrected collateral/share amounts.
>   - Cleanup imports and minor var renames.
> - **Types/Hashing**:
>   - Update `VaultDepositArgs` field to `collateral_quantized_amount`; change `VAULT_DEPOSIT_ARGS_TYPE_HASH` and its test.
> - **Docs/Tests**:
>   - Update `docs/spec.md` and unit tests to reflect renamed arg and new event fields/logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1daf604091273eb0f015284c0f6ee9294c03efc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/96)
<!-- Reviewable:end -->
