### PR TITLE
feat(perps): liquidate vault shares

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -982,7 +982,6 @@ impl StructHashImpl of StructHash<RedeemFromVaultOwnerArgs> {
 pub struct LiquidateVaultSharesArgs {
     position_id: PositionId,
     vault_position_id: PositionId,
-    collateral_id: AssetId,
     number_of_shares: u64,
     vault_share_execution_price: Price,
     expiration: Timestamp,
@@ -993,7 +992,6 @@ pub struct LiquidateVaultSharesArgs {
 ///   "\"LiquidateVaultSharesArgs\"(
 ///    \"position_id\":\"PositionId\",
 ///    \"vault_position_id\":\"PositionId\",
-///    \"collateral_id\":\"AssetId\",
 ///    \"number_of_shares\":\"u64\",
 ///    \"vault_share_execution_price\":\"Price\",
 ///    \"expiration\":\"Timestamp\",
@@ -1001,9 +999,6 @@ pub struct LiquidateVaultSharesArgs {
 ///    )
 ///    \"PositionId\"(
 ///    \"value\":\"u32\"
-///    )"
-///    \"AssetId\"(
-///    \"value\":\"felt\"
 ///    )"
 ///    \"Timestamp\"(
 ///    \"seconds\":\"u64\"
@@ -3815,10 +3810,8 @@ Only the Operator can execute.
 8. position id is not a vault position and exists.
 9. number_of_shares is non zero.
 10. vault_share_execution_price is non zero.
-11. collateral_id is the protocol collateral asset.
-12. position id is liquidatable.
-13. Caller is the operator.
-14. Request is new (check payload hash not exists in the fulfillment map).
+11. position id is liquidatable or deleveragable.
+12. Request is new (check payload hash not exists in the fulfillment map).
 
 **Logic:**
 
@@ -3829,7 +3822,7 @@ Only the Operator can execute.
 5. call the new redeem function of the vault contract (a version where the price of a vault share is dicateded by the operator) which burns the vault shares and transfers the assets from the vault contract to the perps contract
 6. increase the position_id collateral_id balance by vault_share_execution_price*number_of_shares
 7. reduce the vault_position_id collateral_id balance by vault_share_execution_price*number_of_shares
-8. position id becomes healthier (no longer liquidatable) as a result of the collateral increase.
+8. position id becomes healthier.
 
 **Emits:**
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -980,20 +980,22 @@ impl StructHashImpl of StructHash<RedeemFromVaultOwnerArgs> {
 
 ```rust
 pub struct LiquidateVaultSharesArgs {
-    vault_share_execution_price: Price,
+    position_id: PositionId,
     vault_position_id: PositionId,
     collateral_id: AssetId,
     number_of_shares: u64,
+    vault_share_execution_price: Price,
     expiration: Timestamp,
     salt: felt252,
 }
 
 /// selector!(
 ///   "\"LiquidateVaultSharesArgs\"(
-///    \"vault_share_execution_price\":\"Price\",
+///    \"position_id\":\"PositionId\",
 ///    \"vault_position_id\":\"PositionId\",
 ///    \"collateral_id\":\"AssetId\",
 ///    \"number_of_shares\":\"u64\",
+///    \"vault_share_execution_price\":\"Price\",
 ///    \"expiration\":\"Timestamp\",
 ///    \"salt\":\"felt\"
 ///    )
@@ -2988,7 +2990,10 @@ pub struct DepositedIntoVault {
     #[key]
     pub vault_position_id: PositionId,
     pub collateral_id: AssetId,
-    pub quantized_amount: u64
+    pub quantized_amount: u64,
+    pub expiration: Timestamp,
+    pub salt: felt252,
+    pub quantized_shares_amount: u64,
 }
 ```
 
@@ -3001,13 +3006,12 @@ pub struct RedeemedFromVault {
     pub position_id: PositionId,
     #[key]
     pub vault_position_id: PositionId,
-    #[key]
     pub collateral_id: AssetId,
-    pub number_of_shares: u64,
-    pub minimum_received_total_amount: u64,
-    pub vault_share_execution_price: Price,
+    pub quantized_amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
+    pub quantized_shares_amount: u64,
+    pub price: Price,
 }
 ```
 
@@ -3020,13 +3024,12 @@ pub struct LiquidatedFromVault {
     pub position_id: PositionId,
     #[key]
     pub vault_position_id: PositionId,
-    #[key]
     pub collateral_id: AssetId,
-    pub number_of_shares: u64,
-    pub minimum_received_total_amount: u64,
-    pub vault_share_execution_price: Price,
+    pub quantized_amount: u64,
     pub expiration: Timestamp,
     pub salt: felt252,
+    pub quantized_shares_amount: u64,
+    pub price: Price,
 }
 ```
 
@@ -3776,20 +3779,19 @@ Only the Operator can execute.
 
 #### LiquidateVaultShares
 
-Withdraw from vault is called by the operator to let the user "cash out" his vault shares from the vault position into his position
+Liquidate vault shares is called by the operator to liquidate a liquidatable position against his vault shares
 
 ```rust
 fn liquidate_vault_shares(
     ref self: TContractState,
     operator_nonce: u64,
+    vault_owner_signature: Signature,
     position_id: PositionId,
     vault_position_id: PositionId,
-    collateral_id: AssetId,
     number_of_shares: u64,
     vault_share_execution_price: Price,
     expiration: Timestamp,
     salt: felt252,
-    vault_owner_signature: Signature,
 );
 ```
 
@@ -3812,9 +3814,11 @@ Only the Operator can execute.
 7. `vault_position_id` is a registered vault position.
 8. position id is not a vault position and exists.
 9. number_of_shares is non zero.
-10. position id is liquidatable.
-11. vault_share_execution_price is non zero.
-12. Caller is the operator.
+10. vault_share_execution_price is non zero.
+11. collateral_id is the protocol collateral asset.
+12. position id is liquidatable.
+13. Caller is the operator.
+14. Request is new (check payload hash not exists in the fulfillment map).
 
 **Logic:**
 
@@ -3825,7 +3829,7 @@ Only the Operator can execute.
 5. call the new redeem function of the vault contract (a version where the price of a vault share is dicateded by the operator) which burns the vault shares and transfers the assets from the vault contract to the perps contract
 6. increase the position_id collateral_id balance by vault_share_execution_price*number_of_shares
 7. reduce the vault_position_id collateral_id balance by vault_share_execution_price*number_of_shares
-8. position id is healthier
+8. position id becomes healthier (no longer liquidatable) as a result of the collateral increase.
 
 **Emits:**
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/vault/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vault/events.cairo
@@ -41,3 +41,17 @@ pub struct RedeemedFromVault {
     pub quantized_shares_amount: u64,
     pub price: Price,
 }
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct LiquidatedFromVault {
+    #[key]
+    pub position_id: PositionId,
+    #[key]
+    pub vault_position_id: PositionId,
+    pub collateral_id: AssetId,
+    pub quantized_amount: u64,
+    pub expiration: Timestamp,
+    pub salt: felt252,
+    pub quantized_shares_amount: u64,
+    pub price: Price,
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/vault/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vault/interface.cairo
@@ -40,4 +40,15 @@ pub trait IVault<TContractState> {
         expiration: Timestamp,
         salt: felt252,
     );
+    fn liquidate_vault_shares(
+        ref self: TContractState,
+        operator_nonce: u64,
+        vault_owner_signature: Signature,
+        position_id: PositionId,
+        vault_position_id: PositionId,
+        number_of_shares: u64,
+        vault_share_execution_price: Price,
+        expiration: Timestamp,
+        salt: felt252,
+    );
 }

--- a/workspace/apps/perpetuals/contracts/src/core/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types.cairo
@@ -2,6 +2,7 @@ pub mod asset;
 pub mod balance;
 pub mod deposit_into_vault;
 pub mod funding;
+pub mod liquidate_vault_shares;
 pub mod order;
 pub mod position;
 pub mod price;

--- a/workspace/apps/perpetuals/contracts/src/core/types/liquidate_vault_shares.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/liquidate_vault_shares.cairo
@@ -1,0 +1,65 @@
+use core::hash::{HashStateExTrait, HashStateTrait};
+use core::poseidon::PoseidonTrait;
+use openzeppelin::utils::snip12::StructHash;
+use perpetuals::core::types::position::PositionId;
+use perpetuals::core::types::price::Price;
+use starkware_utils::signature::stark::HashType;
+use starkware_utils::time::time::Timestamp;
+
+#[derive(Copy, Drop, Hash, Serde)]
+pub struct LiquidateVaultSharesArgs {
+    pub position_id: PositionId,
+    pub vault_position_id: PositionId,
+    pub number_of_shares: u64,
+    pub vault_share_execution_price: Price,
+    pub expiration: Timestamp,
+    pub salt: felt252,
+}
+
+/// selector!(
+///   "\"LiquidateVaultSharesArgs\"(
+///    \"position_id\":\"PositionId\",
+///    \"vault_position_id\":\"PositionId\",
+///    \"number_of_shares\":\"u64\",
+///    \"vault_share_execution_price\":\"Price\",
+///    \"expiration\":\"Timestamp\",
+///    \"salt\":\"felt\"
+///    )
+///    \"PositionId\"(
+///    \"value\":\"u32\"
+///    )"
+///    \"AssetId\"(
+///    \"value\":\"felt\"
+///    )"
+///    \"Price\"(
+///    \"value\":\"u64\"
+///    )"
+///    \"Timestamp\"(
+///    \"seconds\":\"u64\"
+///    )"
+/// );
+const LIQUIDATE_VAULT_SHARES_ARGS_TYPE_HASH: HashType =
+    0x0198043d1a2a3892f10e94fb3ad87295b01599b2e7329436d107398f7b6ea6ec;
+
+impl StructHashImpl of StructHash<LiquidateVaultSharesArgs> {
+    fn hash_struct(self: @LiquidateVaultSharesArgs) -> HashType {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(LIQUIDATE_VAULT_SHARES_ARGS_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use starkware_utils::math::utils::to_base_16_string;
+    use super::LIQUIDATE_VAULT_SHARES_ARGS_TYPE_HASH;
+
+    #[test]
+    fn test_liquidate_vault_shares_args_type_hash() {
+        let expected = selector!(
+            "\"LiquidateVaultSharesArgs\"(\"position_id\":\"PositionId\",\"vault_position_id\":\"PositionId\",\"number_of_shares\":\"u64\",\"vault_share_execution_price\":\"Price\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"AssetId\"(\"value\":\"felt\")\"Price\"(\"value\":\"u64\")\"Timestamp\"(\"seconds\":\"u64\")",
+        );
+        assert_eq!(
+            to_base_16_string(LIQUIDATE_VAULT_SHARES_ARGS_TYPE_HASH), to_base_16_string(expected),
+        );
+    }
+}

--- a/workspace/apps/perpetuals/contracts/src/core/types/liquidate_vault_shares.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/liquidate_vault_shares.cairo
@@ -28,9 +28,6 @@ pub struct LiquidateVaultSharesArgs {
 ///    \"PositionId\"(
 ///    \"value\":\"u32\"
 ///    )"
-///    \"AssetId\"(
-///    \"value\":\"felt\"
-///    )"
 ///    \"Price\"(
 ///    \"value\":\"u64\"
 ///    )"
@@ -39,7 +36,7 @@ pub struct LiquidateVaultSharesArgs {
 ///    )"
 /// );
 const LIQUIDATE_VAULT_SHARES_ARGS_TYPE_HASH: HashType =
-    0x0198043d1a2a3892f10e94fb3ad87295b01599b2e7329436d107398f7b6ea6ec;
+    0x0141b4c09491cda786aa7d765d022e0a2a45ededc52f93227c12f2107810c9d1;
 
 impl StructHashImpl of StructHash<LiquidateVaultSharesArgs> {
     fn hash_struct(self: @LiquidateVaultSharesArgs) -> HashType {
@@ -56,7 +53,7 @@ mod tests {
     #[test]
     fn test_liquidate_vault_shares_args_type_hash() {
         let expected = selector!(
-            "\"LiquidateVaultSharesArgs\"(\"position_id\":\"PositionId\",\"vault_position_id\":\"PositionId\",\"number_of_shares\":\"u64\",\"vault_share_execution_price\":\"Price\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"AssetId\"(\"value\":\"felt\")\"Price\"(\"value\":\"u64\")\"Timestamp\"(\"seconds\":\"u64\")",
+            "\"LiquidateVaultSharesArgs\"(\"position_id\":\"PositionId\",\"vault_position_id\":\"PositionId\",\"number_of_shares\":\"u64\",\"vault_share_execution_price\":\"Price\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"Price\"(\"value\":\"u64\")\"Timestamp\"(\"seconds\":\"u64\")",
         );
         assert_eq!(
             to_base_16_string(LIQUIDATE_VAULT_SHARES_ARGS_TYPE_HASH), to_base_16_string(expected),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/103)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an operator flow to liquidate positions by redeeming vault shares, adding a new IVault method, event, validations, and SNIP-12-typed args, and updates spec/docs and event structures accordingly.
> 
> - **Vault Component (contracts)**:
>   - Add `fn liquidate_vault_shares(...)` with pausable, nonce, price checks; validates vault owner signature and position state; redeems shares and applies diffs; emits `LiquidatedFromVault`.
>   - New `_validate_liquidate_vault_shares` helper using `LiquidateVaultSharesArgs` + fulfillment guard; reuse `_execute_redeem_from_vault`.
>   - Extend events enum with `LiquidatedFromVault`.
> - **Interface/Events**:
>   - `IVault` gains `liquidate_vault_shares(...)`.
>   - New event struct `LiquidatedFromVault` and expanded vault events to include `quantized_amount`, `expiration`, `salt`, `quantized_shares_amount`, `price`.
> - **Types**:
>   - New `core/types/liquidate_vault_shares.cairo` defining `LiquidateVaultSharesArgs` with SNIP-12 type hash + test; added to `types.cairo`.
> - **Docs (spec.md)**:
>   - Document `LiquidateVaultSharesArgs` (adds `position_id`, removes `collateral_id`), request hash usage, validations (liquidatable/deleveragable), and logic.
>   - Update vault events (`DepositedIntoVault`, `RedeemedFromVault`, `LiquidatedFromVault`) field sets and descriptions; adjust redeem/liquidate sections and hashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84b86735bdf812de539b157702623cc015a64dcb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->