### PR TITLE
test(perpetuals): use decimal erc20 mock

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#f1273496b5c121b2927ad63110368fa809771818"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#b06c2994b22d00906943bab36c1faa2ce183def6"
 dependencies = [
  "openzeppelin",
 ]
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils_testing"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#f1273496b5c121b2927ad63110368fa809771818"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#b06c2994b22d00906943bab36c1faa2ce183def6"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/workspace/apps/perpetuals/contracts/Scarb.toml
+++ b/workspace/apps/perpetuals/contracts/Scarb.toml
@@ -36,8 +36,9 @@ panic-backtrace = true
 [[test]]
 name = "perpetuals_unittest"
 build-external-contracts = [
-    "starkware_utils::erc20::erc20_mocks::DualCaseERC20Mock",
-    "openzeppelin_presets::account::AccountUpgradeable"
+    "starkware_utils::erc20::erc20_mocks::ERC20DecimalsMock",
+    "openzeppelin_presets::account::AccountUpgradeable",
+    "vault::protocol_vault::ProtocolVault",
 ]
 
 [lib]

--- a/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
@@ -65,6 +65,7 @@ pub const CANCEL_DELAY: TimeDelta = TimeDelta { seconds: WEEK };
 pub const MAX_FUNDING_RATE: u32 = 35792; // Which is ~3% in an hour.
 pub const COLLATERAL_QUORUM: u8 = 0;
 pub const COLLATERAL_QUANTUM: u64 = 1_000;
+pub const COLLATERAL_DECIMALS: u8 = 6; // for USDC.
 pub const SYNTHETIC_QUORUM: u8 = 1;
 pub const SYNTHETIC_RESOLUTION_FACTOR: u64 = 1_000_000_000;
 pub const INITIAL_SUPPLY: u256 = 10_000_000_000_000_000;

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/flow_tests.cairo
@@ -159,7 +159,7 @@ fn test_two_users_ten_synthetics_flow() {
                 (STRK_ASSET, 256 + 100), // Value diff user_a: -400, user_b: +400. Risk(both): 142
                 (SOL_ASSET, 128 + 100), // Value diff user_a: -800, user_b: +800. Risk(both): 182
                 (DOGE_ASSET, 64 + 100), // Value diff user_a: -1600, user_b: +1600. Risk(both): 262
-                (PEPE_ASSET, 32 + 100), // Value diff user_a: +3200, user_b: -3200. Risk(both): 422 
+                (PEPE_ASSET, 32 + 100), // Value diff user_a: +3200, user_b: -3200. Risk(both): 422
                 (ETC_ASSET, 16 + 100), // Value diff user_a: +6400, user_b: -6400. Risk(both): 742
                 (TAO_ASSET, 8 + 100), // Value diff user_a: +12800, user_b: -12800. Risk(both): 2764
                 (XRP_ASSET, 4 + 100), // Value diff user_a: +25600, user_b: -25600 Risk(both): 13312
@@ -901,7 +901,7 @@ fn test_multi_trade_with_price_and_funding_ticks() {
                 (STRK_ASSET, 256 + 100), // Value diff user_a: -400, user_b: +400. Risk(both): 142
                 (SOL_ASSET, 128 + 100), // Value diff user_a: -800, user_b: +800. Risk(both): 182
                 (DOGE_ASSET, 64 + 100), // Value diff user_a: -1600, user_b: +1600. Risk(both): 262
-                (PEPE_ASSET, 32 + 100), // Value diff user_a: +3200, user_b: -3200. Risk(both): 422 
+                (PEPE_ASSET, 32 + 100), // Value diff user_a: +3200, user_b: -3200. Risk(both): 422
                 (ETC_ASSET, 16 + 100), // Value diff user_a: +6400, user_b: -6400. Risk(both): 742
                 (TAO_ASSET, 8 + 100), // Value diff user_a: +12800, user_b: -12800. Risk(both): 2764
                 (XRP_ASSET, 4 + 100), // Value diff user_a: +25600, user_b: -25600 Risk(both): 13312

--- a/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
@@ -179,6 +179,7 @@ impl PerpetualsInitConfigDefault of Default<PerpetualsInitConfig> {
                 token_cfg: TokenConfig {
                     name: COLLATERAL_NAME(),
                     symbol: COLLATERAL_SYMBOL(),
+                    decimals: COLLATERAL_DECIMALS,
                     initial_supply: INITIAL_SUPPLY,
                     owner: COLLATERAL_OWNER(),
                 },
@@ -308,6 +309,7 @@ pub fn create_token_state() -> TokenState {
     let token_config = TokenConfig {
         name: COLLATERAL_NAME(),
         symbol: COLLATERAL_SYMBOL(),
+        decimals: COLLATERAL_DECIMALS,
         initial_supply: INITIAL_SUPPLY,
         owner: COLLATERAL_OWNER(),
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use decimals-aware ERC20 mock in tests, add COLLATERAL_DECIMALS to token config, include ProtocolVault in external builds, and update utils dependency commit.
> 
> - **Tests/Config**:
>   - Replace `DualCaseERC20Mock` with `ERC20DecimalsMock` in `Scarb.toml` test `build-external-contracts` and add `vault::protocol_vault::ProtocolVault`.
>   - Introduce `COLLATERAL_DECIMALS` constant in `src/tests/constants.cairo` and pass `decimals` into `TokenConfig` in `src/tests/test_utils.cairo` (init config and `create_token_state`).
> - **Dependencies**:
>   - Bump `starkware_utils` and `starkware_utils_testing` git revs in `Scarb.lock`.
> - **Misc**:
>   - Minor comment/whitespace tidy in `flow_tests.cairo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54d8276d09591df49c8abaaf7c06df2ae103091e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/113)
<!-- Reviewable:end -->
