### PR TITLE
feat: RiskFactor opt

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -73,6 +73,9 @@ pub mod AssetsComponent {
         #[rename("synthetic_timely_data")]
         pub asset_timely_data: IterableMap<AssetId, AssetTimelyData>,
         pub risk_factor_tiers: Map<AssetId, Vec<RiskFactor>>,
+        #[allow(starknet::colliding_storage_paths)]
+        #[rename("risk_factor_tiers")]
+        pub unchecked_access_risk_factor_tiers: Map<AssetId, Map<u64, RiskFactor>>,
         asset_oracle: Map<AssetId, Map<PublicKey, felt252>>,
         max_oracle_price_validity: TimeDelta,
         collateral_id: Option<AssetId>,
@@ -548,26 +551,32 @@ pub mod AssetsComponent {
             balance: Balance,
             price: Price,
         ) -> RiskFactor {
-            if let Option::Some(asset_config) = self.asset_config.read(asset_id) {
-                let asset_risk_factor_tiers = self.risk_factor_tiers.entry(asset_id);
-                let synthetic_value: u128 = price.mul(rhs: balance).abs();
-                let index = if synthetic_value < asset_config.risk_factor_first_tier_boundary {
-                    0_u128
-                } else {
-                    let tier_size = asset_config.risk_factor_tier_size;
-                    let first_tier_offset = synthetic_value
-                        - asset_config.risk_factor_first_tier_boundary;
-                    min(
-                        1_u128 + (first_tier_offset / tier_size),
-                        asset_risk_factor_tiers.len().into() - 1,
-                    )
-                };
-                asset_risk_factor_tiers
-                    .at(index.try_into().expect('INDEX_SHOULD_NEVER_OVERFLOW'))
-                    .read()
-            } else {
+            let entry = self.asset_config.entry(asset_id).as_ptr();
+            if (!AssetTrait::is_some_config(entry)) {
                 panic_with_felt252(ASSET_NOT_EXISTS)
             }
+
+            let risk_factor_first_tier_boundary = AssetTrait::at_risk_factor_first_tier_boundary(
+                entry,
+            );
+            let risk_factor_tier_size = AssetTrait::at_risk_factor_tier_size(entry);
+            let asset_risk_factor_tiers = self.risk_factor_tiers.entry(asset_id);
+            let unchecked_access_risk_factor_tiers = self
+                .unchecked_access_risk_factor_tiers
+                .entry(asset_id);
+
+            let synthetic_value: u128 = price.mul(rhs: balance).abs();
+            let index = if synthetic_value < risk_factor_first_tier_boundary {
+                0_u128
+            } else {
+                let tier_size = risk_factor_tier_size;
+                let first_tier_offset = synthetic_value - risk_factor_first_tier_boundary;
+                min(
+                    1_u128 + (first_tier_offset / tier_size),
+                    asset_risk_factor_tiers.len().into() - 1,
+                )
+            };
+            unchecked_access_risk_factor_tiers.entry(index.try_into().unwrap()).read()
         }
 
         fn get_funding_index(

--- a/workspace/apps/perpetuals/contracts/src/core/types/asset.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/asset.cairo
@@ -299,6 +299,26 @@ pub impl AssetImpl of AssetTrait {
             Option::None
         }
     }
+
+    /// Reads the risk factor first tier boundary from the Option<AssetConfig>.
+    /// This function does not check if the Option is Some or None.
+    fn at_risk_factor_first_tier_boundary(
+        entry: StoragePointer0Offset<Option<AssetConfig>>,
+    ) -> u128 {
+        let value = Self::read_config(
+            entry, OptionAssetConfigOffset::RISK_FACTOR_FIRST_TIER_BOUNDARY,
+        );
+        let value: u128 = value.try_into().unwrap();
+        value
+    }
+
+    /// Reads the risk factor tier size from the Option<AssetConfig>.
+    /// This function does not check if the Option is Some or None.
+    fn at_risk_factor_tier_size(entry: StoragePointer0Offset<Option<AssetConfig>>) -> u128 {
+        let value = Self::read_config(entry, OptionAssetConfigOffset::RISK_FACTOR_TIER_SIZE);
+        let value: u128 = value.try_into().unwrap();
+        value
+    }
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors risk factor computation to read config fields and tiers directly from storage, adding an unchecked map for tier access to reduce overhead.
> 
> - **Core/Assets**:
>   - **Storage**: Add `unchecked_access_risk_factor_tiers` (`Map<AssetId, Map<u64, RiskFactor>>`) with `#[rename("risk_factor_tiers")]` for direct tier access.
>   - **Risk factor calculation**: Rewrite `get_asset_risk_factor` to avoid full `Option` reads, compute index using direct config field reads, and fetch tier via `unchecked_access_risk_factor_tiers` while retaining bounds via `risk_factor_tiers.len()`.
> - **Types/AssetTrait**:
>   - Add `at_risk_factor_first_tier_boundary` and `at_risk_factor_tier_size` to read `Option<AssetConfig>` fields directly from storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72296ffd792457139f4e09ec4702b2c7d43aadb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/117)
<!-- Reviewable:end -->
