### PR TITLE
feat: read access optimization

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -40,8 +40,8 @@ pub mod AssetsComponent {
     use perpetuals::core::types::risk_factor::{RiskFactor, RiskFactorTrait};
     use starknet::ContractAddress;
     use starknet::storage::{
-        Map, MutableVecTrait, StorageMapReadAccess, StoragePathEntry, StoragePointerReadAccess,
-        StoragePointerWriteAccess, Vec, VecTrait,
+        Map, MutableVecTrait, StorageAsPointer, StorageMapReadAccess, StoragePathEntry,
+        StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait,
     };
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalTrait as PausableInternal;
@@ -50,7 +50,8 @@ pub mod AssetsComponent {
     use starkware_utils::math::abs::Abs;
     use starkware_utils::signature::stark::{PublicKey, validate_stark_signature};
     use starkware_utils::storage::iterable_map::{
-        IterableMap, IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
+        IterableMap, IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapTrait,
+        IterableMapWriteAccessImpl,
     };
     use starkware_utils::storage::utils::{AddToStorage, SubFromStorage};
     use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
@@ -76,6 +77,9 @@ pub mod AssetsComponent {
         #[rename("synthetic_timely_data")]
         pub timely_data: IterableMap<AssetId, TimelyData>,
         pub risk_factor_tiers: Map<AssetId, Vec<RiskFactor>>,
+        #[allow(starknet::colliding_storage_paths)]
+        #[rename("risk_factor_tiers")]
+        pub unchecked_access_risk_factor_tiers: Map<AssetId, Map<u64, RiskFactor>>,
         asset_oracle: Map<AssetId, Map<PublicKey, felt252>>,
         max_oracle_price_validity: TimeDelta,
         collateral_id: Option<AssetId>,
@@ -607,12 +611,30 @@ pub mod AssetsComponent {
         }
 
         fn get_asset_price(self: @ComponentState<TContractState>, asset_id: AssetId) -> Price {
-            if let Option::Some(data) = self.timely_data.read(asset_id) {
-                data.price
-            } else {
-                panic_with_felt252(NOT_SYNTHETIC)
+            let entry = self.timely_data.pointer(asset_id);
+            match SyntheticTrait::get_price(entry) {
+                Option::None => panic_with_felt252(NOT_SYNTHETIC),
+                Option::Some(price) => price,
             }
         }
+
+        /// Returns the stored price directly without checking whether it exists.
+        fn get_asset_price_unsafe(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> Price {
+            let entry = self.timely_data.pointer(asset_id);
+            SyntheticTrait::at_price(entry)
+        }
+
+        /// Returns both the stored price and funding index directly without checking their
+        /// existence.
+        fn get_price_and_funding_index(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> (Price, FundingIndex) {
+            let entry = self.timely_data.pointer(asset_id);
+            (SyntheticTrait::at_price(entry), SyntheticTrait::at_funding_index(entry))
+        }
+
 
         /// Get the risk factor of a synthetic asset.
         ///   - synthetic_value = |price * balance|
@@ -643,36 +665,54 @@ pub mod AssetsComponent {
         fn get_synthetic_risk_factor_for_value(
             self: @ComponentState<TContractState>, synthetic_id: AssetId, synthetic_value: u128,
         ) -> RiskFactor {
-            if let Option::Some(asset_config) = self.asset_config.read(synthetic_id) {
-                let asset_risk_factor_tiers = self.risk_factor_tiers.entry(synthetic_id);
-                let index = if synthetic_value < asset_config.risk_factor_first_tier_boundary {
-                    0_u128
-                } else {
-                    let tier_size = asset_config.risk_factor_tier_size;
-                    let first_tier_offset = synthetic_value
-                        - asset_config.risk_factor_first_tier_boundary;
-                    min(
-                        1_u128 + (first_tier_offset / tier_size),
-                        asset_risk_factor_tiers.len().into() - 1,
-                    )
-                };
-                asset_risk_factor_tiers
-                    .at(index.try_into().expect('INDEX_SHOULD_NEVER_OVERFLOW'))
-                    .read()
-            } else {
+            let entry = self.asset_config.entry(synthetic_id).as_ptr();
+            if (!SyntheticTrait::is_some_config(entry)) {
                 panic_with_felt252(NOT_SYNTHETIC)
             }
+            let risk_factor_first_tier_boundary =
+                SyntheticTrait::at_risk_factor_first_tier_boundary(
+                entry,
+            );
+            let risk_factor_tier_size = SyntheticTrait::at_risk_factor_tier_size(entry);
+            let asset_risk_factor_tiers = self.risk_factor_tiers.entry(synthetic_id);
+
+            let unchecked_access_risk_factor_tiers = self
+                .unchecked_access_risk_factor_tiers
+                .entry(synthetic_id);
+
+            let index = if synthetic_value < risk_factor_first_tier_boundary {
+                0_u128
+            } else {
+                let tier_size = risk_factor_tier_size;
+                let first_tier_offset = synthetic_value - risk_factor_first_tier_boundary;
+                min(
+                    1_u128 + (first_tier_offset / tier_size),
+                    asset_risk_factor_tiers.len().into() - 1,
+                )
+            };
+
+            unchecked_access_risk_factor_tiers.entry(index.try_into().unwrap()).read()
         }
 
         fn get_funding_index(
             self: @ComponentState<TContractState>, synthetic_id: AssetId,
         ) -> FundingIndex {
-            if let Option::Some(data) = self.timely_data.read(synthetic_id) {
-                data.funding_index
-            } else {
-                panic_with_felt252(NOT_SYNTHETIC)
+            let entry = self.timely_data.pointer(synthetic_id);
+
+            match SyntheticTrait::get_funding_index(entry) {
+                Option::None => panic_with_felt252(NOT_SYNTHETIC),
+                Option::Some(funding_index) => funding_index,
             }
         }
+
+        /// Returns the stored funding index directly without checking whether it exists.
+        fn get_funding_index_unsafe(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> FundingIndex {
+            let entry = self.timely_data.pointer(asset_id);
+            SyntheticTrait::at_funding_index(entry)
+        }
+
 
         fn validate_asset_active(self: @ComponentState<TContractState>, synthetic_id: AssetId) {
             if let Option::Some(config) = self.asset_config.read(synthetic_id) {

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -536,7 +536,7 @@ pub mod Positions {
                 if synthetic.balance.is_zero() {
                     continue;
                 }
-                let global_funding_index = assets.get_funding_index(synthetic_id);
+                let global_funding_index = assets.get_funding_index_unsafe(synthetic_id);
                 collateral_provisional_balance +=
                     calculate_funding(
                         old_funding_index: synthetic.funding_index,
@@ -569,18 +569,19 @@ pub mod Positions {
                 if balance.is_zero() {
                     continue;
                 }
+                let (price, funding_index) = assets
+                    .get_price_and_funding_index(asset_id: synthetic_id);
 
                 provisional_delta +=
                     calculate_funding(
                         old_funding_index: synthetic.funding_index,
-                        new_funding_index: assets.get_funding_index(synthetic_id),
+                        new_funding_index: funding_index,
                         balance: synthetic.balance,
                     );
                 if synthetic_diff_id == synthetic_id {
                     continue;
                 }
 
-                let price = assets.get_asset_price(synthetic_id);
                 let risk_factor = assets.get_asset_risk_factor(synthetic_id, balance, price);
                 unchanged_assets
                     .append(

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -126,6 +126,7 @@ pub mod Core {
         #[substorage(v0)]
         src5: SRC5Component::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub deposits: Deposit::Storage,

--- a/workspace/apps/perpetuals/contracts/src/core/types/asset/synthetic.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/asset/synthetic.cairo
@@ -3,13 +3,16 @@ use perpetuals::core::types::balance::Balance;
 use perpetuals::core::types::funding::FundingIndex;
 use perpetuals::core::types::price::Price;
 use perpetuals::core::types::risk_factor::RiskFactor;
-use starknet::ContractAddress;
+use starknet::storage::StoragePointer0Offset;
+use starknet::storage_access::storage_address_from_base_and_offset;
+use starknet::syscalls::storage_read_syscall;
+use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils::time::time::Timestamp;
 
 
 const VERSION: u8 = 1;
 
-#[derive(Copy, Drop, Serde, starknet::Store, PartialEq)]
+#[derive(Copy, Debug, Drop, PartialEq, Serde, starknet::Store)]
 pub enum AssetType {
     #[default]
     SYNTHETIC,
@@ -17,20 +20,32 @@ pub enum AssetType {
     VAULT_SHARE_COLLATERAL,
 }
 
+pub impl Felt252TryIntoAssetType of TryInto<felt252, AssetType> {
+    fn try_into(self: felt252) -> Option<AssetType> {
+        match self {
+            0 => Option::Some(AssetType::SYNTHETIC),
+            1 => Option::Some(AssetType::SPOT_COLLATERAL),
+            2 => Option::Some(AssetType::VAULT_SHARE_COLLATERAL),
+            _ => Option::None,
+        }
+    }
+}
+
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct AssetConfig {
     version: u8,
     // Configurable
-    pub status: AssetStatus,
-    pub risk_factor_first_tier_boundary: u128,
-    pub risk_factor_tier_size: u128,
-    pub quorum: u8,
+    pub status: AssetStatus, // V1
+    pub risk_factor_first_tier_boundary: u128, // V1
+    pub risk_factor_tier_size: u128, // V1
+    pub quorum: u8, // V1
     // Smallest unit of a synthetic asset in the system.
-    pub resolution_factor: u64,
-    pub quantum: u64,
-    pub token_contract: Option<ContractAddress>,
-    pub asset_type: AssetType,
+    pub resolution_factor: u64, // V1
+    pub quantum: u64, // V2
+    pub token_contract: Option<ContractAddress>, // V2
+    pub asset_type: AssetType // V2
 }
+
 
 #[derive(Copy, Drop, Serde, starknet::Store)]
 pub struct TimelyData {
@@ -129,5 +144,197 @@ pub impl SyntheticImpl of SyntheticTrait {
         price: Price, last_price_update: Timestamp, funding_index: FundingIndex,
     ) -> TimelyData {
         TimelyData { version: VERSION, price, last_price_update, funding_index }
+    }
+
+    /// Reads the Option<TimelyData> from the storage.
+    /// The offset is used to read specific fields of the struct.
+    #[inline]
+    fn read(
+        entry: StoragePointer0Offset<Option<TimelyData>>, offset: OptionTimelyDataOffset,
+    ) -> felt252 {
+        storage_read_syscall(
+            0,
+            storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset.into()),
+        )
+            .unwrap_syscall()
+    }
+
+    /// Reads the Option<AssetConfig> from the storage.
+    /// The offset is used to read specific fields of the struct.
+    #[inline]
+    fn read_config(
+        entry: StoragePointer0Offset<Option<AssetConfig>>, offset: OptionAssetConfigOffset,
+    ) -> felt252 {
+        storage_read_syscall(
+            0,
+            storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset.into()),
+        )
+            .unwrap_syscall()
+    }
+
+    /// Reads the variant of the Option<TimelyData>.
+    /// The variant mark if the Option is Some or None.
+    #[inline]
+    fn read_variant(entry: StoragePointer0Offset<Option<TimelyData>>) -> felt252 {
+        Self::read(entry, OptionTimelyDataOffset::VARIANT)
+    }
+
+    /// Returns true if the Option is Some, false if None.
+    /// At the storage 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_some(entry: StoragePointer0Offset<Option<TimelyData>>) -> bool {
+        let variant = Self::read_variant(entry);
+        variant == 1
+    }
+
+    /// Returns true if the Option is None, false if Some.
+    /// At the storage 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_none(entry: StoragePointer0Offset<Option<TimelyData>>) -> bool {
+        let variant = Self::read_variant(entry);
+        variant == 0
+    }
+
+    /// Reads the price from the Option<TimelyData>.
+    /// This function does not check if the Option is Some or None.
+    fn at_price(entry: StoragePointer0Offset<Option<TimelyData>>) -> Price {
+        let price = Self::read(entry, OptionTimelyDataOffset::PRICE);
+        let price: u64 = price.try_into().unwrap();
+        price.into()
+    }
+
+    /// Reads the funding index from the Option<TimelyData>.
+    /// This function does not check if the Option is Some or None.
+    fn at_funding_index(entry: StoragePointer0Offset<Option<TimelyData>>) -> FundingIndex {
+        let funding_index = Self::read(entry, OptionTimelyDataOffset::FUNDING_INDEX);
+        let funding_index: i64 = funding_index.try_into().unwrap();
+        funding_index.into()
+    }
+
+    /// Returns true if the Option is Some, false if None.
+    /// At the storage, 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_some_config(entry: StoragePointer0Offset<Option<AssetConfig>>) -> bool {
+        let variant = Self::read_config(entry, OptionAssetConfigOffset::VARIANT);
+        variant == 1
+    }
+
+    /// Reads the asset type from the Option<AssetConfig>.
+    /// This function does not check if the Option is Some or None.
+    #[inline]
+    fn at_asset_type(entry: StoragePointer0Offset<Option<AssetConfig>>) -> AssetType {
+        let asset_type = Self::read_config(entry, OptionAssetConfigOffset::ASSET_TYPE);
+        asset_type.try_into().unwrap()
+    }
+
+    /// Gets the price from the Option<TimelyData>.
+    /// Returns None if the Option is None.
+    fn get_price(entry: StoragePointer0Offset<Option<TimelyData>>) -> Option<Price> {
+        if Self::is_none(entry) {
+            return Option::None;
+        }
+        Option::Some(Self::at_price(entry))
+    }
+
+    /// Gets the funding index from the Option<TimelyData>.
+    /// Returns None if the Option is None.
+    fn get_funding_index(entry: StoragePointer0Offset<Option<TimelyData>>) -> Option<FundingIndex> {
+        if Self::is_none(entry) {
+            return Option::None;
+        }
+        Option::Some(Self::at_funding_index(entry))
+    }
+
+    /// Gets the asset type from the Option<AssetConfig>.
+    /// Returns None if the Option is None.
+    fn get_asset_type(entry: StoragePointer0Offset<Option<AssetConfig>>) -> Option<AssetType> {
+        if Self::is_some_config(entry) {
+            Option::Some(Self::at_asset_type(entry))
+        } else {
+            Option::None
+        }
+    }
+
+    /// Reads the risk factor first tier boundary from the Option<AssetConfig>.
+    /// This function does not check if the Option is Some or None.
+    fn at_risk_factor_first_tier_boundary(
+        entry: StoragePointer0Offset<Option<AssetConfig>>,
+    ) -> u128 {
+        let value = Self::read_config(
+            entry, OptionAssetConfigOffset::RISK_FACTOR_FIRST_TIER_BOUNDARY,
+        );
+        let value: u128 = value.try_into().unwrap();
+        value
+    }
+
+    /// Reads the risk factor tier size from the Option<AssetConfig>.
+    /// This function does not check if the Option is Some or None.
+    fn at_risk_factor_tier_size(entry: StoragePointer0Offset<Option<AssetConfig>>) -> u128 {
+        let value = Self::read_config(entry, OptionAssetConfigOffset::RISK_FACTOR_TIER_SIZE);
+        let value: u128 = value.try_into().unwrap();
+        value
+    }
+}
+
+/// In the storage, the Option<TimelyData> is stored as a struct with the following layout:
+/// - variant: u8 (1 for Some, 0 for None)
+/// - version: u8
+/// - price: u64
+/// - last_price_update: u64
+/// - funding_index: i64
+/// The offsets are used to read specific fields of the struct.
+#[derive(Copy, Drop, Debug, PartialEq, Serde)]
+pub enum OptionTimelyDataOffset {
+    VARIANT,
+    VERSION,
+    PRICE,
+    LAST_PRICE_UPDATE,
+    FUNDING_INDEX,
+}
+
+
+/// Convert the enum to u8 for storage access.
+pub impl OptionTimelyDataOffsetIntoU8 of Into<OptionTimelyDataOffset, u8> {
+    fn into(self: OptionTimelyDataOffset) -> u8 {
+        match self {
+            OptionTimelyDataOffset::VARIANT => 0_u8,
+            OptionTimelyDataOffset::VERSION => 1_u8,
+            OptionTimelyDataOffset::PRICE => 2_u8,
+            OptionTimelyDataOffset::LAST_PRICE_UPDATE => 3_u8,
+            OptionTimelyDataOffset::FUNDING_INDEX => 4_u8,
+        }
+    }
+}
+
+#[derive(Copy, Drop, Debug, PartialEq, Serde)]
+pub enum OptionAssetConfigOffset {
+    VARIANT,
+    VERSION,
+    STATUS,
+    RISK_FACTOR_FIRST_TIER_BOUNDARY,
+    RISK_FACTOR_TIER_SIZE,
+    QUORUM,
+    RESOLUTION_FACTOR,
+    QUANTUM,
+    TOKEN_CONTRACT_VARIANT,
+    TOKEN_CONTRACT,
+    ASSET_TYPE,
+}
+
+pub impl OptionAssetConfigOffsetIntoU8 of Into<OptionAssetConfigOffset, u8> {
+    fn into(self: OptionAssetConfigOffset) -> u8 {
+        match self {
+            OptionAssetConfigOffset::VARIANT => 0_u8,
+            OptionAssetConfigOffset::VERSION => 1_u8,
+            OptionAssetConfigOffset::STATUS => 2_u8,
+            OptionAssetConfigOffset::RISK_FACTOR_FIRST_TIER_BOUNDARY => 3_u8,
+            OptionAssetConfigOffset::RISK_FACTOR_TIER_SIZE => 4_u8,
+            OptionAssetConfigOffset::QUORUM => 5_u8,
+            OptionAssetConfigOffset::RESOLUTION_FACTOR => 6_u8,
+            OptionAssetConfigOffset::QUANTUM => 7_u8,
+            OptionAssetConfigOffset::TOKEN_CONTRACT_VARIANT => 8_u8,
+            OptionAssetConfigOffset::TOKEN_CONTRACT => 9_u8,
+            OptionAssetConfigOffset::ASSET_TYPE => 10_u8,
+        }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
@@ -25,6 +25,13 @@ pub struct FundingIndex {
     pub value: i64,
 }
 
+pub impl I64IntoFundingIndex of Into<i64, FundingIndex> {
+    fn into(self: i64) -> FundingIndex {
+        FundingIndex { value: self }
+    }
+}
+
+
 pub trait FundingIndexMulTrait {
     /// Multiply the funding index with a balance.
     /// The funding is calculated as: funding = funding_index * balance / 2^32.

--- a/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
@@ -32,6 +32,13 @@ pub struct Price {
     value: u64,
 }
 
+pub impl U64IntoPrice of Into<u64, Price> {
+    fn into(self: u64) -> Price {
+        Price { value: self }
+    }
+}
+
+
 #[derive(Copy, Debug, Drop, Serde)]
 pub struct SignedPrice {
     pub signature: Signature,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce pointer-based/unsafe getters and combined reads to reduce storage access for prices, funding, and risk factors across assets and positions.
> 
> - **Core optimizations**
>   - Use storage pointers for `timely_data`/`asset_config` reads; add unsafe/direct accessors.
>   - New getters in `Assets`: `get_asset_price_unsafe`, `get_funding_index_unsafe`, `get_price_and_funding_index`.
>   - Refactor `get_asset_price`/`get_funding_index` to pointer-based `SyntheticTrait` reads.
>   - Rework `get_synthetic_risk_factor_for_value` to read tier params/config via direct storage; add `unchecked_access_risk_factor_tiers` for indexed tier access.
> - **Positions**
>   - Use `get_funding_index_unsafe` and `get_price_and_funding_index` to avoid redundant reads in funding/asset iteration.
> - **Types/traits**
>   - `synthetic.cairo`: add low-level storage read helpers and offsets enums; `TryInto<felt252, AssetType>`; derive Debug; document V1/V2 fields.
>   - `funding.cairo`: add `Into<i64, FundingIndex>`.
>   - `price.cairo`: add `Into<u64, Price>`.
> - **Misc**
>   - Import updates (`StorageAsPointer`, `IterableMapTrait`); allow colliding storage paths for `assets` storage in `core.cairo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b4d2604f7629716152aebc1caa1a4c4061eb3a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/120)
<!-- Reviewable:end -->
