### PR TITLE
Roee gross/change assert with byte array

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/external_components/external_component_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/external_components/external_component_manager.cairo
@@ -3,6 +3,7 @@ pub mod ExternalComponents {
     use RolesComponent::InternalTrait as RolesInternalTrait;
     use core::num::traits::Zero;
     use core::panic_with_felt252;
+    use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use starknet::ClassHash;
@@ -12,7 +13,6 @@ pub mod ExternalComponents {
     use starkware_utils::components::replaceability::ReplaceabilityComponent;
     use starkware_utils::components::replaceability::interface::IReplaceable;
     use starkware_utils::components::roles::RolesComponent;
-    use starkware_utils::errors::assert_with_byte_array;
     use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
     use crate::core::components::deleverage::deleverage_manager::IDeleverageManagerLibraryDispatcher;
     use crate::core::components::deposit::deposit_manager::IDepositExternalLibraryDispatcher;
@@ -172,14 +172,14 @@ pub mod ExternalComponents {
             let declared_type = ITypedComponentLibraryDispatcher { class_hash: class_hash }
                 .component_type();
 
-            assert_with_byte_array(
-                declared_type == component_type,
-                format!(
+            if (declared_type != component_type) {
+                let err = format!(
                     "Component type mismatch: declared {}, expected {}",
                     declared_type,
                     component_type,
-                ),
-            );
+                );
+                panic_with_byte_array(err: @err);
+            }
             if (component_type == EXTERNAL_COMPONENT_VAULT)
                 || (component_type == EXTERNAL_COMPONENT_WITHDRAWALS)
                 || (component_type == EXTERNAL_COMPONENT_DEPOSITS)
@@ -209,12 +209,15 @@ pub mod ExternalComponents {
             get_dep_component!(@self, Roles).only_upgrade_governor();
             let entry = self.registered_external_components.entry(component_type);
             let (registered_class_hash, activation_time) = entry.read();
-            assert_with_byte_array(
-                registered_class_hash == class_hash,
-                format!("{:?} not registered with hash {:?}", component_type, class_hash),
-            );
+            if (registered_class_hash != class_hash) {
+                let err = format!("{:?} not registered with hash {:?}", component_type, class_hash);
+                panic_with_byte_array(err: @err);
+            }
             let now = Time::now();
-            assert_with_byte_array(now >= activation_time, format!("Activation time not reached"));
+            if (now < activation_time) {
+                let err = format!("Activation time not reached");
+                panic_with_byte_array(err: @err);
+            }
             let impl_entry = self.external_component_implementations.entry(component_type);
             impl_entry.write(class_hash);
             self

--- a/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
@@ -1,9 +1,9 @@
 use core::num::traits::{Pow, Zero};
+use core::panics::panic_with_byte_array;
 use perpetuals::core::errors::invalid_funding_rate_err;
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::balance::{Balance, BalanceTrait};
 use perpetuals::core::types::price::{Price, PriceMulTrait};
-use starkware_utils::errors::assert_with_byte_array;
 use starkware_utils::math::utils::mul_wide_and_floor_div;
 
 pub const FUNDING_SCALE: i64 = 2_i64.pow(32);
@@ -123,11 +123,10 @@ pub fn validate_funding_rate(
     time_diff: u64,
     synthetic_price: Price,
 ) {
-    assert_with_byte_array(
-        condition: index_diff.into() <= synthetic_price.mul(rhs: max_funding_rate)
-            * time_diff.into(),
-        err: invalid_funding_rate_err(:synthetic_id),
-    );
+    if (index_diff.into() > synthetic_price.mul(rhs: max_funding_rate) * time_diff.into()) {
+        let err = invalid_funding_rate_err(:synthetic_id);
+        panic_with_byte_array(err: @err);
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/core/utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/utils.cairo
@@ -1,11 +1,11 @@
 use core::num::traits::Zero;
 use core::panic_with_felt252;
+use core::panics::panic_with_byte_array;
 use perpetuals::core::components::positions::Positions::FEE_POSITION;
 use perpetuals::core::errors::{
     CANT_TRADE_WITH_FEE_POSITION, DIFFERENT_BASE_ASSET_IDS, INVALID_QUOTE_FEE_AMOUNT,
     INVALID_ZERO_AMOUNT,
 };
-use starkware_utils::errors::assert_with_byte_array;
 use starkware_utils::hash::message_hash::OffchainMessageHash;
 use starkware_utils::math::abs::Abs;
 use starkware_utils::math::utils::have_same_sign;
@@ -94,7 +94,10 @@ pub fn validate_order<T, impl TValidateableOrder: ValidateableOrderTrait<T>, +Dr
 
     // Expiration check.
     let now = Time::now();
-    assert_with_byte_array(now <= order.expiration(), order_expired_err(order.position_id()));
+    if (now > order.expiration()) {
+        let err = order_expired_err(order.position_id());
+        panic_with_byte_array(err: @err);
+    }
 
     // Sign Validation for amounts.
     assert(!have_same_sign(order.quote_amount(), order.base_amount()), INVALID_AMOUNT_SIGN);

--- a/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
@@ -11,7 +11,6 @@ use perpetuals::core::types::position::{
 };
 use perpetuals::core::types::price::{Price, PriceMulTrait};
 use perpetuals::core::types::risk_factor::RiskFactorMulTrait;
-use starkware_utils::errors::assert_with_byte_array;
 use starkware_utils::math::abs::Abs;
 use starkware_utils::math::fraction::FractionTrait;
 
@@ -107,9 +106,10 @@ pub fn assert_healthy_or_healthier(position_id: PositionId, tvtr: TVTRChange) {
     let before_ratio = FractionTrait::new(tvtr.before.total_value, tvtr.before.total_risk);
     let after_ratio = FractionTrait::new(tvtr.after.total_value, tvtr.after.total_risk);
 
-    assert_with_byte_array(
-        after_ratio >= before_ratio, position_not_healthy_nor_healthier(:position_id, :tvtr),
-    );
+    if (after_ratio < before_ratio) {
+        let err = position_not_healthy_nor_healthier(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
 }
 
 pub fn liquidated_position_validations(
@@ -124,11 +124,12 @@ pub fn liquidated_position_validations(
     let position_state_before_change = get_position_state(position_tvtr: tvtr.before);
 
     // Validate that the position isn't healthy before the change.
-    assert_with_byte_array(
-        position_state_before_change == PositionState::Liquidatable
-            || position_state_before_change == PositionState::Deleveragable,
-        position_not_liquidatable(:position_id, :tvtr),
-    );
+    let condition = position_state_before_change == PositionState::Liquidatable
+        || position_state_before_change == PositionState::Deleveragable;
+    if (!condition) {
+        let err = position_not_liquidatable(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
     assert_healthy_or_healthier(:position_id, :tvtr);
 }
 
@@ -143,16 +144,16 @@ pub fn deleveraged_position_validations(
     );
     let position_state_before_change = get_position_state(position_tvtr: tvtr.before);
 
-    assert_with_byte_array(
-        position_state_before_change == PositionState::Deleveragable,
-        position_not_deleveragable(:position_id, :tvtr),
-    );
+    if (position_state_before_change != PositionState::Deleveragable) {
+        let err = position_not_deleveragable(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
 
     assert_healthy_or_healthier(:position_id, :tvtr);
-    assert_with_byte_array(
-        is_fair_deleverage(before: tvtr.before, after: tvtr.after),
-        position_not_fair_deleverage(:position_id, :tvtr),
-    );
+    if (!is_fair_deleverage(before: tvtr.before, after: tvtr.after)) {
+        let err = position_not_fair_deleverage(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
 }
 
 pub fn calculate_position_tvtr(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces uses of `assert_with_byte_array` with explicit conditionals that `panic_with_byte_array` across core contracts and types, keeping validation logic intact.
> 
> - **Error handling refactor**:
>   - Replace `assert_with_byte_array(...)` with explicit `if` checks that `panic_with_byte_array(...)` in:
>     - `core/components/external_components/external_component_manager.cairo`
>     - `core/components/fulfillment/fulfillment.cairo`
>     - `core/components/vaults/vaults_contract.cairo`
>     - `core/types/funding.cairo`
>     - `core/types/order.cairo`
>     - `core/utils.cairo`
>     - `core/value_risk_calculator.cairo`
>   - Add `use core::panics::panic_with_byte_array;` and remove `starkware_utils::errors::assert_with_byte_array` imports.
> - **Behavior**:
>   - Validation semantics remain the same (e.g., expiration checks, ratio checks, registration/activation guards, vault redeem fairness, funding-rate bounds).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f33d6fc08a7cef4c9ac7b5ab27f36e7063e98d54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/121)
<!-- Reviewable:end -->
