### PR TITLE
chore: bump scarb verion to 2.12.2

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -10,18 +10,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: "0.48.1"
+          starknet-foundry-version: "0.49.0"
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.1"
+          scarb-version: "2.12.2"
 
       - name: Install cairo-coverage
         run: |
           curl -L https://raw.githubusercontent.com/software-mansion/cairo-coverage/main/scripts/install.sh | sh
 
       - name: Run test and coverage
-        run: scarb test
+        run: scarb test -w --coverage
 
       - name: Check formatting
         run: scarb fmt -w --check
@@ -42,7 +42,7 @@ jobs:
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.1"
+          scarb-version: "2.12.2"
 
       - name: Build Contracts
         run: scarb build

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -4,7 +4,7 @@ version = 1
 [[package]]
 name = "openzeppelin"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 name = "openzeppelin_access"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_interfaces",
  "openzeppelin_introspection",
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 name = "openzeppelin_account"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_interfaces",
  "openzeppelin_introspection",
@@ -42,7 +42,7 @@ dependencies = [
 [[package]]
 name = "openzeppelin_finance"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_interfaces",
@@ -52,7 +52,7 @@ dependencies = [
 [[package]]
 name = "openzeppelin_governance"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
@@ -65,12 +65,12 @@ dependencies = [
 [[package]]
 name = "openzeppelin_interfaces"
 version = "2.1.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_introspection"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_interfaces",
 ]
@@ -78,12 +78,12 @@ dependencies = [
 [[package]]
 name = "openzeppelin_merkle_tree"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_presets"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
@@ -98,7 +98,7 @@ dependencies = [
 [[package]]
 name = "openzeppelin_security"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_interfaces",
 ]
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "openzeppelin_token"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
@@ -118,12 +118,12 @@ dependencies = [
 [[package]]
 name = "openzeppelin_upgrades"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 
 [[package]]
 name = "openzeppelin_utils"
 version = "3.0.0-alpha.2"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts#fc942069996633e13f11de0710c586b7d2ed8df7"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts?rev=0e51722f231c0913915945d3df89e43cbb5cfc38#0e51722f231c0913915945d3df89e43cbb5cfc38"
 dependencies = [
  "openzeppelin_interfaces",
 ]
@@ -141,15 +141,15 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:2dd27e8215eea8785b3930e9f452e11b429ca262b1c1fbb071bfc173b9ebc125"
+checksum = "sha256:903150f0e9542e4277d417029eea4c03af0db398b581f9f7ae3ebbdac9afc657"
 
 [[package]]
 name = "snforge_std"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:89f759fa685d48ed0ba7152d2ac2eb168da08dfa8b84b2bee96e203dc5b2413e"
+checksum = "sha256:73d73653cc4356ec51b92a6bec9d8385b20318170c2f2ade7891e5185a0e7e64"
 dependencies = [
  "snforge_scarb_plugin",
 ]
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils"
 version = "1.0.0"
-source = "git+https://github.com/ex10ded/starkware-starknet-utils?branch=main#6624068f0f58a112f11568815d7a85c634ef974b"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#b06c2994b22d00906943bab36c1faa2ce183def6"
 dependencies = [
  "openzeppelin",
 ]
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils_testing"
 version = "1.0.0"
-source = "git+https://github.com/ex10ded/starkware-starknet-utils?branch=main#6624068f0f58a112f11568815d7a85c634ef974b"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#b06c2994b22d00906943bab36c1faa2ce183def6"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -1,14 +1,13 @@
 [workspace]
 members = ["workspace/apps/perpetuals/contracts", "workspace/vault/"]
 
-# TODO(Mohammad): upgrade scarb, snforge, and oz versions.
 [workspace.dependencies]
-starknet = "2.12.1"
-assert_macros = "2.12.1"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", commit = "fc942069996633e13f11de0710c586b7d2ed8df7" }
-snforge_std = "0.48.1"
-starkware_utils = { git = "https://github.com/ex10ded/starkware-starknet-utils", branch = "main" }
-starkware_utils_testing = { git = "https://github.com/ex10ded/starkware-starknet-utils", branch = "main" }
+starknet = "2.12.2"
+assert_macros = "2.12.2"
+openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", rev = "0e51722f231c0913915945d3df89e43cbb5cfc38" }
+snforge_std = "0.49.0"
+starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
+starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
 
 [scripts]
 test = "snforge test --max-n-steps 10000000000"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps StarkNet toolchain and deps (scarb 2.12.2, snfoundry/snforge_std 0.49.0), pins OZ to a new rev, switches starkware utils repo/branch, and enables coverage in CI tests.
> 
> - **CI** (`.github/workflows/on-pull-request.yaml`):
>   - Update `starknet-foundry` to `0.49.0` and `scarb` to `2.12.2`.
>   - Run tests with coverage: `scarb test -w --coverage`.
> - **Dependencies** (`Scarb.toml` / `Scarb.lock`):
>   - Bump `starknet`/`assert_macros` to `2.12.2` and `snforge_std` to `0.49.0` (with `snforge_scarb_plugin 0.49.0`).
>   - Pin `openzeppelin` to rev `0e51722...` and update OZ subpackages to that source.
>   - Switch `starkware_utils` and `_testing` to `starkware-libs` repo on branch `oz-3.0.0-alpha.2`.
>   - Refresh lockfile checksums/sources accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22b71b9ad1e17bc52bd2715e62041fb59f234662. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/122)
<!-- Reviewable:end -->
