### PR TITLE
chore: fix warning

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -95,6 +95,7 @@ pub(crate) mod DeleverageManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -126,6 +126,7 @@ pub(crate) mod DepositManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub deposits: DepositComponent::Storage,

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -113,6 +113,7 @@ pub(crate) mod LiquidationManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -131,6 +131,7 @@ pub(crate) mod TransferManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -125,6 +125,7 @@ pub(crate) mod VaultsManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub deposits: DepositComponent::Storage,

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -127,6 +127,7 @@ pub(crate) mod WithdrawalManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add #[allow(starknet::colliding_storage_paths)] to `assets: AssetsComponent::Storage` across manager/vault contracts to fix compiler warning.
> 
> - **Contracts (storage)**:
>   - Allow colliding storage paths on `assets: AssetsComponent::Storage` by adding `#[allow(starknet::colliding_storage_paths)]` in:
>     - `core/components/deleverage/deleverage_manager.cairo`
>     - `core/components/deposit/deposit_manager.cairo`
>     - `core/components/liquidation/liquidation_manager.cairo`
>     - `core/components/transfer/transfer_manager.cairo`
>     - `core/components/vaults/vaults_contract.cairo`
>     - `core/components/withdrawal/withdrawal_manager.cairo`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3f1792d8e2829ff728a96c40fa15b7708438418. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/123)
<!-- Reviewable:end -->
