### PR TITLE
feat(perpetuals): add forced actions interface

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -422,7 +422,6 @@ pub mod Core {
                 );
         }
 
-
         fn liquidate(
             ref self: ContractState,
             operator_nonce: u64,
@@ -662,6 +661,85 @@ pub mod Core {
                 ._get_vault_manager_dispatcher()
                 .invest_in_vault(operator_nonce: operator_nonce, :signature, :order)
         }
+
+        // Forced actions.
+
+        /// Requests a forced withdrawal of a collateral amount from a position.
+        ///
+        /// Validations:
+        /// - Validates the forced request signature.
+        /// - Validates the position exists.
+        /// - Validates no pending forced withdraw request already exists for this position.
+        /// - Validates the caller is the position owner.
+        ///
+        /// Execution:
+        /// - Stores the forced withdrawal request hash in pending forced actions.
+        /// - transfer `ForcedFee` amount.
+        /// - Emits a `ForcedWithdrawRequest` event.
+        fn forced_withdraw_request(
+            ref self: ContractState,
+            signature: Signature,
+            recipient: ContractAddress,
+            position_id: PositionId,
+            amount: u64,
+            expiration: Timestamp,
+            salt: felt252,
+        ) {}
+
+        /// Executes a previously submitted forced withdrawal request for a position.
+        ///
+        /// Validations:
+        /// - Validates that a matching forced withdrawal request exists.
+        /// - Validates the request is not already completed.
+        /// - Validates the forced request timeout has passed.
+        /// - Validates after the withdrawal the position still healthy.
+        ///
+        /// Execution:
+        /// - Processes the forced withdrawal and releases the collateral to the recipient.
+        /// - Marks the forced request as completed and clears the pending entry.
+        /// - Emits a `ForcedWithdraw` event.
+        fn forced_withdraw(
+            ref self: ContractState,
+            recipient: ContractAddress,
+            position_id: PositionId,
+            amount: u64,
+            expiration: Timestamp,
+            salt: felt252,
+        ) {}
+
+        /// Requests a forced trade - it enables withdrawal of synthetic amount from a position.
+        ///
+        /// Validations:
+        /// - Validates the forced request signature.
+        /// - Validates the position exists.
+        /// - Validates no pending forced withdraw request already exists for this position.
+        /// - Validates the caller is the position owner.
+        ///
+        /// Execution:
+        /// - Stores the forced withdrawal request hash in pending forced actions.
+        /// - transfer `ForcedFee` amount.
+        /// - Emits a `ForcedTradeRequest` event.
+        fn forced_trade_request(
+            ref self: ContractState,
+            signature_a: Signature,
+            signature_b: Signature,
+            order_a: Order,
+            order_b: Order,
+        ) {}
+
+        /// Executes a previously submitted forced trade request for a position.
+        ///
+        /// Validations:
+        /// - Validates that a matching forced trade request exists.
+        /// - Validates the request is not already completed.
+        /// - Validates the forced request timeout has passed.
+        /// - Execute regular trade validations.
+        ///
+        /// Execution:
+        /// - Processes the forced trade.
+        /// - Marks the forced request as completed and clears the pending entry.
+        /// - Emits a `ForcedTrade` event.
+        fn forced_trade(ref self: ContractState, order_a: Order, order_b: Order) {}
     }
 
     #[generate_trait]

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -130,4 +130,29 @@ pub trait ICore<TContractState> {
         actual_shares_user: i64,
         actual_collateral_user: i64,
     );
+    fn forced_withdraw_request(
+        ref self: TContractState,
+        signature: Signature,
+        recipient: ContractAddress,
+        position_id: PositionId,
+        amount: u64,
+        expiration: Timestamp,
+        salt: felt252,
+    );
+    fn forced_withdraw(
+        ref self: TContractState,
+        recipient: ContractAddress,
+        position_id: PositionId,
+        amount: u64,
+        expiration: Timestamp,
+        salt: felt252,
+    );
+    fn forced_trade_request(
+        ref self: TContractState,
+        signature_a: Signature,
+        signature_b: Signature,
+        order_a: Order,
+        order_b: Order,
+    );
+    fn forced_trade(ref self: TContractState, order_a: Order, order_b: Order);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces forced actions endpoints (forced withdraw request/execute and forced trade request/execute) in `core.cairo` and exposes them in `interface.cairo`.
> 
> - **Core (`core.cairo`)**:
>   - Add forced actions functions with validations/docs (stubs): `forced_withdraw_request`, `forced_withdraw`, `forced_trade_request`, `forced_trade`.
> - **Interface (`interface.cairo`)**:
>   - Extend `ICore` with forced actions methods: `forced_withdraw_request`, `forced_withdraw`, `forced_trade_request`, `forced_trade`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8144a6e178ccd5f36cdea362975a1e57ee72e05a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/124)
<!-- Reviewable:end -->
