### PR TITLE
chore(perpetuals): remove unesed nonce arg

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -45,7 +45,6 @@ pub trait IWithdrawalManager<TContractState> {
     );
     fn withdraw(
         ref self: TContractState,
-        operator_nonce: u64,
         recipient: ContractAddress,
         position_id: PositionId,
         amount: u64,
@@ -203,7 +202,6 @@ pub(crate) mod WithdrawalManager {
 
         fn withdraw(
             ref self: ContractState,
-            operator_nonce: u64,
             recipient: starknet::ContractAddress,
             position_id: PositionId,
             amount: u64,

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -283,7 +283,7 @@ pub mod Core {
             self
                 .external_components
                 ._get_withdrawal_manager_dispatcher()
-                .withdraw(:operator_nonce, :recipient, :position_id, :amount, :expiration, :salt);
+                .withdraw(:recipient, :position_id, :amount, :expiration, :salt);
         }
 
         fn transfer_request(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Drops `operator_nonce` from `withdraw` in `withdrawal_manager` and updates `Core.withdraw` to stop passing it (nonce still validated in Core).
> 
> - **Withdrawals**:
>   - **Interface/Impl change**: Remove `operator_nonce` from `IWithdrawalManager::withdraw` and `WithdrawalManager::withdraw` in `core/components/withdrawal/withdrawal_manager.cairo`.
>   - **Core integration**: Update `Core.withdraw` dispatcher call in `core/core.cairo` to omit `operator_nonce` while retaining `self.operator_nonce.use_checked_nonce(:operator_nonce)` validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7c722f297df642fc60bebe659970101286382fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/127)
<!-- Reviewable:end -->
