### PR TITLE
chore: partial read for asset balances

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -29,6 +29,7 @@ pub mod Positions {
     use perpetuals::core::types::position::{
         AssetBalance, AssetEnrichedPositionDiff, POSITION_VERSION, Position, PositionData,
         PositionDiff, PositionDiffEnriched, PositionId, PositionMutableTrait, PositionTrait,
+        OptionAssetBalanceReadAccessTrait,
     };
     use perpetuals::core::types::set_owner_account::SetOwnerAccountArgs;
     use perpetuals::core::types::set_public_key::SetPublicKeyArgs;
@@ -50,7 +51,8 @@ pub mod Positions {
     use starkware_utils::math::utils::have_same_sign;
     use starkware_utils::signature::stark::{PublicKey, Signature};
     use starkware_utils::storage::iterable_map::{
-        IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
+        IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapTrait,
+        IterableMapWriteAccessImpl,
     };
     use starkware_utils::storage::utils::AddToStorage;
     use starkware_utils::time::time::{Timestamp, validate_expiration};
@@ -509,10 +511,10 @@ pub mod Positions {
             position: StoragePath<Position>,
             synthetic_id: AssetId,
         ) -> Balance {
-            if let Option::Some(synthetic) = position.asset_balances.read(synthetic_id) {
-                synthetic.balance
-            } else {
-                0_i64.into()
+            let entry = position.asset_balances.pointer(synthetic_id);
+            match OptionAssetBalanceReadAccessTrait::get_balance(:entry) {
+                Option::None => 0_i64.into(),
+                Option::Some(balance) => balance,
             }
         }
 

--- a/workspace/apps/perpetuals/contracts/src/core/types/position.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/position.cairo
@@ -3,12 +3,15 @@ use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::asset::synthetic::{AssetBalanceDiffEnriched, AssetBalanceInfo};
 use perpetuals::core::types::balance::{Balance, BalanceDiff};
 use perpetuals::core::types::funding::FundingIndex;
-use starknet::ContractAddress;
-use starknet::storage::{Mutable, StoragePath, StoragePointerReadAccess};
+use starknet::storage::{Mutable, StoragePath, StoragePointer0Offset, StoragePointerReadAccess};
+use starknet::storage_access::storage_address_from_base_and_offset;
+use starknet::syscalls::storage_read_syscall;
+use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils::signature::stark::PublicKey;
 use starkware_utils::storage::iterable_map::{
     IterableMap, IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
 };
+
 
 pub const POSITION_VERSION: u8 = 1;
 
@@ -146,5 +149,124 @@ pub impl PositionMutableImpl of PositionMutableTrait {
     }
     fn get_version(self: StoragePath<Mutable<Position>>) -> u8 {
         self.version.read()
+    }
+}
+
+#[generate_trait]
+pub impl OptionAssetBalanceReadAccessImpl of OptionAssetBalanceReadAccessTrait {
+    /// Reads the Option<AssetBalance> from the storage.
+    /// The offset is used to read specific fields of the struct.
+    #[inline]
+    fn read(
+        entry: StoragePointer0Offset<Option<AssetBalance>>, offset: OptionAssetBalanceOffset,
+    ) -> felt252 {
+        storage_read_syscall(
+            0,
+            storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset.into()),
+        )
+            .unwrap_syscall()
+    }
+
+    /// Reads the variant of the Option<AssetBalance>.
+    /// The variant mark if the Option is Some or None.
+    #[inline]
+    fn read_variant(entry: StoragePointer0Offset<Option<AssetBalance>>) -> felt252 {
+        Self::read(entry, OptionAssetBalanceOffset::VARIANT)
+    }
+
+    /// Returns true if the Option is Some, false if None.
+    /// At the storage 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_some(entry: StoragePointer0Offset<Option<AssetBalance>>) -> bool {
+        let variant = Self::read_variant(entry);
+        variant == 1
+    }
+
+    /// Returns true if the Option is None, false if Some.
+    /// At the storage 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_none(entry: StoragePointer0Offset<Option<AssetBalance>>) -> bool {
+        let variant = Self::read_variant(entry);
+        variant == 0
+    }
+
+    /// Reads the funding index from the Option<AssetBalance>.
+    /// This function does not check if the Option is Some or None.
+    fn at_funding_index(entry: StoragePointer0Offset<Option<AssetBalance>>) -> FundingIndex {
+        let funding_index = Self::read(entry, OptionAssetBalanceOffset::FUNDING_INDEX);
+        let funding_index: i64 = funding_index.try_into().unwrap();
+        funding_index.into()
+    }
+
+    /// Gets the funding index from the Option<AssetBalance>.
+    /// Returns None if the Option is None.
+    fn get_funding_index(
+        entry: StoragePointer0Offset<Option<AssetBalance>>,
+    ) -> Option<FundingIndex> {
+        if Self::is_none(entry) {
+            return Option::None;
+        }
+        Option::Some(Self::at_funding_index(entry))
+    }
+
+    /// Reads the balance from the Option<AssetBalance>.
+    /// This function does not check if the Option is Some or None.
+    fn at_balance(entry: StoragePointer0Offset<Option<AssetBalance>>) -> Balance {
+        let balance = Self::read(entry, OptionAssetBalanceOffset::BALANCE);
+        let balance: i64 = balance.try_into().unwrap();
+        balance.into()
+    }
+
+    /// Gets the balance from the Option<AssetBalance>.
+    /// Returns None if the Option is None.
+    fn get_balance(entry: StoragePointer0Offset<Option<AssetBalance>>) -> Option<Balance> {
+        if Self::is_none(entry) {
+            return Option::None;
+        }
+        Option::Some(Self::at_balance(entry))
+    }
+
+    /// Reads the version from the Option<AssetBalance>.
+    /// This function does not check if the Option is Some or None.
+    fn at_version(entry: StoragePointer0Offset<Option<AssetBalance>>) -> u8 {
+        let version = Self::read(entry, OptionAssetBalanceOffset::VERSION);
+        let version: u8 = version.try_into().unwrap();
+        version
+    }
+
+    /// Gets the version from the Option<AssetBalance>.
+    /// Returns None if the Option is None.
+    fn get_version(entry: StoragePointer0Offset<Option<AssetBalance>>) -> Option<u8> {
+        if Self::is_none(entry) {
+            return Option::None;
+        }
+        Option::Some(Self::at_version(entry))
+    }
+}
+
+/// In the storage, the Option<AssetBalance> is stored as a struct with the following layout:
+/// - variant: u8 (1 for Some, 0 for None)
+/// - version: u8
+/// - balance: i64
+/// - funding_index: i64
+/// The offsets are used to read specific fields of the struct.
+#[derive(Copy, Drop, Debug, PartialEq, Serde)]
+pub enum OptionAssetBalanceOffset {
+    VARIANT,
+    VERSION,
+    BALANCE,
+    FUNDING_INDEX,
+}
+
+
+/// Convert the enum to u8 for storage access.
+pub impl OptionAssetBalanceOffsetIntoU8 of Into<OptionAssetBalanceOffset, u8> {
+    fn into(self: OptionAssetBalanceOffset) -> u8 {
+        match self {
+            OptionAssetBalanceOffset::VARIANT => 0_u8,
+            OptionAssetBalanceOffset::VERSION => 1_u8,
+            OptionAssetBalanceOffset::BALANCE => 2_u8,
+            OptionAssetBalanceOffset::FUNDING_INDEX => 3_u8,
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce syscall-based partial read access for `Option<AssetBalance>` and switch `get_synthetic_balance` to use it for efficient balance retrieval.
> 
> - **Core types (`core/types/position.cairo`)**:
>   - Add `OptionAssetBalanceReadAccessTrait` with syscall-based partial reads (`read`, `is_some/is_none`, `get_balance`, `get_funding_index`, `get_version`).
>   - Define `OptionAssetBalanceOffset` enum with offset mapping for storage access.
>   - Import low-level storage utilities to support direct field reads.
> - **Positions component (`core/components/positions/positions.cairo`)**:
>   - Refactor `get_synthetic_balance` to use `OptionAssetBalanceReadAccessTrait::get_balance` on the iterable map entry pointer instead of reading the full `Option<AssetBalance>`.
>   - Update iterable map imports to include `IterableMapTrait`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef5365e702b3858e826ccd6c39d8fb2b80c82980. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/129)
<!-- Reviewable:end -->
