### PR TITLE
wip

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -1,5 +1,7 @@
 #[starknet::component]
 pub mod AssetsComponent {
+    use core::dict::{Felt252Dict, Felt252DictTrait};
+    use core::nullable::{FromNullableResult, match_nullable};
     use RolesComponent::InternalTrait as RolesInternalTrait;
     use core::cmp::min;
     use core::num::traits::{Pow, Zero};
@@ -629,10 +631,25 @@ pub mod AssetsComponent {
         /// Returns both the stored price and funding index directly without checking their
         /// existence.
         fn get_price_and_funding_index(
-            self: @ComponentState<TContractState>, asset_id: AssetId,
+            self: @ComponentState<TContractState>,
+            asset_id: AssetId,
+            ref price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>>,
         ) -> (Price, FundingIndex) {
-            let entry = self.timely_data.pointer(asset_id);
-            (SyntheticTrait::at_price(entry), SyntheticTrait::at_funding_index(entry))
+            let cached_price_and_funding = price_and_funding_cache.get(asset_id.into());
+
+            match match_nullable(cached_price_and_funding) {
+                FromNullableResult::Null => {
+                    let entry = self.timely_data.pointer(asset_id);
+                    let (price, funding): (Price, FundingIndex) = (
+                        SyntheticTrait::at_price(entry), SyntheticTrait::at_funding_index(entry),
+                    );
+                    price_and_funding_cache
+                        .insert(asset_id.into(), NullableTrait::new((price, funding)));
+                    (price, funding)
+                    // update cache
+                },
+                FromNullableResult::NotNull(value) => value.unbox(),
+            }
         }
 
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -29,7 +29,10 @@ pub trait IDeleverageManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod DeleverageManager {
-    use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use crate::core::types::funding::FundingIndex;
+use crate::core::types::price::Price;
+use core::dict::Felt252Dict;
+use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
@@ -196,6 +199,8 @@ pub(crate) mod DeleverageManager {
                     position: deleveraged_position,
                     position_diff: deleveraged_position_diff,
                 );
+                let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -203,6 +208,7 @@ pub(crate) mod DeleverageManager {
                     position: deleverager_position,
                     position_diff: deleverager_position_diff,
                     tvtr_before: Default::default(),
+                    ref price_and_funding_cache: price_and_funding_cache
                 );
 
             // Apply diffs
@@ -239,9 +245,11 @@ pub(crate) mod DeleverageManager {
             position: StoragePath<Position>,
             position_diff: PositionDiff,
         ) {
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             let (provisional_delta, unchanged_assets) = self
                 .positions
-                .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                .derive_funding_delta_and_unchanged_assets(:position, :position_diff, ref :price_and_funding_cache);
 
             let synthetic_enriched_position_diff = self
                 .positions

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -42,7 +42,10 @@ pub trait ILiquidationManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod LiquidationManager {
-    use core::num::traits::Zero;
+    use crate::core::types::funding::FundingIndex;
+use crate::core::types::price::Price;
+use core::dict::Felt252Dict;
+use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -270,6 +273,8 @@ pub(crate) mod LiquidationManager {
                     position: liquidated_position,
                     position_diff: liquidated_position_diff,
                 );
+                let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                Default::default();
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -277,6 +282,7 @@ pub(crate) mod LiquidationManager {
                     position: liquidator_position,
                     position_diff: liquidator_position_diff,
                     tvtr_before: Default::default(),
+                    ref :price_and_funding_cache,
                 );
 
             // Apply Diffs.
@@ -343,9 +349,11 @@ pub(crate) mod LiquidationManager {
                 ._validate_synthetic_shrinks(
                     :position, asset_id: synthetic_diff_id, amount: synthetic_diff_balance.into(),
                 );
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             let (provisional_delta, unchanged_assets) = self
                 .positions
-                .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                .derive_funding_delta_and_unchanged_assets(:position, :position_diff, ref :price_and_funding_cache);
             let synthetic_enriched_position_diff = self
                 .positions
                 .enrich_asset(:position, :position_diff);

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -1,5 +1,6 @@
 #[starknet::component]
 pub mod Positions {
+    use core::dict::{Felt252Dict};
     use core::nullable::{FromNullableResult, match_nullable};
     use core::num::traits::Zero;
     use core::panic_with_felt252;
@@ -21,11 +22,12 @@ pub mod Positions {
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::asset::synthetic::AssetBalanceInfo;
     use perpetuals::core::types::balance::Balance;
-    use perpetuals::core::types::funding::calculate_funding;
+    use perpetuals::core::types::funding::{FundingIndex, calculate_funding};
     use perpetuals::core::types::position::{
         AssetBalance, POSITION_VERSION, Position, PositionData, PositionDiff, PositionId,
         PositionMutableTrait, PositionTrait,
     };
+    use perpetuals::core::types::price::Price;
     use perpetuals::core::types::set_owner_account::SetOwnerAccountArgs;
     use perpetuals::core::types::set_public_key::SetPublicKeyArgs;
     use perpetuals::core::value_risk_calculator::{
@@ -97,9 +99,11 @@ pub mod Positions {
             self: @ComponentState<TContractState>, position_id: PositionId,
         ) -> PositionData {
             let position = self.get_position_snapshot(:position_id);
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             let (provisional_delta, assets) = self
                 .derive_funding_delta_and_unchanged_assets(
-                    :position, position_diff: Default::default(),
+                    :position, position_diff: Default::default(), ref :price_and_funding_cache
                 );
             let collateral_balance = self
                 .get_collateral_provisional_balance(
@@ -115,9 +119,11 @@ pub mod Positions {
             self: @ComponentState<TContractState>, position_id: PositionId,
         ) -> PositionTVTR {
             let position = self.get_position_snapshot(:position_id);
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             let (provisional_delta, unchanged_assets) = self
                 .derive_funding_delta_and_unchanged_assets(
-                    :position, position_diff: Default::default(),
+                    :position, position_diff: Default::default(), ref :price_and_funding_cache
                 );
             let collateral_balance = self
                 .get_collateral_provisional_balance(
@@ -553,6 +559,7 @@ pub mod Positions {
             self: @ComponentState<TContractState>,
             position: StoragePath<Position>,
             position_diff: PositionDiff,
+            ref price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>>,
         ) -> (Balance, Span<AssetBalanceInfo>) {
             let assets = get_dep_component!(self, Assets);
             let mut unchanged_assets = array![];
@@ -570,7 +577,9 @@ pub mod Positions {
                     continue;
                 }
                 let (price, funding_index) = assets
-                    .get_price_and_funding_index(asset_id: synthetic_id);
+                    .get_price_and_funding_index(
+                        asset_id: synthetic_id, ref :price_and_funding_cache,
+                    );
 
                 provisional_delta +=
                     calculate_funding(
@@ -620,12 +629,13 @@ pub mod Positions {
             position: StoragePath<Position>,
             position_diff: PositionDiff,
             tvtr_before: Nullable<PositionTVTR>,
+            ref price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>>,
         ) -> PositionTVTR {
             let asset_enriched_position_diff = self.enrich_asset(:position, :position_diff);
             let tvtr_before = match match_nullable(tvtr_before) {
                 FromNullableResult::Null => {
                     let (provisional_delta, unchanged_assets) = self
-                        .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                        .derive_funding_delta_and_unchanged_assets(:position, :position_diff, ref :price_and_funding_cache);
                     let position_diff_enriched = self
                         .enrich_collateral(
                             :position,
@@ -766,8 +776,10 @@ pub mod Positions {
             self: @ComponentState<TContractState>, position: StoragePath<Position>,
         ) -> PositionState {
             let position_diff = Default::default();
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             let (provisional_delta, unchanged_assets) = self
-                .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                .derive_funding_delta_and_unchanged_assets(:position, :position_diff, ref :price_and_funding_cache);
             let collateral_balance = self
                 .get_collateral_provisional_balance(
                     :position, provisional_delta: Option::Some(provisional_delta),

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -57,7 +57,10 @@ pub trait ITransferManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod TransferManager {
-    use core::num::traits::Zero;
+    use crate::core::types::funding::FundingIndex;
+use crate::core::types::price::Price;
+use core::dict::Felt252Dict;
+use core::num::traits::Zero;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
@@ -326,6 +329,8 @@ pub(crate) mod TransferManager {
 
             /// Validations - Fundamentals:
             let sender_position = self.positions.get_position_snapshot(:position_id);
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -333,6 +338,7 @@ pub(crate) mod TransferManager {
                     position: sender_position,
                     position_diff: position_diff_sender,
                     tvtr_before: Default::default(),
+                    ref : price_and_funding_cache,
                 );
 
             // Execute transfer

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -41,7 +41,10 @@ pub trait IVaultExternal<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod VaultsManager {
-    use core::num::traits::{WideMul, Zero};
+    use crate::core::types::funding::FundingIndex;
+use crate::core::types::price::Price;
+use core::dict::Felt252Dict;
+use core::num::traits::{WideMul, Zero};
     use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
@@ -268,6 +271,8 @@ pub(crate) mod VaultsManager {
             let sending_position_diff = PositionDiff {
                 collateral_diff: order.quote_amount.into(), asset_diff: Option::None,
             };
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
 
             self
                 .positions
@@ -276,6 +281,7 @@ pub(crate) mod VaultsManager {
                     position: sending_position_snapshot,
                     position_diff: sending_position_diff,
                     tvtr_before: Default::default(),
+                    ref price_and_funding_cache: price_and_funding_cache,
                 );
 
             self
@@ -556,6 +562,7 @@ pub(crate) mod VaultsManager {
             };
 
             // vault health checks
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> = Default::default();
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -563,6 +570,7 @@ pub(crate) mod VaultsManager {
                     position: vault_position,
                     position_diff: vault_position_diff,
                     tvtr_before: Default::default(),
+                    ref price_and_funding_cache: price_and_funding_cache,
                 );
 
             self
@@ -591,6 +599,7 @@ pub(crate) mod VaultsManager {
                     position: redeeming_position,
                     position_diff: redeeming_position_diff,
                     tvtr_before: Default::default(),
+                    ref price_and_funding_cache: price_and_funding_cache
                 );
 
             self

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -56,7 +56,10 @@ pub trait IWithdrawalManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod WithdrawalManager {
-    use core::num::traits::Zero;
+    use crate::core::types::funding::FundingIndex;
+use crate::core::types::price::Price;
+use core::dict::Felt252Dict;
+use core::num::traits::Zero;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc20::IERC20DispatcherTrait;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -226,11 +229,13 @@ pub(crate) mod WithdrawalManager {
             let position_diff = PositionDiff {
                 collateral_diff: -amount.into(), asset_diff: Option::None,
             };
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                    Default::default();
 
             self
                 .positions
                 .validate_healthy_or_healthier_position(
-                    :position_id, :position, :position_diff, tvtr_before: Default::default(),
+                    :position_id, :position, :position_diff, tvtr_before: Default::default(), ref :price_and_funding_cache,
                 );
 
             self.positions.apply_diff(:position_id, :position_diff);

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -20,9 +20,10 @@ pub mod Core {
     use perpetuals::core::interface::{ICore, Settlement};
     use perpetuals::core::types::asset::{AssetId, AssetStatus};
     use perpetuals::core::types::balance::Balance;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::order::{LimitOrder, Order};
     use perpetuals::core::types::position::{PositionDiff, PositionId, PositionTrait};
-    use perpetuals::core::types::price::PriceMulTrait;
+    use perpetuals::core::types::price::{Price, PriceMulTrait};
     use perpetuals::core::types::vault::ConvertPositionToVault;
     use perpetuals::core::value_risk_calculator::PositionTVTR;
     use starknet::ContractAddress;
@@ -340,6 +341,8 @@ pub mod Core {
             self.assets.validate_assets_integrity();
 
             let mut tvtr_cache: Felt252Dict<Nullable<PositionTVTR>> = Default::default();
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                Default::default();
 
             for _trade in trades {
                 let trade = *_trade;
@@ -360,6 +363,7 @@ pub mod Core {
                         actual_fee_b: trade.actual_fee_b,
                         tvtr_a_before: cached_pos_a_tvtr,
                         tvtr_b_before: cached_pos_b_tvtr,
+                        ref price_and_funding_cache: price_and_funding_cache,
                     );
                 tvtr_cache.insert(position_id_a, NullableTrait::new(updated_a));
                 tvtr_cache.insert(position_id_b, NullableTrait::new(updated_b));
@@ -406,7 +410,8 @@ pub mod Core {
             self.pausable.assert_not_paused();
             self.assets.validate_assets_integrity();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
-
+            let mut price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>> =
+                Default::default();
             self
                 ._execute_trade(
                     :signature_a,
@@ -419,6 +424,7 @@ pub mod Core {
                     :actual_fee_b,
                     tvtr_a_before: Default::default(),
                     tvtr_b_before: Default::default(),
+                    ref price_and_funding_cache: price_and_funding_cache,
                 );
         }
 
@@ -678,6 +684,7 @@ pub mod Core {
             actual_fee_b: u64,
             tvtr_a_before: Nullable<PositionTVTR>,
             tvtr_b_before: Nullable<PositionTVTR>,
+            ref price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>>,
         ) -> (PositionTVTR, PositionTVTR) {
             let synthetic_asset = self.assets.get_asset_config(order_a.base_asset_id);
             assert(synthetic_asset.asset_type == AssetType::SYNTHETIC, 'TRADE_ASSET_NOT_SYNTHETIC');
@@ -754,6 +761,7 @@ pub mod Core {
                     position: position_a,
                     position_diff: position_diff_a,
                     tvtr_before: tvtr_a_before,
+                    ref price_and_funding_cache: price_and_funding_cache,
                 );
             let tvtr_b_after = self
                 .positions
@@ -762,6 +770,7 @@ pub mod Core {
                     position: position_b,
                     position_diff: position_diff_b,
                     tvtr_before: tvtr_b_before,
+                    ref price_and_funding_cache: price_and_funding_cache,
                 );
 
             // Apply Diffs.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a shared Felt252Dict-backed cache for `(Price, FundingIndex)` and threads it through assets, positions, core, and manager flows to reduce repeated reads during TVTR/health calculations.
> 
> - **Performance/Architecture**:
>   - Add `price_and_funding_cache: Felt252Dict<Nullable<(Price, FundingIndex)>>` used to cache per-asset `(Price, FundingIndex)`.
>   - Update `AssetsComponent::get_price_and_funding_index` to read/write from the cache.
> - **Positions**:
>   - `derive_funding_delta_and_unchanged_assets`, `validate_healthy_or_healthier_position`, `_get_position_state`, `get_position_assets`, and `get_position_tv_tr` now accept/use the cache.
> - **Core & Managers**:
>   - Create and pass the cache in `core.trade`, `core.multi_trade`, and across `DeleverageManager`, `LiquidationManager`, `TransferManager`, `WithdrawalManager`, and `VaultsManager` when validating positions.
>   - No functional changes to validation logic; caching reduces redundant storage access.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d0266a68559839fccd7b6b4745dad6eaf9da404. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/130)
<!-- Reviewable:end -->
