### PR TITLE
refactor(perpetuals): use describe for core errors

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/fulfillment.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/fulfillment.cairo
@@ -4,14 +4,13 @@
 /// used to prevent replay attacks when contracts accept signatures as input.
 #[starknet::component]
 pub mod Fulfillement {
-    use core::panics::panic_with_byte_array;
     use perpetuals::core::components::fulfillment::interface::IFulfillment;
+    use perpetuals::core::errors::Error::FULFILLMENT_EXCEEDED;
     use starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starkware_utils::math::abs::Abs;
     use starkware_utils::signature::stark::HashType;
-    use crate::core::errors::fulfillment_exceeded_err;
 
     #[storage]
     pub struct Storage {
@@ -32,10 +31,9 @@ pub mod Fulfillement {
             let mut fulfillment_entry = self.fulfillment.entry(hash);
             let total_amount = fulfillment_entry.read() + actual_base_amount.abs();
 
-            if (total_amount > order_base_amount.abs()) {
-                let err = fulfillment_exceeded_err(:position_id);
-                panic_with_byte_array(err: @err);
-            }
+            assert!(
+                total_amount <= order_base_amount.abs(), "{}", FULFILLMENT_EXCEEDED(position_id),
+            );
             fulfillment_entry.write(total_amount);
         }
     }

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -48,7 +48,10 @@ pub(crate) mod LiquidationManager {
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
+    use perpetuals::core::components::assets::errors::SYNTHETIC_NOT_EXISTS;
     use perpetuals::core::components::assets::interface::IAssets;
+    use perpetuals::core::components::external_components::interface::EXTERNAL_COMPONENT_LIQUIDATIONS;
+    use perpetuals::core::components::external_components::named_component::ITypedComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::fulfillment::interface::IFulfillment;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
@@ -58,7 +61,10 @@ pub(crate) mod LiquidationManager {
         FEE_POSITION, INSURANCE_FUND_POSITION, InternalTrait as PositionsInternal,
     };
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
-    use perpetuals::core::types::position::{PositionId, PositionTrait};
+    use perpetuals::core::errors::Error::CANT_LIQUIDATE_IF_POSITION;
+    use perpetuals::core::types::position::{Position, PositionDiff, PositionId, PositionTrait};
+    use perpetuals::core::utils::{validate_signature, validate_trade};
+    use perpetuals::core::value_risk_calculator::liquidated_position_validations;
     use starknet::storage::StoragePath;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
@@ -68,13 +74,6 @@ pub(crate) mod LiquidationManager {
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
     use starkware_utils::time::time::Time;
-    use crate::core::components::assets::errors::SYNTHETIC_NOT_EXISTS;
-    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_LIQUIDATIONS;
-    use crate::core::components::external_components::named_component::ITypedComponent;
-    use crate::core::errors::CANT_LIQUIDATE_IF_POSITION;
-    use crate::core::types::position::{Position, PositionDiff};
-    use crate::core::utils::{validate_signature, validate_trade};
-    use crate::core::value_risk_calculator::liquidated_position_validations;
     use super::{ILiquidationManager, Liquidate, Order};
 
 
@@ -184,9 +183,13 @@ pub(crate) mod LiquidationManager {
             actual_liquidator_fee: u64,
             liquidated_fee_amount: u64,
         ) {
-            assert(liquidated_position_id != INSURANCE_FUND_POSITION, CANT_LIQUIDATE_IF_POSITION);
+            assert!(
+                liquidated_position_id != INSURANCE_FUND_POSITION, "{}", CANT_LIQUIDATE_IF_POSITION,
+            );
             let liquidator_position_id = liquidator_order.position_id;
-            assert(liquidator_position_id != INSURANCE_FUND_POSITION, CANT_LIQUIDATE_IF_POSITION);
+            assert!(
+                liquidator_position_id != INSURANCE_FUND_POSITION, "{}", CANT_LIQUIDATE_IF_POSITION,
+            );
 
             let collateral_id = self.assets.get_collateral_id();
             let liquidated_order = Order {

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -84,7 +84,7 @@ pub(crate) mod TransferManager {
     use crate::core::components::external_components::named_component::ITypedComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
-    use crate::core::errors::{INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED};
+    use crate::core::errors::Error::{INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT};
     use crate::core::types::asset::synthetic::AssetType;
     use crate::core::types::position::PositionDiff;
     use crate::core::types::transfer::TransferArgs;
@@ -207,7 +207,7 @@ pub(crate) mod TransferManager {
 
             self.positions.get_position_snapshot(position_id: recipient);
             let position = self.positions.get_position_snapshot(:position_id);
-            assert(amount.is_non_zero(), INVALID_ZERO_AMOUNT);
+            assert!(amount.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
             let owner_account = if (position.owner_protection_enabled.read()) {
                 position.get_owner_account()
             } else {
@@ -262,8 +262,8 @@ pub(crate) mod TransferManager {
             expiration: Timestamp,
             salt: felt252,
         ) {
-            validate_expiration(:expiration, err: SIGNED_TX_EXPIRED);
-            assert(recipient != position_id, INVALID_SAME_POSITIONS);
+            validate_expiration(:expiration, err: 'SIGNED_TX_EXPIRED');
+            assert!(recipient != position_id, "{}", INVALID_SAME_POSITIONS);
             let position = self.positions.get_position_snapshot(:position_id);
             let hash = self
                 .request_approvals

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -42,7 +42,6 @@ pub trait IVaultExternal<TContractState> {
 #[starknet::contract]
 pub(crate) mod VaultsManager {
     use core::num::traits::{WideMul, Zero};
-    use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
@@ -77,7 +76,7 @@ pub(crate) mod VaultsManager {
     use crate::core::components::vaults::events;
     use crate::core::components::vaults::vaults::Vaults::InternalTrait as VaultsInternal;
     use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
-    use crate::core::errors::order_expired_err;
+    use crate::core::errors::Error::ORDER_EXPIRED;
     use crate::core::types::order::ValidateableOrderTrait;
     use crate::core::types::position::PositionDiff;
     use crate::core::utils::{validate_signature, validate_trade};
@@ -197,10 +196,7 @@ pub(crate) mod VaultsManager {
             assert(order.quote_amount < 0, 'INVALID_POSITIVE_QUOTE_AMOUNT');
             // Expiration check.
             let now = Time::now();
-            if (now > order.expiration) {
-                let err = order_expired_err(from_position_id);
-                panic_with_byte_array(err: @err);
-            }
+            assert!(now <= order.expiration, "{}", ORDER_EXPIRED(from_position_id));
             assert(order.quote_asset_id == self.assets.get_collateral_id(), 'INVALID_QUOTE_ASSET');
 
             let receiving_position_id = order.receive_position;
@@ -416,15 +412,17 @@ pub(crate) mod VaultsManager {
             let redeeming_position_id = order.source_position;
             let receiving_position_id = order.receive_position;
 
-            if (actual_shares_user >= 0) {
-                let err = format!("INVALID_ACTUAL_SHARES_AMOUNT: {}", actual_shares_user);
-                panic_with_byte_array(err: @err);
-            }
+            assert!(
+                actual_shares_user < 0,
+                "{}",
+                format!("INVALID_ACTUAL_SHARES_AMOUNT: {}", actual_shares_user),
+            );
 
-            if (actual_collateral_user < 0) {
-                let err = format!("INVALID_ACTUAL_COLLATERAL_AMOUNT: {}", actual_collateral_user);
-                panic_with_byte_array(err: @err);
-            }
+            assert!(
+                actual_collateral_user >= 0,
+                "{}",
+                format!("INVALID_ACTUAL_COLLATERAL_AMOUNT: {}", actual_collateral_user),
+            );
 
             validate_trade(
                 order_a: order,
@@ -523,12 +521,11 @@ pub(crate) mod VaultsManager {
                     value_of_shares: value_to_receive.abs().into(),
                 );
 
-            if (burn_result != value_to_receive.abs().into()) {
-                let err = format!(
-                    "UNFAIR_REDEEM: expected {:?}, got {:?}", value_to_receive, burn_result,
-                );
-                panic_with_byte_array(err: @err);
-            }
+            assert!(
+                burn_result == value_to_receive.abs().into(),
+                "{}",
+                format!("UNFAIR_REDEEM: expected {:?}, got {:?}", value_to_receive, burn_result),
+            );
 
             let vault_position_diff = PositionDiff {
                 collateral_diff: -value_to_receive.into(), asset_diff: None,

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -15,7 +15,7 @@ pub mod Core {
     use perpetuals::core::components::positions::Positions::{
         FEE_POSITION, InternalTrait as PositionsInternalTrait,
     };
-    use perpetuals::core::errors::{AMOUNT_OVERFLOW, SYNTHETIC_IS_ACTIVE};
+    use perpetuals::core::errors::Error::{AMOUNT_OVERFLOW, SYNTHETIC_IS_ACTIVE};
     use perpetuals::core::events;
     use perpetuals::core::interface::{ICore, Settlement};
     use perpetuals::core::types::asset::{AssetId, AssetStatus};
@@ -35,6 +35,7 @@ pub mod Core {
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
     use starkware_utils::components::roles::RolesComponent::InternalTrait as RolesInternal;
+    use starkware_utils::errors::OptionAuxTrait;
     use starkware_utils::signature::stark::{PublicKey, Signature};
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
@@ -531,7 +532,7 @@ pub mod Core {
             // Validate base asset is inactive synthetic.
             if let Option::Some(config) = self.assets.asset_config.read(base_asset_id) {
                 assert(config.asset_type == AssetType::SYNTHETIC, NOT_SYNTHETIC);
-                assert(config.status == AssetStatus::INACTIVE, SYNTHETIC_IS_ACTIVE);
+                assert!(config.status == AssetStatus::INACTIVE, "{}", SYNTHETIC_IS_ACTIVE);
             } else {
                 panic_with_felt252(ASSET_NOT_EXISTS);
             }
@@ -542,7 +543,7 @@ pub mod Core {
                     .get_asset_price(asset_id: base_asset_id)
                     .mul(rhs: base_balance)
                     .try_into()
-                    .expect(AMOUNT_OVERFLOW);
+                    .expect_with_err(AMOUNT_OVERFLOW);
             self
                 .positions
                 ._validate_imposed_reduction_trade(

--- a/workspace/apps/perpetuals/contracts/src/core/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/errors.cairo
@@ -1,85 +1,114 @@
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::position::PositionId;
 use perpetuals::core::value_risk_calculator::TVTRChange;
-
-pub const AMOUNT_OVERFLOW: felt252 = 'AMOUNT_OVERFLOW';
-pub const ASSET_ID_NOT_COLLATERAL: felt252 = 'QUOTE_ASSET_ID_NOT_COLLATERAL';
-pub const CANT_TRADE_WITH_FEE_POSITION: felt252 = 'CANT_TRADE_WITH_FEE_POSITION';
-pub const CANT_LIQUIDATE_IF_POSITION: felt252 = 'CANT_LIQUIDATE_IF_POSITION';
-pub const DIFFERENT_BASE_ASSET_IDS: felt252 = 'DIFFERENT_BASE_ASSET_IDS';
-pub const INVALID_ACTUAL_BASE_SIGN: felt252 = 'INVALID_ACTUAL_BASE_SIGN';
-pub const INVALID_ACTUAL_QUOTE_SIGN: felt252 = 'INVALID_ACTUAL_QUOTE_SIGN';
-pub const INVALID_AMOUNT_SIGN: felt252 = 'INVALID_AMOUNT_SIGN';
-pub const INVALID_BASE_CHANGE: felt252 = 'INVALID_BASE_CHANGE';
-pub const INVALID_QUOTE_AMOUNT_SIGN: felt252 = 'INVALID_QUOTE_AMOUNT_SIGN';
-pub const INVALID_QUOTE_FEE_AMOUNT: felt252 = 'INVALID_QUOTE_FEE_AMOUNT';
-pub const INVALID_SAME_POSITIONS: felt252 = 'INVALID_SAME_POSITIONS';
-pub const INVALID_ZERO_AMOUNT: felt252 = 'INVALID_ZERO_AMOUNT';
-pub const SIGNED_TX_EXPIRED: felt252 = 'SIGNED_TX_EXPIRED';
-pub const SYNTHETIC_IS_ACTIVE: felt252 = 'SYNTHETIC_IS_ACTIVE';
-pub const TRANSFER_FAILED: felt252 = 'TRANSFER_FAILED';
-pub const SAME_BASE_QUOTE_ASSET_IDS: felt252 = 'SAME_BASE_QUOTE_ASSET_IDS';
-
-pub fn fulfillment_exceeded_err(position_id: PositionId) -> ByteArray {
-    format!("FULFILLMENT_EXCEEDED position_id: {:?}", position_id)
+use starkware_utils::errors::{Describable, ErrorDisplay};
+#[derive(Drop)]
+pub enum Error {
+    // Simple error constants
+    AMOUNT_OVERFLOW,
+    ASSET_ID_NOT_COLLATERAL,
+    CANT_TRADE_WITH_FEE_POSITION,
+    CANT_LIQUIDATE_IF_POSITION,
+    DIFFERENT_BASE_ASSET_IDS,
+    INVALID_ACTUAL_BASE_SIGN,
+    INVALID_ACTUAL_QUOTE_SIGN,
+    INVALID_AMOUNT_SIGN,
+    INVALID_BASE_CHANGE,
+    INVALID_QUOTE_AMOUNT_SIGN,
+    INVALID_QUOTE_FEE_AMOUNT,
+    INVALID_SAME_POSITIONS,
+    INVALID_ZERO_AMOUNT,
+    SYNTHETIC_IS_ACTIVE,
+    TRANSFER_FAILED,
+    SAME_BASE_QUOTE_ASSET_IDS,
+    // Error functions with parameters
+    FULFILLMENT_EXCEEDED: PositionId,
+    ILLEGAL_BASE_TO_QUOTE_RATIO: PositionId,
+    ILLEGAL_FEE_TO_QUOTE_RATIO: PositionId,
+    INVALID_FUNDING_RATE: AssetId,
+    ORDER_EXPIRED: PositionId,
+    POSITION_NOT_DELEVERAGABLE: (PositionId, TVTRChange),
+    POSITION_NOT_FAIR_DELEVERAGE: (PositionId, TVTRChange),
+    POSITION_NOT_HEALTHY_NOR_HEALTHIER: (PositionId, TVTRChange),
+    POSITION_NOT_LIQUIDATABLE: (PositionId, TVTRChange),
 }
 
-pub fn illegal_base_to_quote_ratio_err(position_id: PositionId) -> ByteArray {
-    format!("ILLEGAL_BASE_TO_QUOTE_RATIO position_id: {:?}", position_id)
-}
-
-pub fn illegal_fee_to_quote_ratio_err(position_id: PositionId) -> ByteArray {
-    format!("ILLEGAL_FEE_TO_QUOTE_RATIO position_id: {:?}", position_id)
-}
-
-pub fn invalid_funding_rate_err(synthetic_id: AssetId) -> ByteArray {
-    format!("INVALID_FUNDING_RATE synthetic_id: {:?}", synthetic_id)
-}
-
-pub fn order_expired_err(position_id: PositionId) -> ByteArray {
-    format!("ORDER_EXPIRED position_id: {:?}", position_id)
-}
-
-pub fn position_not_deleveragable(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
-    format!(
-        "POSITION_IS_NOT_DELEVERAGABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-        position_id,
-        tvtr.before.total_value,
-        tvtr.before.total_risk,
-        tvtr.after.total_value,
-        tvtr.after.total_risk,
-    )
-}
-
-pub fn position_not_fair_deleverage(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
-    format!(
-        "POSITION_IS_NOT_FAIR_DELEVERAGE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-        position_id,
-        tvtr.before.total_value,
-        tvtr.before.total_risk,
-        tvtr.after.total_value,
-        tvtr.after.total_risk,
-    )
-}
-
-pub fn position_not_healthy_nor_healthier(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
-    format!(
-        "POSITION_NOT_HEALTHY_NOR_HEALTHIER position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-        position_id,
-        tvtr.before.total_value,
-        tvtr.before.total_risk,
-        tvtr.after.total_value,
-        tvtr.after.total_risk,
-    )
-}
-
-pub fn position_not_liquidatable(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
-    format!(
-        "POSITION_IS_NOT_LIQUIDATABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-        position_id,
-        tvtr.before.total_value,
-        tvtr.before.total_risk,
-        tvtr.after.total_value,
-        tvtr.after.total_risk,
-    )
+impl DescribableError of Describable<Error> {
+    fn describe(self: @Error) -> ByteArray {
+        match self {
+            // Simple error constants
+            Error::AMOUNT_OVERFLOW => "AMOUNT_OVERFLOW",
+            Error::ASSET_ID_NOT_COLLATERAL => "QUOTE_ASSET_ID_NOT_COLLATERAL",
+            Error::CANT_TRADE_WITH_FEE_POSITION => "CANT_TRADE_WITH_FEE_POSITION",
+            Error::CANT_LIQUIDATE_IF_POSITION => "CANT_LIQUIDATE_IF_POSITION",
+            Error::DIFFERENT_BASE_ASSET_IDS => "DIFFERENT_BASE_ASSET_IDS",
+            Error::INVALID_ACTUAL_BASE_SIGN => "INVALID_ACTUAL_BASE_SIGN",
+            Error::INVALID_ACTUAL_QUOTE_SIGN => "INVALID_ACTUAL_QUOTE_SIGN",
+            Error::INVALID_AMOUNT_SIGN => "INVALID_AMOUNT_SIGN",
+            Error::INVALID_BASE_CHANGE => "INVALID_BASE_CHANGE",
+            Error::INVALID_QUOTE_AMOUNT_SIGN => "INVALID_QUOTE_AMOUNT_SIGN",
+            Error::INVALID_QUOTE_FEE_AMOUNT => "INVALID_QUOTE_FEE_AMOUNT",
+            Error::INVALID_SAME_POSITIONS => "INVALID_SAME_POSITIONS",
+            Error::INVALID_ZERO_AMOUNT => "INVALID_ZERO_AMOUNT",
+            Error::SYNTHETIC_IS_ACTIVE => "SYNTHETIC_IS_ACTIVE",
+            Error::TRANSFER_FAILED => "TRANSFER_FAILED",
+            Error::SAME_BASE_QUOTE_ASSET_IDS => "SAME_BASE_QUOTE_ASSET_IDS",
+            // Error functions with parameters
+            Error::FULFILLMENT_EXCEEDED(position_id) => format!(
+                "FULFILLMENT_EXCEEDED position_id: {:?}", *position_id,
+            ),
+            Error::ILLEGAL_BASE_TO_QUOTE_RATIO(position_id) => format!(
+                "ILLEGAL_BASE_TO_QUOTE_RATIO position_id: {:?}", *position_id,
+            ),
+            Error::ILLEGAL_FEE_TO_QUOTE_RATIO(position_id) => format!(
+                "ILLEGAL_FEE_TO_QUOTE_RATIO position_id: {:?}", *position_id,
+            ),
+            Error::INVALID_FUNDING_RATE(synthetic_id) => format!(
+                "INVALID_FUNDING_RATE synthetic_id: {:?}", *synthetic_id,
+            ),
+            Error::ORDER_EXPIRED(position_id) => format!(
+                "ORDER_EXPIRED position_id: {:?}", *position_id,
+            ),
+            Error::POSITION_NOT_DELEVERAGABLE((
+                position_id, tvtr,
+            )) => format!(
+                "POSITION_IS_NOT_DELEVERAGABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+                *position_id,
+                *tvtr.before.total_value,
+                *tvtr.before.total_risk,
+                *tvtr.after.total_value,
+                *tvtr.after.total_risk,
+            ),
+            Error::POSITION_NOT_FAIR_DELEVERAGE((
+                position_id, tvtr,
+            )) => format!(
+                "POSITION_IS_NOT_FAIR_DELEVERAGE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+                *position_id,
+                *tvtr.before.total_value,
+                *tvtr.before.total_risk,
+                *tvtr.after.total_value,
+                *tvtr.after.total_risk,
+            ),
+            Error::POSITION_NOT_HEALTHY_NOR_HEALTHIER((
+                position_id, tvtr,
+            )) => format!(
+                "POSITION_NOT_HEALTHY_NOR_HEALTHIER position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+                *position_id,
+                *tvtr.before.total_value,
+                *tvtr.before.total_risk,
+                *tvtr.after.total_value,
+                *tvtr.after.total_risk,
+            ),
+            Error::POSITION_NOT_LIQUIDATABLE((
+                position_id, tvtr,
+            )) => format!(
+                "POSITION_IS_NOT_LIQUIDATABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+                *position_id,
+                *tvtr.before.total_value,
+                *tvtr.before.total_risk,
+                *tvtr.after.total_value,
+                *tvtr.after.total_risk,
+            ),
+        }
+    }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
@@ -1,6 +1,5 @@
 use core::num::traits::{Pow, Zero};
-use core::panics::panic_with_byte_array;
-use perpetuals::core::errors::invalid_funding_rate_err;
+use perpetuals::core::errors::Error::INVALID_FUNDING_RATE;
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::balance::{Balance, BalanceTrait};
 use perpetuals::core::types::price::{Price, PriceMulTrait};
@@ -123,10 +122,11 @@ pub fn validate_funding_rate(
     time_diff: u64,
     synthetic_price: Price,
 ) {
-    if (index_diff.into() > synthetic_price.mul(rhs: max_funding_rate) * time_diff.into()) {
-        let err = invalid_funding_rate_err(:synthetic_id);
-        panic_with_byte_array(err: @err);
-    }
+    assert!(
+        index_diff.into() <= synthetic_price.mul(rhs: max_funding_rate) * time_diff.into(),
+        "{}",
+        INVALID_FUNDING_RATE(synthetic_id),
+    );
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
@@ -1,8 +1,7 @@
 use core::hash::{HashStateExTrait, HashStateTrait};
-use core::panics::panic_with_byte_array;
 use core::poseidon::PoseidonTrait;
 use openzeppelin::utils::snip12::StructHash;
-use perpetuals::core::errors::{illegal_base_to_quote_ratio_err, illegal_fee_to_quote_ratio_err};
+use perpetuals::core::errors::Error::{ILLEGAL_BASE_TO_QUOTE_RATIO, ILLEGAL_FEE_TO_QUOTE_RATIO};
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::position::PositionId;
 use starkware_utils::math::abs::Abs;
@@ -43,10 +42,11 @@ pub trait ValidateableOrderTrait<T> {
         let actual_base_to_quote_ratio = FractionTrait::new(
             numerator: actual_amount_base.into(), denominator: actual_amount_quote.abs().into(),
         );
-        if (order_base_to_quote_ratio > actual_base_to_quote_ratio) {
-            let err = illegal_base_to_quote_ratio_err(position);
-            panic_with_byte_array(err: @err);
-        }
+        assert!(
+            order_base_to_quote_ratio <= actual_base_to_quote_ratio,
+            "{}",
+            ILLEGAL_BASE_TO_QUOTE_RATIO(position),
+        );
 
         // Validating the fee-to-quote ratio enables increasing in both the user's quote and the
         // operator's fee.
@@ -57,10 +57,11 @@ pub trait ValidateableOrderTrait<T> {
             numerator: (order_fee_amount).into(), denominator: (order_quote_amount).abs().into(),
         );
 
-        if (actual_fee_to_quote_ratio > order_fee_to_quote_ratio) {
-            let err = illegal_fee_to_quote_ratio_err(position);
-            panic_with_byte_array(err: @err);
-        }
+        assert!(
+            actual_fee_to_quote_ratio <= order_fee_to_quote_ratio,
+            "{}",
+            ILLEGAL_FEE_TO_QUOTE_RATIO(position),
+        );
     }
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -136,7 +136,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position() {
 
 #[test]
 #[should_panic(expected: "ILLEGAL_BASE_TO_QUOTE_RATIO position_id: PositionId { value: 555 }")]
-fn test_redeem_from_protocol_vault_unfair__user_redeem() {
+fn test_redeem_from_protocol_vault_unfair_user_redeem() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
@@ -186,7 +186,7 @@ fn test_redeem_from_protocol_vault_unfair__user_redeem() {
 
 #[test]
 #[should_panic(expected: "ILLEGAL_BASE_TO_QUOTE_RATIO position_id: PositionId { value: 333 }")]
-fn test_redeem_from_protocol_vault_unfair__vault_redeem() {
+fn test_redeem_from_protocol_vault_unfair_vault_redeem() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let vault_user = state.new_user_with_position_id(333_u32.into());
     let redeeming_user = state.new_user_with_position_id(555_u32.into());

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -2143,7 +2143,7 @@ fn test_late_funding() {
 }
 
 #[test]
-#[should_panic(expected: 'INVALID_BASE_CHANGE')]
+#[should_panic(expected: "INVALID_BASE_CHANGE")]
 fn test_liquidate_change_sign() {
     // Setup.
     let risk_factor_data = RiskFactorTiers {

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -14,7 +14,6 @@ use perpetuals::core::components::positions::interface::{
     IPositions, IPositionsDispatcher, IPositionsDispatcherTrait,
 };
 use perpetuals::core::components::snip::SNIP12MetadataImpl;
-use perpetuals::core::errors::SIGNED_TX_EXPIRED;
 use perpetuals::core::interface::{ICore, ICoreSafeDispatcher, ICoreSafeDispatcherTrait};
 use perpetuals::core::types::asset::AssetStatus;
 use perpetuals::core::types::funding::{FUNDING_SCALE, FundingIndex, FundingTick};
@@ -218,7 +217,7 @@ fn test_expiration_validation() {
             expiration: withdraw_args.expiration,
             salt: withdraw_args.salt,
         );
-    assert_panic_with_felt_error(:result, expected_error: SIGNED_TX_EXPIRED);
+    assert_panic_with_felt_error(:result, expected_error: 'SIGNED_TX_EXPIRED');
 }
 
 #[test]
@@ -2337,7 +2336,7 @@ fn test_successful_trade() {
 }
 
 #[test]
-#[should_panic(expected: 'INVALID_AMOUNT_SIGN')]
+#[should_panic(expected: "INVALID_AMOUNT_SIGN")]
 fn test_invalid_trade_same_base_signs() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();
@@ -3049,7 +3048,7 @@ fn test_successful_transfer() {
 }
 
 #[test]
-#[should_panic(expected: 'INVALID_ZERO_AMOUNT')]
+#[should_panic(expected: "INVALID_ZERO_AMOUNT")]
 fn test_invalid_transfer_request_amount_is_zero() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces string/byte-array panics with a unified typed `Error` enum and `assert!`-based checks across core components, updating imports and tests to standardized error messages.
> 
> - **Errors**:
>   - Introduce typed `Error` enum with `Describable` impl and parameterized variants; remove string constants/helpers.
>   - Standardize failures to `assert!(..., "{}", Error::...)` across codebase.
> - **Core Components Updated**:
>   - `fulfillment`, `liquidation_manager`, `positions`, `transfer_manager`, `withdrawal_manager`, `vaults_contract`, `core` (inactive asset reduction, error propagation), `utils`, `order`, `funding`, `value_risk_calculator`.
>   - Replace `panic_with_byte_array`/felt constants with `Error` variants; minor import/expect helpers (e.g., `expect_with_err`).
> - **Tests**:
>   - Update expected panic strings and minor test names to match new error descriptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40f0c23d43053aecd322a512731a98fe14f6cfe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/131)
<!-- Reviewable:end -->
