### PR TITLE
feat: cache for price and funding

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -29,6 +29,7 @@ pub trait IDeleverageManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod DeleverageManager {
+    use core::dict::Felt252Dict;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
@@ -42,6 +43,7 @@ pub(crate) mod DeleverageManager {
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::position::PositionId;
     use starknet::storage::StoragePath;
     use starkware_utils::components::pausable::PausableComponent;
@@ -155,6 +157,9 @@ pub(crate) mod DeleverageManager {
             deleveraged_base_amount: i64,
             deleveraged_quote_amount: i64,
         ) {
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             let deleveraged_position = self
                 .positions
                 .get_position_snapshot(position_id: deleveraged_position_id);
@@ -195,7 +200,10 @@ pub(crate) mod DeleverageManager {
                     position_id: deleveraged_position_id,
                     position: deleveraged_position,
                     position_diff: deleveraged_position_diff,
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
+
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -203,6 +211,8 @@ pub(crate) mod DeleverageManager {
                     position: deleverager_position,
                     position_diff: deleverager_position_diff,
                     tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             // Apply diffs
@@ -238,20 +248,25 @@ pub(crate) mod DeleverageManager {
             position_id: PositionId,
             position: StoragePath<Position>,
             position_diff: PositionDiff,
+            ref price_cache: Felt252Dict<u64>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) {
             let (provisional_delta, unchanged_assets) = self
                 .positions
-                .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                .derive_funding_delta_and_unchanged_assets(
+                    :position, :position_diff, ref :price_cache, ref :global_funding_index_cache,
+                );
 
             let synthetic_enriched_position_diff = self
                 .positions
-                .enrich_asset(:position, :position_diff);
+                .enrich_asset(:position, :position_diff, ref :price_cache);
             let position_diff_enriched = self
                 .positions
                 .enrich_collateral(
                     :position,
                     position_diff: synthetic_enriched_position_diff,
                     provisional_delta: Option::Some(provisional_delta),
+                    ref :global_funding_index_cache,
                 );
 
             deleveraged_position_validations(

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -42,6 +42,7 @@ pub trait ILiquidationManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod LiquidationManager {
+    use core::dict::Felt252Dict;
     use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
@@ -58,6 +59,7 @@ pub(crate) mod LiquidationManager {
         FEE_POSITION, INSURANCE_FUND_POSITION, InternalTrait as PositionsInternal,
     };
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starknet::storage::StoragePath;
     use starkware_utils::components::pausable::PausableComponent;
@@ -184,6 +186,9 @@ pub(crate) mod LiquidationManager {
             actual_liquidator_fee: u64,
             liquidated_fee_amount: u64,
         ) {
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             assert(liquidated_position_id != INSURANCE_FUND_POSITION, CANT_LIQUIDATE_IF_POSITION);
             let liquidator_position_id = liquidator_order.position_id;
             assert(liquidator_position_id != INSURANCE_FUND_POSITION, CANT_LIQUIDATE_IF_POSITION);
@@ -269,6 +274,8 @@ pub(crate) mod LiquidationManager {
                     position_id: liquidated_position_id,
                     position: liquidated_position,
                     position_diff: liquidated_position_diff,
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
             self
                 .positions
@@ -277,6 +284,8 @@ pub(crate) mod LiquidationManager {
                     position: liquidator_position,
                     position_diff: liquidator_position_diff,
                     tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             // Apply Diffs.
@@ -330,6 +339,8 @@ pub(crate) mod LiquidationManager {
             position_id: PositionId,
             position: StoragePath<Position>,
             position_diff: PositionDiff,
+            ref price_cache: Felt252Dict<u64>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) {
             let (synthetic_diff_id, synthetic_diff_balance) = if let Option::Some((id, balance)) =
                 position_diff
@@ -345,16 +356,19 @@ pub(crate) mod LiquidationManager {
                 );
             let (provisional_delta, unchanged_assets) = self
                 .positions
-                .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                .derive_funding_delta_and_unchanged_assets(
+                    :position, :position_diff, ref :price_cache, ref :global_funding_index_cache,
+                );
             let synthetic_enriched_position_diff = self
                 .positions
-                .enrich_asset(:position, :position_diff);
+                .enrich_asset(:position, :position_diff, ref :price_cache);
             let position_diff_enriched = self
                 .positions
                 .enrich_collateral(
                     :position,
                     position_diff: synthetic_enriched_position_diff,
                     provisional_delta: Option::Some(provisional_delta),
+                    ref :global_funding_index_cache,
                 );
 
             liquidated_position_validations(

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -1,5 +1,6 @@
 #[starknet::component]
 pub mod Positions {
+    use core::dict::{Felt252Dict, Felt252DictTrait};
     use core::nullable::{FromNullableResult, match_nullable};
     use core::num::traits::Zero;
     use core::panic_with_felt252;
@@ -21,11 +22,12 @@ pub mod Positions {
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::asset::synthetic::AssetBalanceInfo;
     use perpetuals::core::types::balance::Balance;
-    use perpetuals::core::types::funding::calculate_funding;
+    use perpetuals::core::types::funding::{FundingIndex, calculate_funding};
     use perpetuals::core::types::position::{
         AssetBalance, POSITION_VERSION, Position, PositionData, PositionDiff, PositionId,
         PositionMutableTrait, PositionTrait,
     };
+    use perpetuals::core::types::price::Price;
     use perpetuals::core::types::set_owner_account::SetOwnerAccountArgs;
     use perpetuals::core::types::set_public_key::SetPublicKeyArgs;
     use perpetuals::core::value_risk_calculator::{
@@ -96,14 +98,22 @@ pub mod Positions {
         fn get_position_assets(
             self: @ComponentState<TContractState>, position_id: PositionId,
         ) -> PositionData {
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             let position = self.get_position_snapshot(:position_id);
             let (provisional_delta, assets) = self
                 .derive_funding_delta_and_unchanged_assets(
-                    :position, position_diff: Default::default(),
+                    :position,
+                    position_diff: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
             let collateral_balance = self
                 .get_collateral_provisional_balance(
-                    :position, provisional_delta: Option::Some(provisional_delta),
+                    :position,
+                    provisional_delta: Option::Some(provisional_delta),
+                    ref :global_funding_index_cache,
                 );
 
             PositionData { assets, collateral_balance }
@@ -114,14 +124,22 @@ pub mod Positions {
         fn get_position_tv_tr(
             self: @ComponentState<TContractState>, position_id: PositionId,
         ) -> PositionTVTR {
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             let position = self.get_position_snapshot(:position_id);
             let (provisional_delta, unchanged_assets) = self
                 .derive_funding_delta_and_unchanged_assets(
-                    :position, position_diff: Default::default(),
+                    :position,
+                    position_diff: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
             let collateral_balance = self
                 .get_collateral_provisional_balance(
-                    :position, provisional_delta: Option::Some(provisional_delta),
+                    :position,
+                    provisional_delta: Option::Some(provisional_delta),
+                    ref :global_funding_index_cache,
                 );
 
             calculate_position_tvtr(:unchanged_assets, :collateral_balance)
@@ -447,8 +465,12 @@ pub mod Positions {
             position: StoragePath<Position>,
             position_diff: AssetEnrichedPositionDiff,
             provisional_delta: Option<Balance>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) -> PositionDiffEnriched {
-            let before = self.get_collateral_provisional_balance(:position, :provisional_delta);
+            let before = self
+                .get_collateral_provisional_balance(
+                    :position, :provisional_delta, ref :global_funding_index_cache,
+                );
             let after = before + position_diff.collateral_diff;
             let collateral_enriched = BalanceDiff { before: before, after };
 
@@ -463,12 +485,21 @@ pub mod Positions {
             self: @ComponentState<TContractState>,
             position: StoragePath<Position>,
             position_diff: PositionDiff,
+            ref price_cache: Felt252Dict<u64>,
         ) -> AssetEnrichedPositionDiff {
             let asset_enriched = if let Option::Some((asset_id, diff)) = position_diff.asset_diff {
                 let balance_before = self.get_synthetic_balance(:position, synthetic_id: asset_id);
                 let balance_after = balance_before + diff;
                 let assets = get_dep_component!(self, Assets);
-                let price = assets.get_asset_price(:asset_id);
+
+                let cached_price = price_cache.get(asset_id.into());
+                let price: Price = if (cached_price == 0) {
+                    let price = assets.get_asset_price(:asset_id);
+                    price_cache.insert(asset_id.into(), price.into());
+                    price.into()
+                } else {
+                    cached_price.into()
+                };
                 let risk_factor_before = assets
                     .get_asset_risk_factor(:asset_id, balance: balance_before, :price);
                 let risk_factor_after = assets
@@ -525,6 +556,7 @@ pub mod Positions {
             self: @ComponentState<TContractState>,
             position: StoragePath<Position>,
             provisional_delta: Option<Balance>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) -> Balance {
             let assets = get_dep_component!(self, Assets);
             let mut collateral_provisional_balance = position.collateral_balance.read();
@@ -536,7 +568,18 @@ pub mod Positions {
                 if synthetic.balance.is_zero() {
                     continue;
                 }
-                let global_funding_index = assets.get_funding_index_unsafe(synthetic_id);
+                let cached_global_funding_index = global_funding_index_cache
+                    .get(synthetic_id.into());
+                let global_funding_index = match match_nullable(cached_global_funding_index) {
+                    FromNullableResult::Null => {
+                        let global_funding_index = assets.get_funding_index_unsafe(synthetic_id);
+                        // update cache
+                        global_funding_index_cache
+                            .insert(synthetic_id.into(), NullableTrait::new(global_funding_index));
+                        global_funding_index
+                    },
+                    FromNullableResult::NotNull(value) => value.unbox(),
+                };
                 collateral_provisional_balance +=
                     calculate_funding(
                         old_funding_index: synthetic.funding_index,
@@ -553,6 +596,8 @@ pub mod Positions {
             self: @ComponentState<TContractState>,
             position: StoragePath<Position>,
             position_diff: PositionDiff,
+            ref price_cache: Felt252Dict<u64>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) -> (Balance, Span<AssetBalanceInfo>) {
             let assets = get_dep_component!(self, Assets);
             let mut unchanged_assets = array![];
@@ -569,13 +614,34 @@ pub mod Positions {
                 if balance.is_zero() {
                     continue;
                 }
-                let (price, funding_index) = assets
-                    .get_price_and_funding_index(asset_id: synthetic_id);
+
+                // Read cached values or fetch and cache them.
+                let cached_global_funding_index = global_funding_index_cache
+                    .get(synthetic_id.into());
+                let global_funding_index = match match_nullable(cached_global_funding_index) {
+                    FromNullableResult::Null => {
+                        let global_funding_index = assets.get_funding_index_unsafe(synthetic_id);
+                        // update cache
+                        global_funding_index_cache
+                            .insert(synthetic_id.into(), NullableTrait::new(global_funding_index));
+                        global_funding_index
+                    },
+                    FromNullableResult::NotNull(value) => value.unbox(),
+                };
+
+                let cached_price = price_cache.get(synthetic_id.into());
+                let price: Price = if (cached_price == 0) {
+                    let price = assets.get_asset_price_unsafe(synthetic_id.into());
+                    price_cache.insert(synthetic_id.into(), price.into());
+                    price.into()
+                } else {
+                    cached_price.into()
+                };
 
                 provisional_delta +=
                     calculate_funding(
                         old_funding_index: synthetic.funding_index,
-                        new_funding_index: funding_index,
+                        new_funding_index: global_funding_index,
                         balance: synthetic.balance,
                     );
                 if synthetic_diff_id == synthetic_id {
@@ -603,10 +669,14 @@ pub mod Positions {
             self: @ComponentState<TContractState>,
             position: StoragePath<Position>,
             asset_id: AssetId,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) {
             let assets = get_dep_component!(self, Assets);
             let balance = if (asset_id == assets.get_collateral_id()) {
-                self.get_collateral_provisional_balance(position, None)
+                self
+                    .get_collateral_provisional_balance(
+                        position, None, ref :global_funding_index_cache,
+                    )
             } else {
                 self.get_synthetic_balance(:position, synthetic_id: asset_id)
             };
@@ -620,17 +690,26 @@ pub mod Positions {
             position: StoragePath<Position>,
             position_diff: PositionDiff,
             tvtr_before: Nullable<PositionTVTR>,
+            ref price_cache: Felt252Dict<u64>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) -> PositionTVTR {
-            let asset_enriched_position_diff = self.enrich_asset(:position, :position_diff);
+            let asset_enriched_position_diff = self
+                .enrich_asset(:position, :position_diff, ref :price_cache);
             let tvtr_before = match match_nullable(tvtr_before) {
                 FromNullableResult::Null => {
                     let (provisional_delta, unchanged_assets) = self
-                        .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                        .derive_funding_delta_and_unchanged_assets(
+                            :position,
+                            :position_diff,
+                            ref :price_cache,
+                            ref :global_funding_index_cache,
+                        );
                     let position_diff_enriched = self
                         .enrich_collateral(
                             :position,
                             position_diff: asset_enriched_position_diff,
                             provisional_delta: Option::Some(provisional_delta),
+                            ref :global_funding_index_cache,
                         );
 
                     calculate_position_tvtr_before(:unchanged_assets, :position_diff_enriched)
@@ -765,12 +844,19 @@ pub mod Positions {
         fn _get_position_state(
             self: @ComponentState<TContractState>, position: StoragePath<Position>,
         ) -> PositionState {
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             let position_diff = Default::default();
             let (provisional_delta, unchanged_assets) = self
-                .derive_funding_delta_and_unchanged_assets(:position, :position_diff);
+                .derive_funding_delta_and_unchanged_assets(
+                    :position, :position_diff, ref :price_cache, ref :global_funding_index_cache,
+                );
             let collateral_balance = self
                 .get_collateral_provisional_balance(
-                    :position, provisional_delta: Option::Some(provisional_delta),
+                    :position,
+                    provisional_delta: Option::Some(provisional_delta),
+                    ref :global_funding_index_cache,
                 );
             evaluate_position(:unchanged_assets, :collateral_balance)
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -57,6 +57,7 @@ pub trait ITransferManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod TransferManager {
+    use core::dict::Felt252Dict;
     use core::num::traits::Zero;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -69,6 +70,7 @@ pub(crate) mod TransferManager {
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::types::asset::AssetId;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starknet::storage::StoragePointerReadAccess;
     use starkware_utils::components::pausable::PausableComponent;
@@ -326,6 +328,9 @@ pub(crate) mod TransferManager {
 
             /// Validations - Fundamentals:
             let sender_position = self.positions.get_position_snapshot(:position_id);
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -333,6 +338,8 @@ pub(crate) mod TransferManager {
                     position: sender_position,
                     position_diff: position_diff_sender,
                     tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             // Execute transfer
@@ -344,7 +351,9 @@ pub(crate) mod TransferManager {
             self
                 .positions
                 .validate_asset_balance_is_not_negative(
-                    position: sender_position, asset_id: collateral_id,
+                    position: sender_position,
+                    asset_id: collateral_id,
+                    ref :global_funding_index_cache,
                 );
         }
     }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -41,6 +41,7 @@ pub trait IVaultExternal<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod VaultsManager {
+    use core::dict::Felt252Dict;
     use core::num::traits::{WideMul, Zero};
     use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
@@ -57,6 +58,7 @@ pub(crate) mod VaultsManager {
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::types::asset::AssetId;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
@@ -269,6 +271,10 @@ pub(crate) mod VaultsManager {
                 collateral_diff: order.quote_amount.into(), asset_diff: Option::None,
             };
 
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
+
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -276,6 +282,8 @@ pub(crate) mod VaultsManager {
                     position: sending_position_snapshot,
                     position_diff: sending_position_diff,
                     tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             self
@@ -556,6 +564,9 @@ pub(crate) mod VaultsManager {
             };
 
             // vault health checks
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
             self
                 .positions
                 .validate_healthy_or_healthier_position(
@@ -563,6 +574,8 @@ pub(crate) mod VaultsManager {
                     position: vault_position,
                     position_diff: vault_position_diff,
                     tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             self
@@ -574,13 +587,17 @@ pub(crate) mod VaultsManager {
             self
                 .positions
                 .validate_asset_balance_is_not_negative(
-                    position: vault_position, asset_id: self.assets.get_collateral_id(),
+                    position: vault_position,
+                    asset_id: self.assets.get_collateral_id(),
+                    ref :global_funding_index_cache,
                 );
 
             self
                 .positions
                 .validate_asset_balance_is_not_negative(
-                    position: redeeming_position, asset_id: order.base_asset_id,
+                    position: redeeming_position,
+                    asset_id: order.base_asset_id,
+                    ref :global_funding_index_cache,
                 );
             // user health checks
 
@@ -591,6 +608,8 @@ pub(crate) mod VaultsManager {
                     position: redeeming_position,
                     position_diff: redeeming_position_diff,
                     tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             self

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -56,6 +56,7 @@ pub trait IWithdrawalManager<TContractState> {
 
 #[starknet::contract]
 pub(crate) mod WithdrawalManager {
+    use core::dict::Felt252Dict;
     use core::num::traits::Zero;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc20::IERC20DispatcherTrait;
@@ -69,6 +70,7 @@ pub(crate) mod WithdrawalManager {
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalImpl as OperatorNonceInternal;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starknet::ContractAddress;
     use starknet::storage::StoragePointerReadAccess;
@@ -227,10 +229,19 @@ pub(crate) mod WithdrawalManager {
                 collateral_diff: -amount.into(), asset_diff: Option::None,
             };
 
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
+
             self
                 .positions
                 .validate_healthy_or_healthier_position(
-                    :position_id, :position, :position_diff, tvtr_before: Default::default(),
+                    :position_id,
+                    :position,
+                    :position_diff,
+                    tvtr_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             self.positions.apply_diff(:position_id, :position_diff);

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -20,6 +20,7 @@ pub mod Core {
     use perpetuals::core::interface::{ICore, Settlement};
     use perpetuals::core::types::asset::{AssetId, AssetStatus};
     use perpetuals::core::types::balance::Balance;
+    use perpetuals::core::types::funding::FundingIndex;
     use perpetuals::core::types::order::{LimitOrder, Order};
     use perpetuals::core::types::position::{PositionDiff, PositionId, PositionTrait};
     use perpetuals::core::types::price::PriceMulTrait;
@@ -340,6 +341,9 @@ pub mod Core {
             self.assets.validate_assets_integrity();
 
             let mut tvtr_cache: Felt252Dict<Nullable<PositionTVTR>> = Default::default();
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
 
             for _trade in trades {
                 let trade = *_trade;
@@ -360,6 +364,8 @@ pub mod Core {
                         actual_fee_b: trade.actual_fee_b,
                         tvtr_a_before: cached_pos_a_tvtr,
                         tvtr_b_before: cached_pos_b_tvtr,
+                        ref :price_cache,
+                        ref :global_funding_index_cache,
                     );
                 tvtr_cache.insert(position_id_a, NullableTrait::new(updated_a));
                 tvtr_cache.insert(position_id_b, NullableTrait::new(updated_b));
@@ -406,6 +412,9 @@ pub mod Core {
             self.pausable.assert_not_paused();
             self.assets.validate_assets_integrity();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
+            let mut price_cache: Felt252Dict<u64> = Default::default();
+            let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> =
+                Default::default();
 
             self
                 ._execute_trade(
@@ -419,6 +428,8 @@ pub mod Core {
                     :actual_fee_b,
                     tvtr_a_before: Default::default(),
                     tvtr_b_before: Default::default(),
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
         }
 
@@ -678,6 +689,8 @@ pub mod Core {
             actual_fee_b: u64,
             tvtr_a_before: Nullable<PositionTVTR>,
             tvtr_b_before: Nullable<PositionTVTR>,
+            ref price_cache: Felt252Dict<u64>,
+            ref global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>>,
         ) -> (PositionTVTR, PositionTVTR) {
             let synthetic_asset = self.assets.get_asset_config(order_a.base_asset_id);
             assert(synthetic_asset.asset_type == AssetType::SYNTHETIC, 'TRADE_ASSET_NOT_SYNTHETIC');
@@ -754,6 +767,8 @@ pub mod Core {
                     position: position_a,
                     position_diff: position_diff_a,
                     tvtr_before: tvtr_a_before,
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
             let tvtr_b_after = self
                 .positions
@@ -762,6 +777,8 @@ pub mod Core {
                     position: position_b,
                     position_diff: position_diff_b,
                     tvtr_before: tvtr_b_before,
+                    ref :price_cache,
+                    ref :global_funding_index_cache,
                 );
 
             // Apply Diffs.

--- a/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
@@ -38,6 +38,12 @@ pub impl U64IntoPrice of Into<u64, Price> {
     }
 }
 
+pub impl PriceIntoU64 of Into<Price, u64> {
+    fn into(self: Price) -> u64 {
+        self.value
+    }
+}
+
 #[derive(Copy, Debug, Drop, Serde)]
 pub struct SignedPrice {
     pub signature: Signature,

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -1,3 +1,4 @@
+use core::dict::Felt252Dict;
 use core::num::traits::{Pow, Zero};
 use perpetuals::core::components::assets::interface::{
     IAssets, IAssetsDispatcher, IAssetsDispatcherTrait,
@@ -2216,6 +2217,7 @@ fn test_cancel_deposit_before_cancellation_delay_passed() {
 fn test_successful_trade() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();
+    let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
 
@@ -2308,7 +2310,9 @@ fn test_successful_trade() {
     let position_a = state.positions.get_position_snapshot(position_id: user_a.position_id);
     let user_a_collateral_balance = state
         .positions
-        .get_collateral_provisional_balance(position: position_a, provisional_delta: Option::None);
+        .get_collateral_provisional_balance(
+            position: position_a, provisional_delta: Option::None, ref :global_funding_index_cache,
+        );
     let user_a_synthetic_balance = state
         .positions
         .get_synthetic_balance(position: position_a, :synthetic_id);
@@ -2320,7 +2324,9 @@ fn test_successful_trade() {
     let position_b = state.positions.get_position_snapshot(position_id: user_b.position_id);
     let user_b_collateral_balance = state
         .positions
-        .get_collateral_provisional_balance(position: position_b, provisional_delta: Option::None);
+        .get_collateral_provisional_balance(
+            position: position_b, provisional_delta: Option::None, ref :global_funding_index_cache,
+        );
     let user_b_synthetic_balance = state
         .positions
         .get_synthetic_balance(position: position_b, :synthetic_id);
@@ -2332,7 +2338,9 @@ fn test_successful_trade() {
     let position = state.positions.get_position_snapshot(position_id: FEE_POSITION);
     let fee_position_balance = state
         .positions
-        .get_collateral_provisional_balance(:position, provisional_delta: Option::None);
+        .get_collateral_provisional_balance(
+            :position, provisional_delta: Option::None, ref :global_funding_index_cache,
+        );
     assert!(fee_position_balance == (FEE + FEE).into());
 }
 
@@ -2456,6 +2464,7 @@ fn test_successful_withdraw_request_with_public_key() {
 fn test_successful_deleverage() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();
+    let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
 
@@ -2533,7 +2542,9 @@ fn test_successful_deleverage() {
     let deleveraged_collateral_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: deleveraged_position, provisional_delta: Option::None,
+            position: deleveraged_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     let deleveraged_synthetic_balance = state
         .positions
@@ -2544,7 +2555,9 @@ fn test_successful_deleverage() {
     let deleverager_collateral_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: deleverager_position, provisional_delta: Option::None,
+            position: deleverager_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     let deleverager_synthetic_balance = state
         .positions
@@ -2557,6 +2570,7 @@ fn test_successful_deleverage() {
 fn test_successful_liquidate() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();
+    let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
 
@@ -2642,7 +2656,9 @@ fn test_successful_liquidate() {
     let liquidated_collateral_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: liquidated_position, provisional_delta: Option::None,
+            position: liquidated_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     let liquidated_synthetic_balance = state
         .positions
@@ -2657,7 +2673,9 @@ fn test_successful_liquidate() {
     let liquidator_collateral_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: liquidator_position, provisional_delta: Option::None,
+            position: liquidator_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     let liquidator_synthetic_balance = state
         .positions
@@ -2673,7 +2691,9 @@ fn test_successful_liquidate() {
     let fee_position_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: fee_position, provisional_delta: Option::None,
+            position: fee_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     assert!(fee_position_balance == FEE.into());
 
@@ -2683,7 +2703,9 @@ fn test_successful_liquidate() {
     let insurance_position_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: insurance_fund_position, provisional_delta: Option::None,
+            position: insurance_fund_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     assert!(insurance_position_balance == INSURANCE_FEE.into());
 }
@@ -2955,6 +2977,7 @@ fn test_successful_transfer_request_using_public_key() {
 fn test_successful_transfer() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();
+    let mut global_funding_index_cache: Felt252Dict<Nullable<FundingIndex>> = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
 
@@ -3033,7 +3056,9 @@ fn test_successful_transfer() {
     let sender_collateral_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: sender_position, provisional_delta: Option::None,
+            position: sender_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     assert_eq!(sender_collateral_balance, 0_i64.into());
 
@@ -3043,7 +3068,9 @@ fn test_successful_transfer() {
     let recipient_collateral_balance = state
         .positions
         .get_collateral_provisional_balance(
-            position: recipient_position, provisional_delta: Option::None,
+            position: recipient_position,
+            provisional_delta: Option::None,
+            ref :global_funding_index_cache,
         );
     assert_eq!(recipient_collateral_balance, (2 * COLLATERAL_BALANCE_AMOUNT).into());
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces per-call caches for prices and funding indices and threads them through core trade/validation paths to reduce redundant reads.
> 
> - **Positions Component**:
>   - Add `Felt252Dict` caches for `price` and `global_funding_index` in `derive_funding_delta_and_unchanged_assets`, `get_collateral_provisional_balance`, `enrich_asset`, `validate_healthy_or_healthier_position`, `validate_asset_balance_is_not_negative`, `get_position_assets`, `get_position_tv_tr`, and `_get_position_state`.
>   - Cache lookups with fallback to `assets.get_asset_price(_unsafe)` and `assets.get_funding_index_unsafe` to populate caches.
> - **Core**:
>   - `trade` and `multi_trade` create and reuse caches; `_execute_trade` accepts cache refs.
> - **Managers**:
>   - Deleverage, Liquidation, Transfer, Vaults, and Withdrawal managers instantiate caches and pass them into position validations.
> - **Types**:
>   - Add `Into<Price, u64>` impl for `Price`.
> - **Tests**:
>   - Update unit tests to construct/pass funding index cache when calling `get_collateral_provisional_balance` and related paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccffd5a70f9444c30dc935424814e2f8b85edfa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/132)
<!-- Reviewable:end -->
