### PR TITLE
test(perpetuals): add tests for forced withdraw

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -2,6 +2,9 @@ use perpetuals::core::components::assets::events as assets_events;
 use perpetuals::core::components::deposit::events as deposit_events;
 use perpetuals::core::components::positions::events as positions_events;
 use perpetuals::core::components::snip::SNIP12MetadataImpl;
+use perpetuals::core::components::withdrawal::withdrawal_manager::{
+    ForcedWithdraw, ForcedWithdrawRequest,
+};
 use perpetuals::core::events;
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::funding::FundingIndex;
@@ -155,6 +158,60 @@ pub fn assert_withdraw_event_with_expected(
         :expected_event,
         expected_event_selector: @selector!("Withdraw"),
         expected_event_name: "Withdraw",
+    );
+}
+
+pub fn assert_forced_withdraw_request_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    position_id: PositionId,
+    recipient: ContractAddress,
+    collateral_id: AssetId,
+    amount: u64,
+    expiration: Timestamp,
+    forced_withdraw_request_hash: felt252,
+    salt: felt252,
+) {
+    let expected_event = ForcedWithdrawRequest {
+        position_id,
+        recipient,
+        collateral_id,
+        amount,
+        expiration,
+        forced_withdraw_request_hash,
+        salt,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("ForcedWithdrawRequest"),
+        expected_event_name: "ForcedWithdrawRequest",
+    );
+}
+
+pub fn assert_forced_withdraw_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    position_id: PositionId,
+    recipient: ContractAddress,
+    collateral_id: AssetId,
+    amount: u64,
+    expiration: Timestamp,
+    forced_withdraw_request_hash: felt252,
+    salt: felt252,
+) {
+    let expected_event = ForcedWithdraw {
+        position_id,
+        recipient,
+        collateral_id,
+        amount,
+        expiration,
+        forced_withdraw_request_hash,
+        salt,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("ForcedWithdraw"),
+        expected_event_name: "ForcedWithdraw",
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds unit tests and event helpers for forced withdraw flows, covering request, execution by operator/user, timing and double-processing edge cases.
> 
> - **Tests (`tests/unit_tests/unit_tests.cairo`)**:
>   - Add comprehensive forced withdraw scenarios:
>     - Request emits `ForcedWithdrawRequest` and charges premium to sequencer.
>     - Execution by operator within window; execution by user after timeout.
>     - Reverts for early execution, double-processing (after operator/user action), and zero-amount requests.
>   - Wire in `ICoreDispatcher` usage and timing helpers to support scenarios.
> - **Event Assertions (`tests/event_test_utils.cairo`)**:
>   - Add `assert_forced_withdraw_request_event_with_expected` and `assert_forced_withdraw_event_with_expected` for `ForcedWithdrawRequest`/`ForcedWithdraw` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c6d4c884b0427aead26122cf04f4b123c37747b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/135)
<!-- Reviewable:end -->
