### PR TITLE
test(perps): add helper functions and basic utilities

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -191,7 +191,7 @@ async def upgrade_perpetuals_core_contract(
     deployer_account: Account,
     operator_account: Account,
     app_governor_account: Account,
-) -> Contract:
+) -> dict[str, Contract]:
     abi, cairo_version = await ContractAbiResolver(
         address=contract_address,
         client=deployer_account.client,

--- a/devnet_tests/perpetuals_test_utils.py
+++ b/devnet_tests/perpetuals_test_utils.py
@@ -1,0 +1,106 @@
+import os
+import random
+from starknet_py.contract import Contract
+from starknet_py.net.account.account import Account
+from starknet_py.proxy.contract_abi_resolver import ContractAbiResolver, ProxyConfig
+from test_utils.starknet_test_utils import StarknetTestUtils
+
+MAX_UINT32 = 2**32 - 1  # Maximum value for a 32-bit unsigned integer
+
+
+def formatted_position_id(value: int) -> dict:
+    return {"value": value}
+
+
+class PerpetualsTestUtils:
+    def __init__(
+        self, StarknetTestUtils: StarknetTestUtils, upgrade_perpetuals_core_contract: dict
+    ):
+        self.starknet_test_utils = StarknetTestUtils
+        self.operator_contract = upgrade_perpetuals_core_contract["operator_contract"]
+        self.app_governor_contract = upgrade_perpetuals_core_contract["app_governor_contract"]
+
+        self.operator_nonce = None
+        self.accounts_number = 0
+        self.account_contracts = {}
+        self.account_key_pairs = {}  # key_pairs[account] = (public_key, private_key)
+        self.account_positions = {}
+
+    ## Helper functions
+
+    def get_account_public_key(self, account: Account) -> int:
+        return self.account_key_pairs[account][0]
+
+    def get_account_address(self, account: Account) -> int:
+        return account.address
+
+    def get_account_position_id(self, account: Account) -> int:
+        return self.account_positions[account]
+
+    async def new_account(self) -> Account:
+        if self.accounts_number >= len(self.starknet_test_utils.starknet.accounts):
+            raise ValueError("No more accounts available")
+
+        account = self.starknet_test_utils.starknet.accounts[self.accounts_number]
+        self.account_key_pairs[account] = (account.signer.public_key, account.signer.private_key)
+        self.accounts_number += 1
+
+        abi, cairo_version = await ContractAbiResolver(
+            address=self.operator_contract.address,
+            client=account.client,
+            proxy_config=ProxyConfig(),
+        ).resolve()
+
+        account_contract = Contract(
+            address=self.operator_contract.address,
+            abi=abi,
+            provider=account,
+            cairo_version=cairo_version,
+        )
+        self.account_contracts[account] = account_contract
+
+        return account
+
+    ## View functions
+
+    async def get_operator_nonce(self) -> int:
+        (nonce,) = await self.operator_contract.functions["get_operator_nonce"].call()
+        self.operator_nonce = nonce
+        return nonce
+
+    async def consume_operator_nonce(self) -> int:
+        if self.operator_nonce is None:
+            await self.get_operator_nonce()
+        nonce = self.operator_nonce
+        self.operator_nonce += 1
+        return nonce
+
+    ## Storage-mutating functions
+
+    async def new_position(self, account: Account, seed: int | None = None, tries: int = 3) -> int:
+        error = None
+        if seed is None:
+            seed = int(os.getenv("RANDOM_SEED", "0"))
+        random.seed(seed)
+        while tries > 0:
+            position_id = random.randint(1, MAX_UINT32)
+            try:
+                invocation = await self.operator_contract.functions["new_position"].invoke_v3(
+                    await self.consume_operator_nonce(),
+                    formatted_position_id(position_id),
+                    self.get_account_public_key(account),
+                    self.get_account_address(account),
+                    auto_estimate=True,
+                )
+                await invocation.wait_for_acceptance(check_interval=0.1)
+                # Success! Store and return the position_id
+                self.account_positions[account] = position_id
+                return position_id
+
+            except Exception as e:
+                tries -= 1
+                error = e
+                continue
+
+        assert error is not None
+        raise Exception(f"Failed to create a new position: {error}")

--- a/devnet_tests/system_test.py
+++ b/devnet_tests/system_test.py
@@ -1,11 +1,35 @@
 import pytest
 from test_utils.starknet_test_utils import StarknetTestUtils
+from starknet_py.contract import Contract
+from devnet_tests.perpetuals_test_utils import PerpetualsTestUtils
 
 
-# TODO: Implement system tests for the forked Starknet environment.
 @pytest.mark.asyncio
-async def test_dummy(
+async def test_helper_functions(
+    upgrade_perpetuals_core_contract: Contract,
     starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    declare_perpetuals_core_contract: int,
 ):
-    assert starknet_forked_with_impersonated_accounts
+    test_utils = PerpetualsTestUtils(
+        starknet_forked_with_impersonated_accounts, upgrade_perpetuals_core_contract
+    )
+
+    # Test that we can access the contracts
+    assert test_utils.operator_contract is not None
+    assert test_utils.app_governor_contract is not None
+
+    # Test new_account
+    account = await test_utils.new_account()
+    assert account is not None
+
+    # Test helper functions with the created account
+    assert test_utils.get_account_address(account) == account.address
+    assert test_utils.get_account_public_key(account) == account.signer.public_key
+
+    # Test get_operator_nonce
+    nonce = await test_utils.get_operator_nonce()
+    assert nonce >= 0
+
+    # Test new_position
+    position_id = await test_utils.new_position(account)
+    assert position_id > 0
+    assert test_utils.get_account_position_id(account) == position_id


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce `PerpetualsTestUtils`, change `upgrade_perpetuals_core_contract` to return operator/app governor contracts, and add a system test validating helper flows.
> 
> - **Tests**:
>   - Add `devnet_tests/system_test.py::test_helper_functions` to validate account setup, nonce retrieval, and `new_position` via helpers.
> - **Utilities**:
>   - Add `devnet_tests/perpetuals_test_utils.py` with `PerpetualsTestUtils` providing account management, operator nonce handling, and `new_position` helper.
> - **Fixtures**:
>   - Update `devnet_tests/conftest.py` `upgrade_perpetuals_core_contract` to return `{ "operator_contract", "app_governor_contract" }` instead of a single `Contract`, and wire resolved ABIs/providers accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4c9e107ccc2c2e4c3fa9856480709f014cb968d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/138)
<!-- Reviewable:end -->
