### PR TITLE
test(perps): add view functions, deposit and withdraw

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -29,6 +29,9 @@ OPERATOR_DUMMY_KEY = 1
 DEPLOYER_DUMMY_KEY = 2
 APP_GOVERNOR_DUMMY_KEY = 3
 
+# Random block number for the forked network
+FORK_BLOCK = 3861835
+
 
 @pytest.fixture(scope="session")
 def operator_address() -> int:
@@ -68,7 +71,7 @@ def starknet_forked(
 ) -> Iterator[StarknetTestUtils]:
     with starknet_test_utils_factory(
         fork_network="https://rpc.starknet.lava.build/",
-        fork_block=3861835,
+        fork_block=FORK_BLOCK,
         starknet_chain_id=StarknetChainId.MAINNET,
         request_body_size_limit=20_000_000,
     ) as val:
@@ -76,17 +79,19 @@ def starknet_forked(
 
 
 @pytest.fixture(scope="function")
+def accounts_to_impersonate(operator_address: int, deployer_address: int, app_governor_address: int) -> list[int]:
+    return [operator_address, deployer_address, app_governor_address]
+
+@pytest.fixture(scope="function")
 def starknet_forked_with_impersonated_accounts(
     starknet_forked: StarknetTestUtils,
-    operator_address: int,
-    deployer_address: int,
-    app_governor_address: int,
+    accounts_to_impersonate: list[int],
 ) -> StarknetTestUtils:
     """
     Impersonate the operator account in the forked Starknet instance.
     """
     client = starknet_forked.starknet.get_client()
-    for address in [operator_address, deployer_address, app_governor_address]:
+    for address in accounts_to_impersonate:
         client.impersonate_account_sync(address)
 
     return starknet_forked

--- a/devnet_tests/perpetuals_test_utils.py
+++ b/devnet_tests/perpetuals_test_utils.py
@@ -1,15 +1,35 @@
 import os
 import random
+from poseidon_py.poseidon_hash import poseidon_hash_many
+from starknet_py.cairo.felt import encode_shortstring
 from starknet_py.contract import Contract
+from starknet_py.hash.utils import message_signature
 from starknet_py.net.account.account import Account
+from starknet_py.net.models.chains import StarknetChainId
 from starknet_py.proxy.contract_abi_resolver import ContractAbiResolver, ProxyConfig
 from test_utils.starknet_test_utils import StarknetTestUtils
+
+# Required for hash computations.
+WITHDEAW_ARGS_HASH = 0x250A5FA378E8B771654BD43DCB34844534F9D1E29E16B14760D7936EA7F4B1D
+STARKNET_DOMAIN_HASH = 0x1FF2F602E42168014D405A94F75E8A93D640751D71D16311266E140D8B0A210
+PERPETUALS_NAME = "Perpetuals"
+PERPETUALS_VERSION = "v0"
+STARKNET_CHAIN_ID = StarknetChainId.MAINNET
+REVISION = 1
 
 MAX_UINT32 = 2**32 - 1  # Maximum value for a 32-bit unsigned integer
 
 
 def formatted_position_id(value: int) -> dict:
     return {"value": value}
+
+
+def formatted_asset_id(value: int) -> dict:
+    return {"value": value}
+
+
+def formatted_timestamp(seconds: int) -> dict:
+    return {"seconds": seconds}
 
 
 class PerpetualsTestUtils:
@@ -75,6 +95,28 @@ class PerpetualsTestUtils:
         self.operator_nonce += 1
         return nonce
 
+    async def get_collateral_asset_id(self) -> int:
+        (asset_id,) = await self.operator_contract.functions["get_collateral_id"].call()
+        return asset_id["value"]
+
+    async def get_collateral_token_contract(self) -> int:
+        (token_contract,) = await self.operator_contract.functions[
+            "get_collateral_token_contract"
+        ].call()
+        return token_contract["contract_address"]
+
+    async def get_position_total_value(self, position_id: int) -> int:
+        (tv_tr,) = await self.operator_contract.functions["get_position_tv_tr"].call(
+            formatted_position_id(position_id)
+        )
+        return tv_tr["total_value"]
+
+    async def get_num_of_active_synthetic_assets(self) -> int:
+        (num_of_active_synthetic_assets,) = await self.operator_contract.functions[
+            "get_num_of_active_synthetic_assets"
+        ].call()
+        return num_of_active_synthetic_assets
+
     ## Storage-mutating functions
 
     async def new_position(self, account: Account, seed: int | None = None, tries: int = 3) -> int:
@@ -104,3 +146,122 @@ class PerpetualsTestUtils:
 
         assert error is not None
         raise Exception(f"Failed to create a new position: {error}")
+
+    async def deposit(self, account: Account, amount: int):
+        # Approve deposit
+        async def _approve_deposit(account: Account, amount: int):
+            abi, cairo_version = await ContractAbiResolver(
+                address=await self.get_collateral_token_contract(),
+                client=account.client,
+                proxy_config=ProxyConfig(),
+            ).resolve()
+
+            erc20_contract = Contract(
+                address=await self.get_collateral_token_contract(),
+                abi=abi,
+                provider=account,
+                cairo_version=cairo_version,
+            )
+
+            invocation = await erc20_contract.functions["approve"].invoke_v3(
+                self.operator_contract.address, amount, auto_estimate=True
+            )
+            await invocation.wait_for_acceptance(check_interval=0.1)
+
+        await _approve_deposit(account, amount)
+
+        # Deposit
+        salt = random.randint(0, MAX_UINT32)
+        invocation = (
+            await self.account_contracts[account]
+            .functions["deposit"]
+            .invoke_v3(
+                formatted_asset_id(await self.get_collateral_asset_id()),
+                self.get_account_address(account),
+                formatted_position_id(self.get_account_position_id(account)),
+                amount,
+                salt,
+                auto_estimate=True,
+            )
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+        # Process deposit
+        async def _process_deposit(account: Account, amount: int, salt: int):
+            invocation = await self.operator_contract.functions["process_deposit"].invoke_v3(
+                await self.consume_operator_nonce(),
+                formatted_asset_id(await self.get_collateral_asset_id()),
+                self.get_account_address(account),
+                formatted_position_id(self.get_account_position_id(account)),
+                amount,
+                salt,
+                auto_estimate=True,
+            )
+            await invocation.wait_for_acceptance(check_interval=0.1)
+
+        await _process_deposit(account, amount, salt)
+
+    async def withdraw(self, account: Account, amount: int, expiration: int):
+        salt = random.randint(0, MAX_UINT32)
+        collateral_asset_id = await self.get_collateral_asset_id()
+
+        withdraw_args_hash = poseidon_hash_many(
+            [
+                WITHDEAW_ARGS_HASH,
+                self.get_account_address(account),
+                self.get_account_position_id(account),
+                collateral_asset_id,
+                amount,
+                expiration,
+                salt,
+            ]
+        )
+        starknet_domain_hash = poseidon_hash_many(
+            [
+                STARKNET_DOMAIN_HASH,
+                encode_shortstring(PERPETUALS_NAME),
+                encode_shortstring(PERPETUALS_VERSION),
+                STARKNET_CHAIN_ID,
+                REVISION,
+            ]
+        )
+
+        message = [
+            encode_shortstring("StarkNet Message"),
+            starknet_domain_hash,
+            self.get_account_public_key(account),
+            withdraw_args_hash,
+        ]
+
+        message_hash = poseidon_hash_many(message)
+        signature = message_signature(message_hash, self.account_key_pairs[account][1])
+
+        invocation = (
+            await self.account_contracts[account]
+            .functions["withdraw_request"]
+            .invoke_v3(
+                signature,
+                self.get_account_address(account),
+                formatted_position_id(self.get_account_position_id(account)),
+                amount,
+                formatted_timestamp(expiration),
+                salt,
+                auto_estimate=True,
+            )
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+        # Process withdrawal request
+        async def _process_withdraw(account: Account, amount: int, expiration: int, salt: int):
+            invocation = await self.operator_contract.functions["withdraw"].invoke_v3(
+                await self.consume_operator_nonce(),
+                self.get_account_address(account),
+                formatted_position_id(self.get_account_position_id(account)),
+                amount,
+                formatted_timestamp(expiration),
+                salt,
+                auto_estimate=True,
+            )
+            await invocation.wait_for_acceptance(check_interval=0.1)
+
+        await _process_withdraw(account, amount, expiration, salt)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds Perpetuals test utilities for view/deposit/withdraw flows and corresponding system tests, plus a small devnet fixture refactor.
> 
> - **Tests**:
>   - Add `test_view_functions` and `test_deposit_withdraw` in `devnet_tests/system_test.py` validating collateral info, active assets count, position TV, and deposit/withdraw effects.
> - **Test Utilities (`devnet_tests/perpetuals_test_utils.py`)**:
>   - Add view helpers: `get_collateral_asset_id`, `get_collateral_token_contract`, `get_position_total_value`, `get_num_of_active_synthetic_assets`.
>   - Implement `deposit` (ERC20 `approve` + operator `process_deposit`) and `withdraw` (request with Poseidon-signed message + operator `withdraw`).
>   - Add helpers `formatted_asset_id`, `formatted_timestamp` and hashing/signature constants/imports.
> - **Fixtures (`devnet_tests/conftest.py`)**:
>   - Introduce `FORK_BLOCK` constant and use it in `starknet_forked`.
>   - Add `accounts_to_impersonate` fixture and use it in `starknet_forked_with_impersonated_accounts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0287956575361ea33863a0b6deb0886f03e6b1a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/139)
<!-- Reviewable:end -->
