### PR TITLE
test(perps): add asset, add oracle and price tick fns

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -40,6 +40,7 @@ RICH_USDC_HOLDER_DUMMY_KEY = 4
 
 # Random block number for the forked network
 FORK_BLOCK = 4415803
+NOW = 1765971224
 
 
 def wait_for_devnet(port: int, timeout: int = 60) -> bool:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds utils to create signed oracle prices, manage synthetic assets/oracles, and a system test that exercises price_tick; introduces a NOW timestamp constant.
> 
> - **Tests/Utils**:
>   - `devnet_tests/perpetuals_test_utils.py`:
>     - Add `create_signed_price` (uses `pedersen_hash`) and constants `TWO_POW_40`, `TWO_POW_32`.
>     - Add helpers: `price_tick`, `add_synthetic_asset`, `add_oracle_to_asset`.
>   - `devnet_tests/system_test.py`:
>     - New `test_asset_management` that adds a synthetic asset, registers an oracle, signs a price, and calls `price_tick` (verifies asset count increment).
>     - Imports and uses `NOW` for timestamp.
> - **Config**:
>   - `devnet_tests/conftest.py`: define `NOW` constant for test timestamps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e6c2d6c9378e6aae2322283e61fb1f59eebcf31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/140)
<!-- Reviewable:end -->
