### PR TITLE
test(perps): add funding tick

### DIFF
--- a/devnet_tests/perpetuals_test_utils.py
+++ b/devnet_tests/perpetuals_test_utils.py
@@ -1,3 +1,5 @@
+import asyncio
+import bisect
 import os
 import random
 from poseidon_py.poseidon_hash import poseidon_hash_many
@@ -8,6 +10,8 @@ from starknet_py.net.account.account import Account
 from starknet_py.net.models.chains import StarknetChainId
 from starknet_py.proxy.contract_abi_resolver import ContractAbiResolver, ProxyConfig
 from test_utils.starknet_test_utils import StarknetTestUtils
+from typing import Dict, Tuple, Optional
+from conftest import NOW
 
 # Required for hash computations.
 WITHDEAW_ARGS_HASH = 0x250A5FA378E8B771654BD43DCB34844534F9D1E29E16B14760D7936EA7F4B1D
@@ -21,6 +25,89 @@ MAX_UINT32 = 2**32 - 1  # Maximum value for a 32-bit unsigned integer
 TWO_POW_40 = 2**40  # 2^40
 TWO_POW_32 = 2**32  # 2^32
 
+# Required for funding tick when forking from mainnet.
+# This list is relavent for block number 3861835.
+# When changing the forked block number, this list needs to be updated to support funding tick.
+# This list must be sorted in ascending order.
+EXTENDED_SYNTHETIC_ASSET_IDS = [
+    255399919616426605400900257294843904,
+    255399919633304379671818952480129024,
+    255399919636945194886730150859243520,
+    270915948027776046540867925536931840,
+    338824487460085561411166284290195456,
+    338883663474438343746899177019277312,
+    338905303280690764515996647076921344,
+    339127382605583335846376969292742656,
+    339128557725978860634015450544472064,
+    339167696437051981397172032081231872,
+    339189412421329087967425821086318592,
+    339248760150559911178053148269871104,
+    339249788878727834962578719796887552,
+    344097595806435454645696181259206656,
+    344278863660798979802850626929426432,
+    344400637349001255728961162330505216,
+    349208209667358115027548008674754560,
+    349553874717371921940984895618678784,
+    354684143347689286618180522700963840,
+    359653178029624005735478030701166592,
+    359754745788483493062461101120159744,
+    359855675003405245145646005674311680,
+    359977924063000458297011360688504832,
+    359998998794517018713123529349398528,
+    364785659509114736355216580319117312,
+    370260563196593831237922481296637952,
+    370321410161845694364216165796937728,
+    375656867931341909315028931361898496,
+    380625508329364671305743144700608512,
+    380663843873413173657742089127985152,
+    385960324586951584765944650413375488,
+    390746430762672347138718348219514880,
+    396000038112596647361460946256003072,
+    396101378379648832210803477251620864,
+    396101380212403101135280116273774592,
+    396323605930722754555422238098587648,
+    401211989740530901651818111897174016,
+    401212385921352564110845035577081856,
+    401334549526471356934815741500194816,
+    401395555207980563015918882817835008,
+    401415362247400203280702639630712832,
+    401415448619475043208479622807158784,
+    406403816491335810657189215283970048,
+    411778891792336016648512811332272128,
+    411817625024622139428925067103305728,
+    416789435879299995223824283975286784,
+    416789436818522072078212394507042816,
+    416992418108949182116875998607704064,
+    417113878881044044170394349040828416,
+    427174429141597609995520190256775168,
+    431877150642355703025313311742754816,
+    432365923161760081025958177373421568,
+    432549653271839585844452234968956928,
+    432568984945910917982054318042251264,
+    432590218091046889185300129471528960,
+    432590218096110157059814614722674688,
+    432670881640427675234041645227835392,
+    432690441716627433572355962568704000,
+    437477565754482165017662333485318144,
+    437557744680566327621078168874516480,
+    437638715834618327041098343530889216,
+    437761440258352922500030743109959680,
+    437822852025511902434950189083000832,
+    437823079767580094335063891128614912,
+    442933058567680452956063953642848256,
+    448024668544195796360802891422760960,
+    453216002551035381248377800238301184,
+    453276691323521307730974454904258560,
+    453276858440817581570030792557461504,
+    458247228599093253039736795210711040,
+    458267273324209361917147961830146048,
+    458550751644561930336286859415519232,
+    458591633377628216554099757268598784,
+    468711525804946640478875348763672576,
+    468915544507303112068184696028135424,
+    468976147866535357546823156383088640,
+]
+
 
 def formatted_position_id(value: int) -> dict:
     return {"value": value}
@@ -32,6 +119,10 @@ def formatted_asset_id(value: int) -> dict:
 
 def formatted_timestamp(seconds: int) -> dict:
     return {"seconds": seconds}
+
+
+def formatted_funding_index(value: int) -> dict:
+    return {"value": value}
 
 
 class PerpetualsTestUtils:
@@ -48,6 +139,7 @@ class PerpetualsTestUtils:
 
         self.operator_nonce = None
         self.accounts_number = 0
+        self.asset_ids = EXTENDED_SYNTHETIC_ASSET_IDS
         self.account_contracts = {}
         self.account_key_pairs = {}  # key_pairs[account] = (public_key, private_key)
         self.account_positions = {}
@@ -141,6 +233,12 @@ class PerpetualsTestUtils:
             "get_num_of_active_synthetic_assets"
         ].call()
         return num_of_active_synthetic_assets
+
+    async def get_asset_timely_data(self, asset_id: int) -> dict:
+        (asset_timely_data,) = await self.operator_contract.functions["get_timely_data"].call(
+            formatted_asset_id(asset_id)
+        )
+        return asset_timely_data
 
     ## Storage-mutating functions
 
@@ -346,6 +444,7 @@ class PerpetualsTestUtils:
                 auto_estimate=True,
             )
             await invocation.wait_for_acceptance(check_interval=0.1)
+            bisect.insort(self.asset_ids, asset_id)
             return asset_id
         except Exception as e:
             raise Exception(f"Failed to add synthetic asset {asset_id}: {e}")
@@ -358,6 +457,73 @@ class PerpetualsTestUtils:
             oracle_public_key,
             oracle_name,
             asset_name,
+            auto_estimate=True,
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+    async def funding_tick(self, funding_ticks_diffs: dict):
+        FUNDING_INDEX_STR = "funding_index"
+        FUNDING_INDEX_VALUE_STR = "value"
+        ASSET_ID_STR = "asset_id"
+
+        # Get all funding indices
+        async def _get_all_funding_indices() -> Dict[int, int]:
+            async def fetch_funding_index(asset_id: int) -> Tuple[int, Optional[int]]:
+                try:
+                    timely_data = await self.get_asset_timely_data(asset_id)
+                    funding_index_value = timely_data[FUNDING_INDEX_STR][FUNDING_INDEX_VALUE_STR]
+                    return (asset_id, funding_index_value)
+                except Exception as e:
+                    print(f"Error fetching funding index for asset {hex(asset_id)}: {e}")
+                    return (asset_id, None)
+
+            coroutines = [fetch_funding_index(asset_id) for asset_id in self.asset_ids]
+
+            results = await asyncio.gather(*coroutines)
+
+            funding_indices = {
+                asset_id: funding_index
+                for asset_id, funding_index in results
+                if funding_index is not None
+            }
+
+            num_of_active_synthetic_assets = await self.get_num_of_active_synthetic_assets()
+            if len(funding_indices) != num_of_active_synthetic_assets:
+                raise Exception(
+                    f"Failed to get all funding indices. \
+                    Expected {num_of_active_synthetic_assets}, got {len(funding_indices)}."
+                )
+            return funding_indices
+
+        current_funding_indices = await _get_all_funding_indices()
+
+        # Calculate new funding indices
+        new_funding_indices = []
+        for asset_id in self.asset_ids:
+            if asset_id in funding_ticks_diffs.keys():
+                new_funding_indices.append(
+                    {
+                        ASSET_ID_STR: formatted_asset_id(asset_id),
+                        FUNDING_INDEX_STR: formatted_funding_index(
+                            current_funding_indices[asset_id] + funding_ticks_diffs[asset_id]
+                        ),
+                    }
+                )
+            else:
+                new_funding_indices.append(
+                    {
+                        ASSET_ID_STR: formatted_asset_id(asset_id),
+                        FUNDING_INDEX_STR: formatted_funding_index(
+                            current_funding_indices[asset_id]
+                        ),
+                    }
+                )
+
+        # Execute funding tick
+        invocation = await self.operator_contract.functions["funding_tick"].invoke_v3(
+            await self.get_operator_nonce(),
+            new_funding_indices,
+            formatted_timestamp(NOW),
             auto_estimate=True,
         )
         await invocation.wait_for_acceptance(check_interval=0.1)

--- a/devnet_tests/system_test.py
+++ b/devnet_tests/system_test.py
@@ -132,3 +132,16 @@ async def test_asset_management(test_utils: PerpetualsTestUtils):
     # Verify the number of active synthetic assets increased
     num_assets_after = await test_utils.get_num_of_active_synthetic_assets()
     assert num_assets_after == num_assets_before + 1
+
+    # Test funding_tick
+    # Get timely data to verify funding index exists
+    timely_data = await test_utils.get_asset_timely_data(asset_id)
+    initial_funding_index = timely_data["funding_index"]["value"]
+
+    # Execute funding tick with a diff for the new asset
+    await test_utils.funding_tick({asset_id: 1024})
+
+    # Verify funding index was updated
+    timely_data_after = await test_utils.get_asset_timely_data(asset_id)
+    final_funding_index = timely_data_after["funding_index"]["value"]
+    assert final_funding_index - initial_funding_index == 1024


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds funding_tick support to test utils (including timely data access and mainnet asset IDs) and verifies it in system tests.
> 
> - **Devnet Test Utilities (`devnet_tests/perpetuals_test_utils.py`)**:
>   - Add funding_tick support: fetch current funding indices concurrently, compute updated indices, and invoke `operator_contract.funding_tick` with timestamp.
>   - Introduce `get_asset_timely_data` and `formatted_funding_index` helpers.
>   - Track synthetic asset IDs via `EXTENDED_SYNTHETIC_ASSET_IDS` (sorted list for mainnet fork) and maintain it on `add_synthetic_asset`.
> - **System Tests (`devnet_tests/system_test.py`)**:
>   - After adding a synthetic asset and price tick, validate funding_tick updates the asset's `funding_index` by a specified diff.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84a528c5a13427f9e59e851b5eb535714c374c13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/141)
<!-- Reviewable:end -->
