### PR TITLE
Revert "refactor(perpetuals): use describe for core errors (#131)"

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/fulfillment.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/fulfillment.cairo
@@ -4,13 +4,14 @@
 /// used to prevent replay attacks when contracts accept signatures as input.
 #[starknet::component]
 pub mod Fulfillement {
+    use core::panics::panic_with_byte_array;
     use perpetuals::core::components::fulfillment::interface::IFulfillment;
-    use perpetuals::core::errors::Error::FULFILLMENT_EXCEEDED;
     use starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starkware_utils::math::abs::Abs;
     use starkware_utils::signature::stark::HashType;
+    use crate::core::errors::fulfillment_exceeded_err;
 
     #[storage]
     pub struct Storage {
@@ -31,9 +32,10 @@ pub mod Fulfillement {
             let mut fulfillment_entry = self.fulfillment.entry(hash);
             let total_amount = fulfillment_entry.read() + actual_base_amount.abs();
 
-            assert!(
-                total_amount <= order_base_amount.abs(), "{}", FULFILLMENT_EXCEEDED(position_id),
-            );
+            if (total_amount > order_base_amount.abs()) {
+                let err = fulfillment_exceeded_err(:position_id);
+                panic_with_byte_array(err: @err);
+            }
             fulfillment_entry.write(total_amount);
         }
     }

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -48,10 +48,7 @@ pub(crate) mod LiquidationManager {
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
-    use perpetuals::core::components::assets::errors::SYNTHETIC_NOT_EXISTS;
     use perpetuals::core::components::assets::interface::IAssets;
-    use perpetuals::core::components::external_components::interface::EXTERNAL_COMPONENT_LIQUIDATIONS;
-    use perpetuals::core::components::external_components::named_component::ITypedComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::fulfillment::interface::IFulfillment;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
@@ -61,10 +58,7 @@ pub(crate) mod LiquidationManager {
         FEE_POSITION, INSURANCE_FUND_POSITION, InternalTrait as PositionsInternal,
     };
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
-    use perpetuals::core::errors::Error::CANT_LIQUIDATE_IF_POSITION;
-    use perpetuals::core::types::position::{Position, PositionDiff, PositionId, PositionTrait};
-    use perpetuals::core::utils::{validate_signature, validate_trade};
-    use perpetuals::core::value_risk_calculator::liquidated_position_validations;
+    use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starknet::storage::StoragePath;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
@@ -74,6 +68,13 @@ pub(crate) mod LiquidationManager {
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
     use starkware_utils::time::time::Time;
+    use crate::core::components::assets::errors::SYNTHETIC_NOT_EXISTS;
+    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_LIQUIDATIONS;
+    use crate::core::components::external_components::named_component::ITypedComponent;
+    use crate::core::errors::CANT_LIQUIDATE_IF_POSITION;
+    use crate::core::types::position::{Position, PositionDiff};
+    use crate::core::utils::{validate_signature, validate_trade};
+    use crate::core::value_risk_calculator::liquidated_position_validations;
     use super::{ILiquidationManager, Liquidate, Order};
 
 
@@ -183,13 +184,9 @@ pub(crate) mod LiquidationManager {
             actual_liquidator_fee: u64,
             liquidated_fee_amount: u64,
         ) {
-            assert!(
-                liquidated_position_id != INSURANCE_FUND_POSITION, "{}", CANT_LIQUIDATE_IF_POSITION,
-            );
+            assert(liquidated_position_id != INSURANCE_FUND_POSITION, CANT_LIQUIDATE_IF_POSITION);
             let liquidator_position_id = liquidator_order.position_id;
-            assert!(
-                liquidator_position_id != INSURANCE_FUND_POSITION, "{}", CANT_LIQUIDATE_IF_POSITION,
-            );
+            assert(liquidator_position_id != INSURANCE_FUND_POSITION, CANT_LIQUIDATE_IF_POSITION);
 
             let collateral_id = self.assets.get_collateral_id();
             let liquidated_order = Order {

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -18,23 +18,18 @@ pub mod Positions {
     };
     use perpetuals::core::components::positions::events;
     use perpetuals::core::components::positions::interface::IPositions;
-    use perpetuals::core::components::snip::SNIP12MetadataImpl;
-    use perpetuals::core::errors::Error::{
-        INVALID_AMOUNT_SIGN, INVALID_BASE_CHANGE, INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT,
-    };
     use perpetuals::core::types::asset::AssetId;
-    use perpetuals::core::types::asset::synthetic::{AssetBalanceDiffEnriched, AssetBalanceInfo};
-    use perpetuals::core::types::balance::{Balance, BalanceDiff};
+    use perpetuals::core::types::asset::synthetic::AssetBalanceInfo;
+    use perpetuals::core::types::balance::Balance;
     use perpetuals::core::types::funding::calculate_funding;
     use perpetuals::core::types::position::{
-        AssetBalance, AssetEnrichedPositionDiff, POSITION_VERSION, Position, PositionData,
-        PositionDiff, PositionDiffEnriched, PositionId, PositionMutableTrait, PositionTrait,
+        AssetBalance, POSITION_VERSION, Position, PositionData, PositionDiff, PositionId,
+        PositionMutableTrait, PositionTrait,
     };
     use perpetuals::core::types::set_owner_account::SetOwnerAccountArgs;
     use perpetuals::core::types::set_public_key::SetPublicKeyArgs;
     use perpetuals::core::value_risk_calculator::{
-        PositionState, PositionTVTR, assert_healthy_or_healthier, calculate_position_tvtr,
-        calculate_position_tvtr_before, calculate_position_tvtr_change, evaluate_position,
+        PositionState, PositionTVTR, calculate_position_tvtr, evaluate_position,
     };
     use starknet::storage::{
         Map, Mutable, StoragePath, StoragePathEntry, StoragePointerReadAccess,
@@ -54,6 +49,16 @@ pub mod Positions {
     };
     use starkware_utils::storage::utils::AddToStorage;
     use starkware_utils::time::time::{Timestamp, validate_expiration};
+    use crate::core::components::snip::SNIP12MetadataImpl;
+    use crate::core::errors::{
+        INVALID_AMOUNT_SIGN, INVALID_BASE_CHANGE, INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT,
+    };
+    use crate::core::types::asset::synthetic::AssetBalanceDiffEnriched;
+    use crate::core::types::balance::BalanceDiff;
+    use crate::core::types::position::{AssetEnrichedPositionDiff, PositionDiffEnriched};
+    use crate::core::value_risk_calculator::{
+        assert_healthy_or_healthier, calculate_position_tvtr_before, calculate_position_tvtr_change,
+    };
 
     pub const FEE_POSITION: PositionId = PositionId { value: 0 };
     pub const INSURANCE_FUND_POSITION: PositionId = PositionId { value: 1 };
@@ -649,8 +654,8 @@ pub mod Positions {
                 .get_synthetic_balance(:position, synthetic_id: asset_id)
                 .into();
 
-            assert!(!have_same_sign(amount, position_base_balance), "{}", INVALID_AMOUNT_SIGN);
-            assert!(amount.abs() <= position_base_balance.abs(), "{}", INVALID_BASE_CHANGE);
+            assert(!have_same_sign(amount, position_base_balance), INVALID_AMOUNT_SIGN);
+            assert(amount.abs() <= position_base_balance.abs(), INVALID_BASE_CHANGE);
         }
 
         fn _validate_imposed_reduction_trade(
@@ -664,14 +669,14 @@ pub mod Positions {
             quote_amount_a: i64,
         ) {
             // Validate positions.
-            assert!(position_id_a != position_id_b, "{}", INVALID_SAME_POSITIONS);
+            assert(position_id_a != position_id_b, INVALID_SAME_POSITIONS);
 
             // Non-zero amount check.
-            assert!(base_amount_a.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
-            assert!(quote_amount_a.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
+            assert(base_amount_a.is_non_zero(), INVALID_ZERO_AMOUNT);
+            assert(quote_amount_a.is_non_zero(), INVALID_ZERO_AMOUNT);
 
             // Sign Validation for amounts.
-            assert!(!have_same_sign(base_amount_a, quote_amount_a), "{}", INVALID_AMOUNT_SIGN);
+            assert(!have_same_sign(base_amount_a, quote_amount_a), INVALID_AMOUNT_SIGN);
 
             // Ensure that TR does not increase and that the base amount retains the same sign.
             self

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -84,7 +84,7 @@ pub(crate) mod TransferManager {
     use crate::core::components::external_components::named_component::ITypedComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
-    use crate::core::errors::Error::{INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT};
+    use crate::core::errors::{INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED};
     use crate::core::types::asset::synthetic::AssetType;
     use crate::core::types::position::PositionDiff;
     use crate::core::types::transfer::TransferArgs;
@@ -207,7 +207,7 @@ pub(crate) mod TransferManager {
 
             self.positions.get_position_snapshot(position_id: recipient);
             let position = self.positions.get_position_snapshot(:position_id);
-            assert!(amount.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
+            assert(amount.is_non_zero(), INVALID_ZERO_AMOUNT);
             let owner_account = if (position.owner_protection_enabled.read()) {
                 position.get_owner_account()
             } else {
@@ -262,8 +262,8 @@ pub(crate) mod TransferManager {
             expiration: Timestamp,
             salt: felt252,
         ) {
-            validate_expiration(:expiration, err: 'SIGNED_TX_EXPIRED');
-            assert!(recipient != position_id, "{}", INVALID_SAME_POSITIONS);
+            validate_expiration(:expiration, err: SIGNED_TX_EXPIRED);
+            assert(recipient != position_id, INVALID_SAME_POSITIONS);
             let position = self.positions.get_position_snapshot(:position_id);
             let hash = self
                 .request_approvals

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -63,17 +63,12 @@ pub(crate) mod WithdrawalManager {
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::Deposit::InternalImpl as DepositInternal;
-    use perpetuals::core::components::external_components::interface::EXTERNAL_COMPONENT_WITHDRAWALS;
-    use perpetuals::core::components::external_components::named_component::ITypedComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalImpl as OperatorNonceInternal;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
-    use perpetuals::core::components::snip::SNIP12MetadataImpl;
-    use perpetuals::core::errors::Error::{INVALID_ZERO_AMOUNT, TRANSFER_FAILED};
-    use perpetuals::core::types::position::{PositionDiff, PositionId, PositionTrait};
-    use perpetuals::core::types::withdraw::WithdrawArgs;
+    use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starknet::ContractAddress;
     use starknet::storage::StoragePointerReadAccess;
     use starkware_utils::components::pausable::PausableComponent;
@@ -85,6 +80,12 @@ pub(crate) mod WithdrawalManager {
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
     use starkware_utils::time::time::validate_expiration;
+    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_WITHDRAWALS;
+    use crate::core::components::external_components::named_component::ITypedComponent;
+    use crate::core::components::snip::SNIP12MetadataImpl;
+    use crate::core::errors::{INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED, TRANSFER_FAILED};
+    use crate::core::types::position::PositionDiff;
+    use crate::core::types::withdraw::WithdrawArgs;
     use super::{IWithdrawalManager, Signature, Timestamp, Withdraw, WithdrawRequest};
 
     impl SnipImpl = SNIP12MetadataImpl;
@@ -169,7 +170,7 @@ pub(crate) mod WithdrawalManager {
         ) {
             let position = self.positions.get_position_snapshot(:position_id);
             let collateral_id = self.assets.get_collateral_id();
-            assert!(amount.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
+            assert(amount.is_non_zero(), INVALID_ZERO_AMOUNT);
             let owner_account = if (position.owner_protection_enabled.read()) {
                 position.get_owner_account()
             } else {
@@ -207,7 +208,7 @@ pub(crate) mod WithdrawalManager {
             expiration: super::Timestamp,
             salt: felt252,
         ) {
-            validate_expiration(expiration: expiration, err: 'SIGNED_TX_EXPIRED');
+            validate_expiration(expiration: expiration, err: SIGNED_TX_EXPIRED);
             let collateral_id = self.assets.get_collateral_id();
             let position = self.positions.get_position_snapshot(:position_id);
             let hash = self
@@ -234,9 +235,8 @@ pub(crate) mod WithdrawalManager {
             let quantum = self.assets.get_collateral_quantum();
             let withdraw_unquantized_amount = quantum * amount;
             let token_contract = self.assets.get_collateral_token_contract();
-            assert!(
+            assert(
                 token_contract.transfer(:recipient, amount: withdraw_unquantized_amount.into()),
-                "{}",
                 TRANSFER_FAILED,
             );
 

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -15,7 +15,7 @@ pub mod Core {
     use perpetuals::core::components::positions::Positions::{
         FEE_POSITION, InternalTrait as PositionsInternalTrait,
     };
-    use perpetuals::core::errors::Error::{AMOUNT_OVERFLOW, SYNTHETIC_IS_ACTIVE};
+    use perpetuals::core::errors::{AMOUNT_OVERFLOW, SYNTHETIC_IS_ACTIVE};
     use perpetuals::core::events;
     use perpetuals::core::interface::{ICore, Settlement};
     use perpetuals::core::types::asset::{AssetId, AssetStatus};
@@ -35,7 +35,6 @@ pub mod Core {
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
     use starkware_utils::components::roles::RolesComponent::InternalTrait as RolesInternal;
-    use starkware_utils::errors::OptionAuxTrait;
     use starkware_utils::signature::stark::{PublicKey, Signature};
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
@@ -532,7 +531,7 @@ pub mod Core {
             // Validate base asset is inactive synthetic.
             if let Option::Some(config) = self.assets.asset_config.read(base_asset_id) {
                 assert(config.asset_type == AssetType::SYNTHETIC, NOT_SYNTHETIC);
-                assert!(config.status == AssetStatus::INACTIVE, "{}", SYNTHETIC_IS_ACTIVE);
+                assert(config.status == AssetStatus::INACTIVE, SYNTHETIC_IS_ACTIVE);
             } else {
                 panic_with_felt252(ASSET_NOT_EXISTS);
             }
@@ -543,7 +542,7 @@ pub mod Core {
                     .get_asset_price(asset_id: base_asset_id)
                     .mul(rhs: base_balance)
                     .try_into()
-                    .expect_with_err(AMOUNT_OVERFLOW);
+                    .expect(AMOUNT_OVERFLOW);
             self
                 .positions
                 ._validate_imposed_reduction_trade(

--- a/workspace/apps/perpetuals/contracts/src/core/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/errors.cairo
@@ -1,114 +1,85 @@
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::position::PositionId;
 use perpetuals::core::value_risk_calculator::TVTRChange;
-use starkware_utils::errors::{Describable, ErrorDisplay};
-#[derive(Drop)]
-pub enum Error {
-    // Simple error constants
-    AMOUNT_OVERFLOW,
-    ASSET_ID_NOT_COLLATERAL,
-    CANT_TRADE_WITH_FEE_POSITION,
-    CANT_LIQUIDATE_IF_POSITION,
-    DIFFERENT_BASE_ASSET_IDS,
-    INVALID_ACTUAL_BASE_SIGN,
-    INVALID_ACTUAL_QUOTE_SIGN,
-    INVALID_AMOUNT_SIGN,
-    INVALID_BASE_CHANGE,
-    INVALID_QUOTE_AMOUNT_SIGN,
-    INVALID_QUOTE_FEE_AMOUNT,
-    INVALID_SAME_POSITIONS,
-    INVALID_ZERO_AMOUNT,
-    SYNTHETIC_IS_ACTIVE,
-    TRANSFER_FAILED,
-    SAME_BASE_QUOTE_ASSET_IDS,
-    // Error functions with parameters
-    FULFILLMENT_EXCEEDED: PositionId,
-    ILLEGAL_BASE_TO_QUOTE_RATIO: PositionId,
-    ILLEGAL_FEE_TO_QUOTE_RATIO: PositionId,
-    INVALID_FUNDING_RATE: AssetId,
-    ORDER_EXPIRED: PositionId,
-    POSITION_NOT_DELEVERAGABLE: (PositionId, TVTRChange),
-    POSITION_NOT_FAIR_DELEVERAGE: (PositionId, TVTRChange),
-    POSITION_NOT_HEALTHY_NOR_HEALTHIER: (PositionId, TVTRChange),
-    POSITION_NOT_LIQUIDATABLE: (PositionId, TVTRChange),
+
+pub const AMOUNT_OVERFLOW: felt252 = 'AMOUNT_OVERFLOW';
+pub const ASSET_ID_NOT_COLLATERAL: felt252 = 'QUOTE_ASSET_ID_NOT_COLLATERAL';
+pub const CANT_TRADE_WITH_FEE_POSITION: felt252 = 'CANT_TRADE_WITH_FEE_POSITION';
+pub const CANT_LIQUIDATE_IF_POSITION: felt252 = 'CANT_LIQUIDATE_IF_POSITION';
+pub const DIFFERENT_BASE_ASSET_IDS: felt252 = 'DIFFERENT_BASE_ASSET_IDS';
+pub const INVALID_ACTUAL_BASE_SIGN: felt252 = 'INVALID_ACTUAL_BASE_SIGN';
+pub const INVALID_ACTUAL_QUOTE_SIGN: felt252 = 'INVALID_ACTUAL_QUOTE_SIGN';
+pub const INVALID_AMOUNT_SIGN: felt252 = 'INVALID_AMOUNT_SIGN';
+pub const INVALID_BASE_CHANGE: felt252 = 'INVALID_BASE_CHANGE';
+pub const INVALID_QUOTE_AMOUNT_SIGN: felt252 = 'INVALID_QUOTE_AMOUNT_SIGN';
+pub const INVALID_QUOTE_FEE_AMOUNT: felt252 = 'INVALID_QUOTE_FEE_AMOUNT';
+pub const INVALID_SAME_POSITIONS: felt252 = 'INVALID_SAME_POSITIONS';
+pub const INVALID_ZERO_AMOUNT: felt252 = 'INVALID_ZERO_AMOUNT';
+pub const SIGNED_TX_EXPIRED: felt252 = 'SIGNED_TX_EXPIRED';
+pub const SYNTHETIC_IS_ACTIVE: felt252 = 'SYNTHETIC_IS_ACTIVE';
+pub const TRANSFER_FAILED: felt252 = 'TRANSFER_FAILED';
+pub const SAME_BASE_QUOTE_ASSET_IDS: felt252 = 'SAME_BASE_QUOTE_ASSET_IDS';
+
+pub fn fulfillment_exceeded_err(position_id: PositionId) -> ByteArray {
+    format!("FULFILLMENT_EXCEEDED position_id: {:?}", position_id)
 }
 
-impl DescribableError of Describable<Error> {
-    fn describe(self: @Error) -> ByteArray {
-        match self {
-            // Simple error constants
-            Error::AMOUNT_OVERFLOW => "AMOUNT_OVERFLOW",
-            Error::ASSET_ID_NOT_COLLATERAL => "QUOTE_ASSET_ID_NOT_COLLATERAL",
-            Error::CANT_TRADE_WITH_FEE_POSITION => "CANT_TRADE_WITH_FEE_POSITION",
-            Error::CANT_LIQUIDATE_IF_POSITION => "CANT_LIQUIDATE_IF_POSITION",
-            Error::DIFFERENT_BASE_ASSET_IDS => "DIFFERENT_BASE_ASSET_IDS",
-            Error::INVALID_ACTUAL_BASE_SIGN => "INVALID_ACTUAL_BASE_SIGN",
-            Error::INVALID_ACTUAL_QUOTE_SIGN => "INVALID_ACTUAL_QUOTE_SIGN",
-            Error::INVALID_AMOUNT_SIGN => "INVALID_AMOUNT_SIGN",
-            Error::INVALID_BASE_CHANGE => "INVALID_BASE_CHANGE",
-            Error::INVALID_QUOTE_AMOUNT_SIGN => "INVALID_QUOTE_AMOUNT_SIGN",
-            Error::INVALID_QUOTE_FEE_AMOUNT => "INVALID_QUOTE_FEE_AMOUNT",
-            Error::INVALID_SAME_POSITIONS => "INVALID_SAME_POSITIONS",
-            Error::INVALID_ZERO_AMOUNT => "INVALID_ZERO_AMOUNT",
-            Error::SYNTHETIC_IS_ACTIVE => "SYNTHETIC_IS_ACTIVE",
-            Error::TRANSFER_FAILED => "TRANSFER_FAILED",
-            Error::SAME_BASE_QUOTE_ASSET_IDS => "SAME_BASE_QUOTE_ASSET_IDS",
-            // Error functions with parameters
-            Error::FULFILLMENT_EXCEEDED(position_id) => format!(
-                "FULFILLMENT_EXCEEDED position_id: {:?}", *position_id,
-            ),
-            Error::ILLEGAL_BASE_TO_QUOTE_RATIO(position_id) => format!(
-                "ILLEGAL_BASE_TO_QUOTE_RATIO position_id: {:?}", *position_id,
-            ),
-            Error::ILLEGAL_FEE_TO_QUOTE_RATIO(position_id) => format!(
-                "ILLEGAL_FEE_TO_QUOTE_RATIO position_id: {:?}", *position_id,
-            ),
-            Error::INVALID_FUNDING_RATE(synthetic_id) => format!(
-                "INVALID_FUNDING_RATE synthetic_id: {:?}", *synthetic_id,
-            ),
-            Error::ORDER_EXPIRED(position_id) => format!(
-                "ORDER_EXPIRED position_id: {:?}", *position_id,
-            ),
-            Error::POSITION_NOT_DELEVERAGABLE((
-                position_id, tvtr,
-            )) => format!(
-                "POSITION_IS_NOT_DELEVERAGABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-                *position_id,
-                *tvtr.before.total_value,
-                *tvtr.before.total_risk,
-                *tvtr.after.total_value,
-                *tvtr.after.total_risk,
-            ),
-            Error::POSITION_NOT_FAIR_DELEVERAGE((
-                position_id, tvtr,
-            )) => format!(
-                "POSITION_IS_NOT_FAIR_DELEVERAGE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-                *position_id,
-                *tvtr.before.total_value,
-                *tvtr.before.total_risk,
-                *tvtr.after.total_value,
-                *tvtr.after.total_risk,
-            ),
-            Error::POSITION_NOT_HEALTHY_NOR_HEALTHIER((
-                position_id, tvtr,
-            )) => format!(
-                "POSITION_NOT_HEALTHY_NOR_HEALTHIER position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-                *position_id,
-                *tvtr.before.total_value,
-                *tvtr.before.total_risk,
-                *tvtr.after.total_value,
-                *tvtr.after.total_risk,
-            ),
-            Error::POSITION_NOT_LIQUIDATABLE((
-                position_id, tvtr,
-            )) => format!(
-                "POSITION_IS_NOT_LIQUIDATABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
-                *position_id,
-                *tvtr.before.total_value,
-                *tvtr.before.total_risk,
-                *tvtr.after.total_value,
-                *tvtr.after.total_risk,
-            ),
-        }
-    }
+pub fn illegal_base_to_quote_ratio_err(position_id: PositionId) -> ByteArray {
+    format!("ILLEGAL_BASE_TO_QUOTE_RATIO position_id: {:?}", position_id)
+}
+
+pub fn illegal_fee_to_quote_ratio_err(position_id: PositionId) -> ByteArray {
+    format!("ILLEGAL_FEE_TO_QUOTE_RATIO position_id: {:?}", position_id)
+}
+
+pub fn invalid_funding_rate_err(synthetic_id: AssetId) -> ByteArray {
+    format!("INVALID_FUNDING_RATE synthetic_id: {:?}", synthetic_id)
+}
+
+pub fn order_expired_err(position_id: PositionId) -> ByteArray {
+    format!("ORDER_EXPIRED position_id: {:?}", position_id)
+}
+
+pub fn position_not_deleveragable(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
+    format!(
+        "POSITION_IS_NOT_DELEVERAGABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+        position_id,
+        tvtr.before.total_value,
+        tvtr.before.total_risk,
+        tvtr.after.total_value,
+        tvtr.after.total_risk,
+    )
+}
+
+pub fn position_not_fair_deleverage(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
+    format!(
+        "POSITION_IS_NOT_FAIR_DELEVERAGE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+        position_id,
+        tvtr.before.total_value,
+        tvtr.before.total_risk,
+        tvtr.after.total_value,
+        tvtr.after.total_risk,
+    )
+}
+
+pub fn position_not_healthy_nor_healthier(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
+    format!(
+        "POSITION_NOT_HEALTHY_NOR_HEALTHIER position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+        position_id,
+        tvtr.before.total_value,
+        tvtr.before.total_risk,
+        tvtr.after.total_value,
+        tvtr.after.total_risk,
+    )
+}
+
+pub fn position_not_liquidatable(position_id: PositionId, tvtr: TVTRChange) -> ByteArray {
+    format!(
+        "POSITION_IS_NOT_LIQUIDATABLE position_id: {:?} TV before {:?}, TR before {:?}, TV after {:?}, TR after {:?}",
+        position_id,
+        tvtr.before.total_value,
+        tvtr.before.total_risk,
+        tvtr.after.total_value,
+        tvtr.after.total_risk,
+    )
 }

--- a/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/funding.cairo
@@ -1,5 +1,6 @@
 use core::num::traits::{Pow, Zero};
-use perpetuals::core::errors::Error::INVALID_FUNDING_RATE;
+use core::panics::panic_with_byte_array;
+use perpetuals::core::errors::invalid_funding_rate_err;
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::balance::{Balance, BalanceTrait};
 use perpetuals::core::types::price::{Price, PriceMulTrait};
@@ -122,11 +123,10 @@ pub fn validate_funding_rate(
     time_diff: u64,
     synthetic_price: Price,
 ) {
-    assert!(
-        index_diff.into() <= synthetic_price.mul(rhs: max_funding_rate) * time_diff.into(),
-        "{}",
-        INVALID_FUNDING_RATE(synthetic_id),
-    );
+    if (index_diff.into() > synthetic_price.mul(rhs: max_funding_rate) * time_diff.into()) {
+        let err = invalid_funding_rate_err(:synthetic_id);
+        panic_with_byte_array(err: @err);
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/core/utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/utils.cairo
@@ -1,21 +1,24 @@
 use core::num::traits::Zero;
 use core::panic_with_felt252;
-use perpetuals::core::components::assets::errors::{SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS};
+use core::panics::panic_with_byte_array;
 use perpetuals::core::components::positions::Positions::FEE_POSITION;
-use perpetuals::core::errors::Error::{
-    ASSET_ID_NOT_COLLATERAL, CANT_TRADE_WITH_FEE_POSITION, DIFFERENT_BASE_ASSET_IDS,
-    INVALID_ACTUAL_BASE_SIGN, INVALID_ACTUAL_QUOTE_SIGN, INVALID_AMOUNT_SIGN,
-    INVALID_QUOTE_AMOUNT_SIGN, INVALID_QUOTE_FEE_AMOUNT, INVALID_SAME_POSITIONS,
-    INVALID_ZERO_AMOUNT, ORDER_EXPIRED,
+use perpetuals::core::errors::{
+    CANT_TRADE_WITH_FEE_POSITION, DIFFERENT_BASE_ASSET_IDS, INVALID_QUOTE_FEE_AMOUNT,
+    INVALID_ZERO_AMOUNT,
 };
-use perpetuals::core::types::asset::synthetic::AssetConfig;
-use perpetuals::core::types::asset::{AssetId, AssetStatus};
-use perpetuals::core::types::order::ValidateableOrderTrait;
 use starkware_utils::hash::message_hash::OffchainMessageHash;
 use starkware_utils::math::abs::Abs;
 use starkware_utils::math::utils::have_same_sign;
 use starkware_utils::signature::stark::{HashType, PublicKey, Signature, validate_stark_signature};
 use starkware_utils::time::time::Time;
+use super::components::assets::errors::{SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS};
+use super::errors::{
+    ASSET_ID_NOT_COLLATERAL, INVALID_ACTUAL_BASE_SIGN, INVALID_ACTUAL_QUOTE_SIGN,
+    INVALID_AMOUNT_SIGN, INVALID_QUOTE_AMOUNT_SIGN, INVALID_SAME_POSITIONS, order_expired_err,
+};
+use super::types::asset::synthetic::AssetConfig;
+use super::types::asset::{AssetId, AssetStatus};
+use super::types::order::ValidateableOrderTrait;
 
 pub fn validate_signature<T, +Drop<T>, +Copy<T>, +OffchainMessageHash<T>>(
     public_key: PublicKey, message: T, signature: Signature,
@@ -36,7 +39,7 @@ pub fn validate_trade<T, impl TValidateableOrder: ValidateableOrderTrait<T>, +Dr
     collateral_id: AssetId,
 ) {
     // Base asset check.
-    assert!(order_a.base_asset_id() == order_b.base_asset_id(), "{}", DIFFERENT_BASE_ASSET_IDS);
+    assert(order_a.base_asset_id() == order_b.base_asset_id(), DIFFERENT_BASE_ASSET_IDS);
 
     match asset {
         None => panic_with_felt252(SYNTHETIC_NOT_EXISTS),
@@ -45,28 +48,22 @@ pub fn validate_trade<T, impl TValidateableOrder: ValidateableOrderTrait<T>, +Dr
         ),
     }
 
-    assert!(order_a.position_id() != order_b.position_id(), "{}", INVALID_SAME_POSITIONS);
+    assert(order_a.position_id() != order_b.position_id(), INVALID_SAME_POSITIONS);
 
     validate_order(order: order_a, collateral_id: collateral_id);
     validate_order(order: order_b, collateral_id: collateral_id);
 
     // Non-zero actual amount check.
-    assert!(actual_amount_base_a.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
-    assert!(actual_amount_quote_a.is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
+    assert(actual_amount_base_a.is_non_zero(), INVALID_ZERO_AMOUNT);
+    assert(actual_amount_quote_a.is_non_zero(), INVALID_ZERO_AMOUNT);
 
     // Sign Validation for amounts.
-    assert!(
-        !have_same_sign(order_a.quote_amount(), order_b.quote_amount()),
-        "{}",
-        INVALID_QUOTE_AMOUNT_SIGN,
+    assert(
+        !have_same_sign(order_a.quote_amount(), order_b.quote_amount()), INVALID_QUOTE_AMOUNT_SIGN,
     );
-    assert!(
-        have_same_sign(order_a.base_amount(), actual_amount_base_a), "{}", INVALID_ACTUAL_BASE_SIGN,
-    );
-    assert!(
-        have_same_sign(order_a.quote_amount(), actual_amount_quote_a),
-        "{}",
-        INVALID_ACTUAL_QUOTE_SIGN,
+    assert(have_same_sign(order_a.base_amount(), actual_amount_base_a), INVALID_ACTUAL_BASE_SIGN);
+    assert(
+        have_same_sign(order_a.quote_amount(), actual_amount_quote_a), INVALID_ACTUAL_QUOTE_SIGN,
     );
 
     order_a
@@ -88,21 +85,24 @@ pub fn validate_order<T, impl TValidateableOrder: ValidateableOrderTrait<T>, +Dr
     order: T, collateral_id: AssetId,
 ) {
     // Verify that position is not fee position.
-    assert!(order.position_id() != FEE_POSITION, "{}", CANT_TRADE_WITH_FEE_POSITION);
+    assert(order.position_id() != FEE_POSITION, CANT_TRADE_WITH_FEE_POSITION);
     // This is to make sure that the fee is relative to the quote amount.
-    assert!(order.quote_amount().abs() > order.fee_amount(), "{}", INVALID_QUOTE_FEE_AMOUNT);
+    assert(order.quote_amount().abs() > order.fee_amount(), INVALID_QUOTE_FEE_AMOUNT);
     // Non-zero amount check.
-    assert!(order.base_amount().is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
-    assert!(order.quote_amount().is_non_zero(), "{}", INVALID_ZERO_AMOUNT);
+    assert(order.base_amount().is_non_zero(), INVALID_ZERO_AMOUNT);
+    assert(order.quote_amount().is_non_zero(), INVALID_ZERO_AMOUNT);
 
     // Expiration check.
     let now = Time::now();
-    assert!(now <= order.expiration(), "{}", ORDER_EXPIRED(order.position_id()));
+    if (now > order.expiration()) {
+        let err = order_expired_err(order.position_id());
+        panic_with_byte_array(err: @err);
+    }
 
     // Sign Validation for amounts.
-    assert!(!have_same_sign(order.quote_amount(), order.base_amount()), "{}", INVALID_AMOUNT_SIGN);
+    assert(!have_same_sign(order.quote_amount(), order.base_amount()), INVALID_AMOUNT_SIGN);
 
     // Validate asset ids.
-    assert!(order.quote_asset_id() == collateral_id, "{}", ASSET_ID_NOT_COLLATERAL);
-    assert!(order.fee_asset_id() == collateral_id, "{}", ASSET_ID_NOT_COLLATERAL);
+    assert(order.quote_asset_id() == collateral_id, ASSET_ID_NOT_COLLATERAL);
+    assert(order.fee_asset_id() == collateral_id, ASSET_ID_NOT_COLLATERAL);
 }

--- a/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
@@ -1,7 +1,8 @@
 use core::num::traits::{One, Zero};
-use perpetuals::core::errors::Error::{
-    POSITION_NOT_DELEVERAGABLE, POSITION_NOT_FAIR_DELEVERAGE, POSITION_NOT_HEALTHY_NOR_HEALTHIER,
-    POSITION_NOT_LIQUIDATABLE,
+use core::panics::panic_with_byte_array;
+use perpetuals::core::errors::{
+    position_not_deleveragable, position_not_fair_deleverage, position_not_healthy_nor_healthier,
+    position_not_liquidatable,
 };
 use perpetuals::core::types::asset::synthetic::AssetBalanceInfo;
 use perpetuals::core::types::balance::{Balance, BalanceDiff};
@@ -20,7 +21,7 @@ const EPSILON: i128 = 1_i128;
 /// Represents the state of a position based on its total value and total risk.
 /// - A position is **Deleveragable** (and also **Liquidatable**) if its total value is negative.
 /// - A position is **Liquidatable** if its total value is less than its total risk.
-/// - Otherwise, the position is considered **Healthy**.
+/// - Otherwise, the position is considered **Healthy**.clear
 #[derive(Copy, Drop, Debug, PartialEq, Serde)]
 pub enum PositionState {
     Healthy,
@@ -89,11 +90,9 @@ pub fn assert_healthy_or_healthier(position_id: PositionId, tvtr: TVTRChange) {
         return;
     }
 
-    assert!(
-        tvtr.before.total_risk.is_non_zero() && tvtr.after.total_risk.is_non_zero(),
-        "{}",
-        POSITION_NOT_HEALTHY_NOR_HEALTHIER((position_id, tvtr)),
-    );
+    if tvtr.before.total_risk.is_zero() || tvtr.after.total_risk.is_zero() {
+        panic_with_byte_array(@position_not_healthy_nor_healthier(:position_id, :tvtr));
+    }
 
     /// This is checked only when the after is not healthy:
     /// The position is healthier if the total_value divided by the total_risk
@@ -101,17 +100,16 @@ pub fn assert_healthy_or_healthier(position_id: PositionId, tvtr: TVTRChange) {
     /// Formal definition:
     /// total_value_after / total_risk_after >= total_value_before / total_risk_before
     /// AND total_risk_after < total_risk_before.
-    assert!(
-        tvtr.after.total_risk < tvtr.before.total_risk,
-        "{}",
-        POSITION_NOT_HEALTHY_NOR_HEALTHIER((position_id, tvtr)),
-    );
+    if tvtr.after.total_risk >= tvtr.before.total_risk {
+        panic_with_byte_array(@position_not_healthy_nor_healthier(:position_id, :tvtr));
+    }
     let before_ratio = FractionTrait::new(tvtr.before.total_value, tvtr.before.total_risk);
     let after_ratio = FractionTrait::new(tvtr.after.total_value, tvtr.after.total_risk);
 
-    assert!(
-        after_ratio >= before_ratio, "{}", POSITION_NOT_HEALTHY_NOR_HEALTHIER((position_id, tvtr)),
-    );
+    if (after_ratio < before_ratio) {
+        let err = position_not_healthy_nor_healthier(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
 }
 
 pub fn liquidated_position_validations(
@@ -126,12 +124,12 @@ pub fn liquidated_position_validations(
     let position_state_before_change = get_position_state(position_tvtr: tvtr.before);
 
     // Validate that the position isn't healthy before the change.
-    assert!(
-        position_state_before_change == PositionState::Liquidatable
-            || position_state_before_change == PositionState::Deleveragable,
-        "{}",
-        POSITION_NOT_LIQUIDATABLE((position_id, tvtr)),
-    );
+    let condition = position_state_before_change == PositionState::Liquidatable
+        || position_state_before_change == PositionState::Deleveragable;
+    if (!condition) {
+        let err = position_not_liquidatable(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
     assert_healthy_or_healthier(:position_id, :tvtr);
 }
 
@@ -146,18 +144,16 @@ pub fn deleveraged_position_validations(
     );
     let position_state_before_change = get_position_state(position_tvtr: tvtr.before);
 
-    assert!(
-        position_state_before_change == PositionState::Deleveragable,
-        "{}",
-        POSITION_NOT_DELEVERAGABLE((position_id, tvtr)),
-    );
+    if (position_state_before_change != PositionState::Deleveragable) {
+        let err = position_not_deleveragable(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
 
     assert_healthy_or_healthier(:position_id, :tvtr);
-    assert!(
-        is_fair_deleverage(before: tvtr.before, after: tvtr.after),
-        "{}",
-        POSITION_NOT_FAIR_DELEVERAGE((position_id, tvtr)),
-    );
+    if (!is_fair_deleverage(before: tvtr.before, after: tvtr.after)) {
+        let err = position_not_fair_deleverage(:position_id, :tvtr);
+        panic_with_byte_array(err: @err);
+    }
 }
 
 pub fn calculate_position_tvtr(

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -136,7 +136,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position() {
 
 #[test]
 #[should_panic(expected: "ILLEGAL_BASE_TO_QUOTE_RATIO position_id: PositionId { value: 555 }")]
-fn test_redeem_from_protocol_vault_unfair_user_redeem() {
+fn test_redeem_from_protocol_vault_unfair__user_redeem() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position_id(555_u32.into());
@@ -186,7 +186,7 @@ fn test_redeem_from_protocol_vault_unfair_user_redeem() {
 
 #[test]
 #[should_panic(expected: "ILLEGAL_BASE_TO_QUOTE_RATIO position_id: PositionId { value: 333 }")]
-fn test_redeem_from_protocol_vault_unfair_vault_redeem() {
+fn test_redeem_from_protocol_vault_unfair__vault_redeem() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let vault_user = state.new_user_with_position_id(333_u32.into());
     let redeeming_user = state.new_user_with_position_id(555_u32.into());

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -2143,7 +2143,7 @@ fn test_late_funding() {
 }
 
 #[test]
-#[should_panic(expected: "INVALID_BASE_CHANGE")]
+#[should_panic(expected: 'INVALID_BASE_CHANGE')]
 fn test_liquidate_change_sign() {
     // Setup.
     let risk_factor_data = RiskFactorTiers {

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -14,6 +14,7 @@ use perpetuals::core::components::positions::interface::{
     IPositions, IPositionsDispatcher, IPositionsDispatcherTrait,
 };
 use perpetuals::core::components::snip::SNIP12MetadataImpl;
+use perpetuals::core::errors::SIGNED_TX_EXPIRED;
 use perpetuals::core::interface::{ICore, ICoreSafeDispatcher, ICoreSafeDispatcherTrait};
 use perpetuals::core::types::asset::AssetStatus;
 use perpetuals::core::types::funding::{FUNDING_SCALE, FundingIndex, FundingTick};
@@ -217,7 +218,7 @@ fn test_expiration_validation() {
             expiration: withdraw_args.expiration,
             salt: withdraw_args.salt,
         );
-    assert_panic_with_felt_error(:result, expected_error: 'SIGNED_TX_EXPIRED');
+    assert_panic_with_felt_error(:result, expected_error: SIGNED_TX_EXPIRED);
 }
 
 #[test]
@@ -2336,7 +2337,7 @@ fn test_successful_trade() {
 }
 
 #[test]
-#[should_panic(expected: "INVALID_AMOUNT_SIGN")]
+#[should_panic(expected: 'INVALID_AMOUNT_SIGN')]
 fn test_invalid_trade_same_base_signs() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();
@@ -3048,7 +3049,7 @@ fn test_successful_transfer() {
 }
 
 #[test]
-#[should_panic(expected: "INVALID_ZERO_AMOUNT")]
+#[should_panic(expected: 'INVALID_ZERO_AMOUNT')]
 fn test_invalid_transfer_request_amount_is_zero() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();


### PR DESCRIPTION
This reverts commit 176e721cff6683c64f060bb0ada793bc87bc997a.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to felt-based error constants and explicit byte-array panic messages, updating assertions/validations across core components and aligning tests with new error formats.
> 
> - **Errors**:
>   - Replace `Error` enum/Describable with felt constants in `core/errors.cairo` and helper formatters (e.g., `order_expired_err`, `fulfillment_exceeded_err`).
>   - Remove enum-based describe logic; introduce ByteArray message constructors.
> - **Core logic updates**:
>   - Convert `assert!(..., "{}", ERR(..))` to `assert(cond, ERR_CONST)` or `panic_with_byte_array` in:
>     - `components/fulfillment`, `liquidation/liquidation_manager`, `positions`, `transfer/transfer_manager`, `withdrawal/withdrawal_manager`, `vaults/vaults_contract`.
>     - `types/order`: ratio validations now panic with formatted ByteArray.
>     - `types/funding`: `validate_funding_rate` panics with formatted error.
>     - `utils`: order/trade validation uses constants and `order_expired_err`.
>     - `value_risk_calculator`: validations panic with formatted messages.
>     - `core/core.cairo`: use constants in inactive-asset reduction and `expect(AMOUNT_OVERFLOW)`.
> - **Tests**:
>   - Update expected panic strings (single-quoted where needed) and messages to match new constants and formatted errors.
>   - Minor test name tweaks to reflect message changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f91652edad8aa043095a525dc41725cda72dbfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/145)
<!-- Reviewable:end -->
