### PR TITLE
refactor(perps): reduce contract size

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets.cairo
@@ -1,4 +1,5 @@
 pub(crate) mod assets;
+pub(crate) mod assets_manager;
 pub(crate) mod errors;
 pub(crate) mod events;
 pub mod interface;

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -6,26 +6,20 @@ pub mod AssetsComponent {
     use core::panic_with_felt252;
     use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
-    use openzeppelin::interfaces::erc20::{
-        IERC20Dispatcher, IERC20MetadataDispatcher, IERC20MetadataDispatcherTrait,
-    };
+    use openzeppelin::interfaces::erc20::IERC20Dispatcher;
     use openzeppelin::introspection::src5::SRC5Component;
+    use perpetuals::core::components::assets::assets_manager::IAssetsExternalDispatcherTrait;
     use perpetuals::core::components::assets::errors::{
-        ALREADY_INITIALIZED, ASSET_NAME_TOO_LONG, ASSET_NOT_EXISTS, ASSET_REGISTERED_AS_COLLATERAL,
-        COLLATERAL_NOT_REGISTERED, FUNDING_EXPIRED, FUNDING_TICKS_NOT_SORTED, INACTIVE_ASSET,
-        INVALID_FUNDING_TICK_LEN, INVALID_MEDIAN, INVALID_PRICE_TIMESTAMP, INVALID_RF_VALUE,
-        INVALID_SAME_QUORUM, INVALID_TIMESTAMP, INVALID_ZERO_ASSET_ID, INVALID_ZERO_ASSET_NAME,
-        INVALID_ZERO_ORACLE_NAME, INVALID_ZERO_PUBLIC_KEY, INVALID_ZERO_QUANTUM,
-        INVALID_ZERO_QUORUM, INVALID_ZERO_RESOLUTION_FACTOR, INVALID_ZERO_RF_FIRST_BOUNDRY,
-        INVALID_ZERO_RF_TIERS_LEN, INVALID_ZERO_RF_TIER_SIZE, INVALID_ZERO_TOKEN_ADDRESS,
-        NOT_SYNTHETIC, ORACLE_ALREADY_EXISTS, ORACLE_NAME_TOO_LONG, ORACLE_NOT_EXISTS,
-        QUORUM_NOT_REACHED, SIGNED_PRICES_UNSORTED, SYNTHETIC_ALREADY_EXISTS,
+        ALREADY_INITIALIZED, ASSET_NOT_EXISTS, COLLATERAL_NOT_REGISTERED, FUNDING_EXPIRED,
+        FUNDING_TICKS_NOT_SORTED, INACTIVE_ASSET, INVALID_FUNDING_TICK_LEN, INVALID_MEDIAN,
+        INVALID_PRICE_TIMESTAMP, INVALID_TIMESTAMP, INVALID_ZERO_ASSET_ID, INVALID_ZERO_QUANTUM,
+        INVALID_ZERO_TOKEN_ADDRESS, NOT_SYNTHETIC, QUORUM_NOT_REACHED, SIGNED_PRICES_UNSORTED,
         SYNTHETIC_EXPIRED_PRICE, SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS,
-        UNSORTED_RISK_FACTOR_TIERS, ZERO_MAX_FUNDING_INTERVAL, ZERO_MAX_FUNDING_RATE,
-        ZERO_MAX_ORACLE_PRICE, ZERO_MAX_PRICE_INTERVAL, oracle_public_key_not_registered,
+        ZERO_MAX_FUNDING_INTERVAL, ZERO_MAX_FUNDING_RATE, ZERO_MAX_ORACLE_PRICE,
+        ZERO_MAX_PRICE_INTERVAL, oracle_public_key_not_registered,
     };
     use perpetuals::core::components::assets::events;
-    use perpetuals::core::components::assets::interface::IAssets;
+    use perpetuals::core::components::assets::interface::{IAssets, IAssetsManager};
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalTrait as NonceInternal;
     use perpetuals::core::types::asset::synthetic::{
@@ -46,16 +40,22 @@ pub mod AssetsComponent {
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalTrait as PausableInternal;
     use starkware_utils::components::roles::RolesComponent;
-    use starkware_utils::constants::{MINUTE, TWO_POW_128, TWO_POW_32, TWO_POW_40};
+    use starkware_utils::constants::{MINUTE, TWO_POW_32};
     use starkware_utils::math::abs::Abs;
     use starkware_utils::signature::stark::{PublicKey, validate_stark_signature};
     use starkware_utils::storage::iterable_map::{
         IterableMap, IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapTrait,
         IterableMapWriteAccessImpl,
     };
-    use starkware_utils::storage::utils::{AddToStorage, SubFromStorage};
+    use starkware_utils::storage::utils::AddToStorage;
     use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
-    use crate::core::types::price::SN_PERPS_SCALE;
+    use crate::core::components::assets::errors::{
+        ASSET_REGISTERED_AS_COLLATERAL, INVALID_RF_VALUE, INVALID_ZERO_RF_FIRST_BOUNDRY,
+        INVALID_ZERO_RF_TIERS_LEN, INVALID_ZERO_RF_TIER_SIZE, UNSORTED_RISK_FACTOR_TIERS,
+    };
+    use crate::core::components::external_components::external_component_manager::ExternalComponents as ExternalComponentsComponent;
+    use crate::core::components::external_components::external_component_manager::ExternalComponents::InternalTrait as ExternalComponentsInternalTrait;
+
 
     const MAX_TIME: u64 = 2_u64.pow(56);
 
@@ -111,260 +111,6 @@ pub mod AssetsComponent {
         impl Pausable: PausableComponent::HasComponent<TContractState>,
         impl Roles: RolesComponent::HasComponent<TContractState>,
     > of IAssets<ComponentState<TContractState>> {
-        /// Add oracle to a synthetic asset.
-        ///
-        /// Validations:
-        /// - Only the app governor can call this function.
-        /// - The 'oracle_public_key' does not exist in the Oracle map.
-        /// - The size of 'oracle_name' is 40 bits.
-        /// - The size of 'asset_name' is 128 bits.
-        ///
-        /// Execution:
-        /// - Add a new entry to the Oracle map.
-        fn add_oracle_to_asset(
-            ref self: ComponentState<TContractState>,
-            asset_id: AssetId,
-            oracle_public_key: PublicKey,
-            oracle_name: felt252,
-            asset_name: felt252,
-        ) {
-            get_dep_component!(@self, Roles).only_app_governor();
-
-            let asset_config = self._get_asset_config(synthetic_id: asset_id);
-            assert(asset_config.status != AssetStatus::INACTIVE, INACTIVE_ASSET);
-
-            // Validate the oracle does not exist.
-            let asset_oracle_entry = self.asset_oracle.entry(asset_id).entry(oracle_public_key);
-            let asset_oracle_data = asset_oracle_entry.read();
-            assert(asset_oracle_data.is_zero(), ORACLE_ALREADY_EXISTS);
-
-            assert(oracle_public_key.is_non_zero(), INVALID_ZERO_PUBLIC_KEY);
-            assert(asset_name.is_non_zero(), INVALID_ZERO_ASSET_NAME);
-            assert(oracle_name.is_non_zero(), INVALID_ZERO_ORACLE_NAME);
-
-            // Validate the size of the oracle name.
-            if let Option::Some(oracle_name) = oracle_name.try_into() {
-                assert(oracle_name < TWO_POW_40, ORACLE_NAME_TOO_LONG);
-            } else {
-                panic_with_felt252(ORACLE_NAME_TOO_LONG);
-            }
-
-            // Validate the size of the asset name.
-            assert(asset_name.into() < TWO_POW_128, ASSET_NAME_TOO_LONG);
-
-            // Add the oracle to the asset.
-            let shifted_asset_name = TWO_POW_40.into() * asset_name;
-            asset_oracle_entry.write(shifted_asset_name + oracle_name);
-
-            self.emit(events::OracleAdded { asset_id, asset_name, oracle_public_key, oracle_name });
-        }
-
-        /// Add asset is called by the app governer to add a new synthetic asset.
-        ///
-        /// Validations:
-        /// - Only the app_governor can call this function.
-        /// - The asset does not exists.
-        /// - Each risk factor in risk_factor_tiers is less or equal to 1000.
-        /// - The quorum is greater than 0.
-        ///
-        /// Execution:
-        /// - Add new entry to asset_config.
-        ///     - Set the asset as in-active.
-        /// - Add a new entry at the beginning of timely_data
-        ///     - Set the price to zero.
-        ///     - Set the funding index to zero.
-        ///     - Set the `last_price_update` to zero.
-        ///
-        /// Risk factor tiers example:
-        /// - risk_factor_tiers = [10, 20, 30, 50, 100, 200, 400]
-        /// - risk_factor_first_tier_boundary = 10,000
-        /// - risk_factor_tier_size = 20,000
-        /// which means:
-        /// - [0, 10,000) -> 1%
-        /// - [10,000, 30,000) -> 2%
-        /// - [30,000, 50,000) -> 3%
-        /// - [50,000, 70,000) -> 5%
-        /// - [70,000, 90,000) -> 10%
-        /// - [90,000, 110,000) -> 20%
-        /// - [110,000, MAX) -> 40%
-        fn add_synthetic_asset(
-            ref self: ComponentState<TContractState>,
-            asset_id: AssetId,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
-            quorum: u8,
-            resolution_factor: u64,
-        ) {
-            // resolution_factor: u64,
-            // asset_type: AssetType,
-            // quantum: u64,
-            // erc20_address: ContractAddress,
-
-            self
-                ._add_asset(
-                    asset_id,
-                    risk_factor_tiers,
-                    risk_factor_first_tier_boundary,
-                    risk_factor_tier_size,
-                    quorum,
-                    resolution_factor,
-                    AssetType::SYNTHETIC,
-                    0,
-                    None,
-                )
-        }
-
-        fn add_vault_collateral_asset(
-            ref self: ComponentState<TContractState>,
-            asset_id: AssetId,
-            erc20_contract_address: ContractAddress,
-            quantum: u64,
-            resolution_factor: u64,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
-            quorum: u8,
-        ) {
-            get_dep_component!(@self, Roles).only_app_governor();
-
-            assert(quantum == 1, 'INVALID_SHARE_QUANTUM');
-            let erc20Contract = IERC20MetadataDispatcher {
-                contract_address: erc20_contract_address,
-            };
-            let underlying_decimals = erc20Contract.decimals();
-            let underlying_resolution = 10_u128.pow(underlying_decimals.into());
-            assert(underlying_resolution == SN_PERPS_SCALE, 'INVALID_UNDERLYING');
-            let calculated_resolution: u64 = (10_u256.pow(underlying_decimals.into())
-                / quantum.into())
-                .try_into()
-                .unwrap();
-            assert(
-                calculated_resolution == SN_PERPS_SCALE.try_into().unwrap(),
-                'INVALID_SHARE_RESOLUTION',
-            );
-            self
-                ._add_asset(
-                    asset_id,
-                    risk_factor_tiers,
-                    risk_factor_first_tier_boundary,
-                    risk_factor_tier_size,
-                    quorum,
-                    calculated_resolution,
-                    AssetType::VAULT_SHARE_COLLATERAL,
-                    quantum,
-                    Some(erc20_contract_address),
-                );
-        }
-
-        /// Update synthetic asset risk factors.
-        /// Validations:
-        /// - Only the operator can call this function, cause it must be sequenced.
-        /// (Liqudation may fail if submitted out of order)
-        /// - Each risk factor in risk_factor_tiers is less or equal to 1000.
-        /// - After update postitions risk must be the same or lower.
-        ///
-        /// Execution:
-        fn update_synthetic_asset_risk_factor(
-            ref self: ComponentState<TContractState>,
-            operator_nonce: u64,
-            asset_id: AssetId,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
-        ) {
-            // Validations:
-            get_dep_component!(@self, Pausable).assert_not_paused();
-            let mut nonce = get_dep_component_mut!(ref self, OperatorNonce);
-            nonce.use_checked_nonce(:operator_nonce);
-
-            assert(asset_id.is_non_zero(), INVALID_ZERO_ASSET_ID);
-            assert(risk_factor_tiers.len().is_non_zero(), INVALID_ZERO_RF_TIERS_LEN);
-            assert(risk_factor_first_tier_boundary.is_non_zero(), INVALID_ZERO_RF_FIRST_BOUNDRY);
-            assert(risk_factor_tier_size.is_non_zero(), INVALID_ZERO_RF_TIER_SIZE);
-            if let Option::Some(collateral_id) = self.collateral_id.read() {
-                assert(collateral_id != asset_id, ASSET_REGISTERED_AS_COLLATERAL);
-            }
-
-            let mut old_synthetic_config = self._get_asset_config(asset_id);
-            let mut bound = risk_factor_first_tier_boundary;
-
-            for i in 0..risk_factor_tiers.len() {
-                let mut old_factor = self
-                    .get_synthetic_risk_factor_for_value(
-                        synthetic_id: asset_id, synthetic_value: bound - 1,
-                    );
-                assert(old_factor.value >= *risk_factor_tiers.at(i), INVALID_RF_VALUE);
-                old_factor = self
-                    .get_synthetic_risk_factor_for_value(
-                        synthetic_id: asset_id, synthetic_value: bound,
-                    );
-                if i + 1 < risk_factor_tiers.len() {
-                    assert(old_factor.value >= *risk_factor_tiers.at(i + 1), INVALID_RF_VALUE);
-                }
-
-                bound += risk_factor_tier_size;
-            }
-
-            old_synthetic_config.risk_factor_tier_size = risk_factor_tier_size;
-            old_synthetic_config.risk_factor_first_tier_boundary = risk_factor_first_tier_boundary;
-            let synthetic_entry = self.asset_config.entry(asset_id);
-            synthetic_entry.write(Option::Some(old_synthetic_config));
-
-            let mut prev_risk_factor = 0_u16;
-            let entry = self.risk_factor_tiers.entry(asset_id);
-            while true {
-                if entry.pop().is_none() {
-                    break;
-                }
-            }
-            for risk_factor in risk_factor_tiers {
-                assert(prev_risk_factor < *risk_factor, UNSORTED_RISK_FACTOR_TIERS);
-                self
-                    .risk_factor_tiers
-                    .entry(asset_id) // New function checks that `risk_factor` is lower than 100.
-                    .push(RiskFactorTrait::new(*risk_factor));
-                prev_risk_factor = *risk_factor;
-            }
-            self
-                .emit(
-                    events::SyntheticChanged {
-                        asset_id: asset_id,
-                        risk_factor_tiers: risk_factor_tiers,
-                        risk_factor_first_tier_boundary: risk_factor_first_tier_boundary,
-                        risk_factor_tier_size: risk_factor_tier_size,
-                        resolution_factor: old_synthetic_config.resolution_factor,
-                        quorum: old_synthetic_config.quorum,
-                    },
-                );
-        }
-
-
-        /// - Deactivate synthetic asset.
-        ///
-        /// Validations:
-        /// - Only the app governor can call this function.
-        /// - The asset is already exists and active.
-        ///
-        /// Execution:
-        /// - Deactivate asset_config.
-        ///     - Set the asset as active = false.
-        /// - Decrement the number of active synthetic assets.
-        ///
-        /// When a synthetic asset is inactive, it can no longer be traded or liquidated. It also
-        /// stops receiving funding and price updates. Additionally, a inactive asset cannot be
-        /// reactivated.
-        fn deactivate_synthetic(ref self: ComponentState<TContractState>, synthetic_id: AssetId) {
-            get_dep_component!(@self, Roles).only_app_governor();
-            let mut config = self._get_asset_config(:synthetic_id);
-            assert(config.status == AssetStatus::ACTIVE, SYNTHETIC_NOT_ACTIVE);
-            assert(config.asset_type == AssetType::SYNTHETIC, NOT_SYNTHETIC);
-            config.status = AssetStatus::INACTIVE;
-            self.asset_config.entry(synthetic_id).write(Option::Some(config));
-            self.num_of_active_synthetic_assets.sub_and_write(1);
-            self.emit(events::SyntheticAssetDeactivated { asset_id: synthetic_id });
-        }
-
         /// Funding tick is called by the operator to update the funding index of all synthetic
         /// assets.
         ///
@@ -457,6 +203,88 @@ pub mod AssetsComponent {
             self._set_price(:asset_id, :oracle_price);
         }
 
+        /// Update synthetic asset risk factors.
+        /// Validations:
+        /// - Only the operator can call this function, cause it must be sequenced.
+        /// (Liqudation may fail if submitted out of order)
+        /// - Each risk factor in risk_factor_tiers is less or equal to 1000.
+        /// - After update postitions risk must be the same or lower.
+        ///
+        /// Execution:
+        fn update_synthetic_asset_risk_factor(
+            ref self: ComponentState<TContractState>,
+            operator_nonce: u64,
+            asset_id: AssetId,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+        ) {
+            // Validations:
+            get_dep_component!(@self, Pausable).assert_not_paused();
+            let mut nonce = get_dep_component_mut!(ref self, OperatorNonce);
+            nonce.use_checked_nonce(:operator_nonce);
+
+            assert(asset_id.is_non_zero(), INVALID_ZERO_ASSET_ID);
+            assert(risk_factor_tiers.len().is_non_zero(), INVALID_ZERO_RF_TIERS_LEN);
+            assert(risk_factor_first_tier_boundary.is_non_zero(), INVALID_ZERO_RF_FIRST_BOUNDRY);
+            assert(risk_factor_tier_size.is_non_zero(), INVALID_ZERO_RF_TIER_SIZE);
+            if let Option::Some(collateral_id) = self.collateral_id.read() {
+                assert(collateral_id != asset_id, ASSET_REGISTERED_AS_COLLATERAL);
+            }
+
+            let mut old_synthetic_config = self._get_asset_config(asset_id);
+            let mut bound = risk_factor_first_tier_boundary;
+
+            for i in 0..risk_factor_tiers.len() {
+                let mut old_factor = self
+                    .get_synthetic_risk_factor_for_value(
+                        synthetic_id: asset_id, synthetic_value: bound - 1,
+                    );
+                assert(old_factor.value >= *risk_factor_tiers.at(i), INVALID_RF_VALUE);
+                old_factor = self
+                    .get_synthetic_risk_factor_for_value(
+                        synthetic_id: asset_id, synthetic_value: bound,
+                    );
+                if i + 1 < risk_factor_tiers.len() {
+                    assert(old_factor.value >= *risk_factor_tiers.at(i + 1), INVALID_RF_VALUE);
+                }
+
+                bound += risk_factor_tier_size;
+            }
+
+            old_synthetic_config.risk_factor_tier_size = risk_factor_tier_size;
+            old_synthetic_config.risk_factor_first_tier_boundary = risk_factor_first_tier_boundary;
+            let synthetic_entry = self.asset_config.entry(asset_id);
+            synthetic_entry.write(Option::Some(old_synthetic_config));
+
+            let mut prev_risk_factor = 0_u16;
+            let entry = self.risk_factor_tiers.entry(asset_id);
+            while true {
+                if entry.pop().is_none() {
+                    break;
+                }
+            }
+            for risk_factor in risk_factor_tiers {
+                assert(prev_risk_factor < *risk_factor, UNSORTED_RISK_FACTOR_TIERS);
+                self
+                    .risk_factor_tiers
+                    .entry(asset_id) // New function checks that `risk_factor` is lower than 100.
+                    .push(RiskFactorTrait::new(*risk_factor));
+                prev_risk_factor = *risk_factor;
+            }
+            self
+                .emit(
+                    events::SyntheticChanged {
+                        asset_id: asset_id,
+                        risk_factor_tiers: risk_factor_tiers,
+                        risk_factor_first_tier_boundary: risk_factor_first_tier_boundary,
+                        risk_factor_tier_size: risk_factor_tier_size,
+                        resolution_factor: old_synthetic_config.resolution_factor,
+                        quorum: old_synthetic_config.quorum,
+                    },
+                );
+        }
+
         fn get_collateral_token_contract(
             self: @ComponentState<TContractState>,
         ) -> IERC20Dispatcher {
@@ -467,24 +295,11 @@ pub mod AssetsComponent {
             self.collateral_quantum.read()
         }
 
-        fn get_max_price_interval(self: @ComponentState<TContractState>) -> TimeDelta {
-            self.max_price_interval.read()
-        }
-
-        fn get_max_funding_interval(self: @ComponentState<TContractState>) -> TimeDelta {
-            self.max_funding_interval.read()
-        }
         fn get_last_funding_tick(self: @ComponentState<TContractState>) -> Timestamp {
             self.last_funding_tick.read()
         }
         fn get_last_price_validation(self: @ComponentState<TContractState>) -> Timestamp {
             self.last_price_validation.read()
-        }
-        fn get_max_funding_rate(self: @ComponentState<TContractState>) -> u32 {
-            self.max_funding_rate.read()
-        }
-        fn get_max_oracle_price_validity(self: @ComponentState<TContractState>) -> TimeDelta {
-            self.max_oracle_price_validity.read()
         }
         fn get_num_of_active_synthetic_assets(self: @ComponentState<TContractState>) -> usize {
             self.num_of_active_synthetic_assets.read()
@@ -503,15 +318,161 @@ pub mod AssetsComponent {
             self._get_timely_data(:synthetic_id)
         }
 
-        fn get_risk_factor_tiers(
-            self: @ComponentState<TContractState>, asset_id: AssetId,
-        ) -> Span<RiskFactor> {
-            let mut tiers = array![];
-            let risk_factor_tiers = self.risk_factor_tiers.entry(asset_id);
-            for i in 0..risk_factor_tiers.len() {
-                tiers.append(risk_factor_tiers.at(i).read());
-            }
-            tiers.span()
+        fn get_max_price_interval(self: @ComponentState<TContractState>) -> TimeDelta {
+            self.max_price_interval.read()
+        }
+
+        fn get_max_funding_interval(self: @ComponentState<TContractState>) -> TimeDelta {
+            self.max_funding_interval.read()
+        }
+
+        fn get_max_oracle_price_validity(self: @ComponentState<TContractState>) -> TimeDelta {
+            self.max_oracle_price_validity.read()
+        }
+
+        fn get_max_funding_rate(self: @ComponentState<TContractState>) -> u32 {
+            self.max_funding_rate.read()
+        }
+    }
+
+    #[embeddable_as(AssetsManagerImpl)]
+    impl AssetsManager<
+        TContractState,
+        +HasComponent<TContractState>,
+        +Drop<TContractState>,
+        +AccessControlComponent::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        impl OperatorNonce: OperatorNonceComponent::HasComponent<TContractState>,
+        impl Pausable: PausableComponent::HasComponent<TContractState>,
+        impl Roles: RolesComponent::HasComponent<TContractState>,
+        impl ExternalComponents: ExternalComponentsComponent::HasComponent<TContractState>,
+    > of IAssetsManager<ComponentState<TContractState>> {
+        /// Add oracle to a synthetic asset.
+        ///
+        /// Validations:
+        /// - Only the app governor can call this function.
+        /// - The 'oracle_public_key' does not exist in the Oracle map.
+        /// - The size of 'oracle_name' is 40 bits.
+        /// - The size of 'asset_name' is 128 bits.
+        ///
+        /// Execution:
+        /// - Add a new entry to the Oracle map.
+        fn add_oracle_to_asset(
+            ref self: ComponentState<TContractState>,
+            asset_id: AssetId,
+            oracle_public_key: PublicKey,
+            oracle_name: felt252,
+            asset_name: felt252,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .add_oracle_to_asset(
+                    asset_id: asset_id,
+                    oracle_public_key: oracle_public_key,
+                    oracle_name: oracle_name,
+                    asset_name: asset_name,
+                );
+        }
+
+
+        /// Add asset is called by the app governer to add a new synthetic asset.
+        ///
+        /// Validations:
+        /// - Only the app_governor can call this function.
+        /// - The asset does not exists.
+        /// - Each risk factor in risk_factor_tiers is less or equal to 1000.
+        /// - The quorum is greater than 0.
+        ///
+        /// Execution:
+        /// - Add new entry to asset_config.
+        ///     - Set the asset as in-active.
+        /// - Add a new entry at the beginning of timely_data
+        ///     - Set the price to zero.
+        ///     - Set the funding index to zero.
+        ///     - Set the `last_price_update` to zero.
+        ///
+        /// Risk factor tiers example:
+        /// - risk_factor_tiers = [10, 20, 30, 50, 100, 200, 400]
+        /// - risk_factor_first_tier_boundary = 10,000
+        /// - risk_factor_tier_size = 20,000
+        /// which means:
+        /// - [0, 10,000) -> 1%
+        /// - [10,000, 30,000) -> 2%
+        /// - [30,000, 50,000) -> 3%
+        /// - [50,000, 70,000) -> 5%
+        /// - [70,000, 90,000) -> 10%
+        /// - [90,000, 110,000) -> 20%
+        /// - [110,000, MAX) -> 40%
+        fn add_synthetic_asset(
+            ref self: ComponentState<TContractState>,
+            asset_id: AssetId,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+            quorum: u8,
+            resolution_factor: u64,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .add_synthetic_asset(
+                    :asset_id,
+                    :risk_factor_tiers,
+                    :risk_factor_first_tier_boundary,
+                    :risk_factor_tier_size,
+                    :quorum,
+                    :resolution_factor,
+                );
+        }
+
+        fn add_vault_collateral_asset(
+            ref self: ComponentState<TContractState>,
+            asset_id: AssetId,
+            erc20_contract_address: ContractAddress,
+            quantum: u64,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+            quorum: u8,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .add_vault_collateral_asset(
+                    :asset_id,
+                    :erc20_contract_address,
+                    :quantum,
+                    :risk_factor_tiers,
+                    :risk_factor_first_tier_boundary,
+                    :risk_factor_tier_size,
+                    :quorum,
+                );
+        }
+
+        /// - Deactivate synthetic asset.
+        ///
+        /// Validations:
+        /// - Only the app governor can call this function.
+        /// - The asset is already exists and active.
+        ///
+        /// Execution:
+        /// - Deactivate asset_config.
+        ///     - Set the asset as active = false.
+        /// - Decrement the number of active synthetic assets.
+        ///
+        /// When a synthetic asset is inactive, it can no longer be traded or liquidated. It also
+        /// stops receiving funding and price updates. Additionally, a inactive asset cannot be
+        /// reactivated.
+        fn deactivate_synthetic(ref self: ComponentState<TContractState>, synthetic_id: AssetId) {
+            get_dep_component!(@self, Roles).only_app_governor();
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .deactivate_synthetic(:synthetic_id);
         }
 
         /// Remove oracle from asset.
@@ -528,12 +489,10 @@ pub mod AssetsComponent {
             oracle_public_key: PublicKey,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
-
-            // Validate the oracle exists.
-            let asset_oracle_entry = self.asset_oracle.entry(asset_id).entry(oracle_public_key);
-            assert(asset_oracle_entry.read().is_non_zero(), ORACLE_NOT_EXISTS);
-            asset_oracle_entry.write(Zero::zero());
-            self.emit(events::OracleRemoved { asset_id, oracle_public_key });
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .remove_oracle_from_asset(asset_id: asset_id, oracle_public_key: oracle_public_key);
         }
 
         /// Update synthetic quorum.
@@ -551,19 +510,18 @@ pub mod AssetsComponent {
             ref self: ComponentState<TContractState>, synthetic_id: AssetId, quorum: u8,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
-            let mut asset_config = self._get_asset_config(:synthetic_id);
-            assert(asset_config.status != AssetStatus::INACTIVE, INACTIVE_ASSET);
-            assert(quorum.is_non_zero(), INVALID_ZERO_QUORUM);
-            let old_quorum = asset_config.quorum;
-            assert(old_quorum != quorum, INVALID_SAME_QUORUM);
-            asset_config.quorum = quorum;
-            self.asset_config.write(synthetic_id, Option::Some(asset_config));
-            self
-                .emit(
-                    events::AssetQuorumUpdated {
-                        asset_id: synthetic_id, new_quorum: quorum, old_quorum,
-                    },
-                );
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .update_synthetic_quorum(synthetic_id: synthetic_id, quorum: quorum);
+        }
+
+        // View functions for manager
+        fn get_risk_factor_tiers(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> Span<RiskFactor> {
+            let external_components = get_dep_component!(self, ExternalComponents);
+            external_components._get_assets_manager_dispatcher().get_risk_factor_tiers(:asset_id)
         }
     }
 
@@ -924,126 +882,6 @@ pub mod AssetsComponent {
                     );
                 }
             };
-        }
-
-        fn _add_asset(
-            ref self: ComponentState<TContractState>,
-            asset_id: AssetId,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
-            quorum: u8,
-            resolution_factor: u64,
-            asset_type: AssetType,
-            quantum: u64,
-            erc20_address: Option<ContractAddress>,
-        ) {
-            /// Validations:
-            get_dep_component!(@self, Roles).only_app_governor();
-
-            let asset_entry = self.asset_config.entry(asset_id);
-            assert(asset_entry.read().is_none(), SYNTHETIC_ALREADY_EXISTS);
-            if let Option::Some(collateral_id) = self.collateral_id.read() {
-                assert(collateral_id != asset_id, ASSET_REGISTERED_AS_COLLATERAL);
-            }
-
-            assert(asset_id.is_non_zero(), INVALID_ZERO_ASSET_ID);
-            assert(risk_factor_tiers.len().is_non_zero(), INVALID_ZERO_RF_TIERS_LEN);
-            assert(risk_factor_first_tier_boundary.is_non_zero(), INVALID_ZERO_RF_FIRST_BOUNDRY);
-            assert(risk_factor_tier_size.is_non_zero(), INVALID_ZERO_RF_TIER_SIZE);
-            assert(quorum.is_non_zero(), INVALID_ZERO_QUORUM);
-            assert(resolution_factor.is_non_zero(), INVALID_ZERO_RESOLUTION_FACTOR);
-
-            let (asset_config, asset_added_event): (AssetConfig, Event) = match asset_type {
-                AssetType::SYNTHETIC => {
-                    (
-                        SyntheticTrait::synthetic(
-                            AssetStatus::PENDING,
-                            risk_factor_first_tier_boundary,
-                            risk_factor_tier_size,
-                            quorum,
-                            resolution_factor,
-                        ),
-                        Event::SyntheticAdded(
-                            events::SyntheticAdded {
-                                asset_id,
-                                risk_factor_tiers,
-                                risk_factor_first_tier_boundary,
-                                risk_factor_tier_size,
-                                resolution_factor,
-                                quorum,
-                            },
-                        ),
-                    )
-                },
-                AssetType::VAULT_SHARE_COLLATERAL => {
-                    assert(risk_factor_tiers.len() == 1, 'INVALID_VAULT_RF_TIERS');
-
-                    (
-                        SyntheticTrait::vault_share(
-                            AssetStatus::PENDING,
-                            risk_factor_first_tier_boundary,
-                            risk_factor_tier_size,
-                            quorum,
-                            resolution_factor,
-                            quantum,
-                            erc20_address.expect('MISSING_ERC20_ADDRESS_FOR_VAULT'),
-                        ),
-                        Event::SpotAssetAdded(
-                            events::SpotAssetAdded {
-                                asset_id,
-                                risk_factor_tiers,
-                                risk_factor_first_tier_boundary,
-                                risk_factor_tier_size,
-                                resolution_factor,
-                                quorum,
-                                contract_address: erc20_address.expect('MISSING_ERC20_ADDRESS'),
-                            },
-                        ),
-                    )
-                },
-                AssetType::SPOT_COLLATERAL => {
-                    assert(risk_factor_tiers.len() == 1, 'INVALID_SPOT_RF_TIERS');
-                    (
-                        SyntheticTrait::spot(
-                            AssetStatus::PENDING,
-                            risk_factor_first_tier_boundary,
-                            risk_factor_tier_size,
-                            quorum,
-                            resolution_factor,
-                            quantum,
-                            erc20_address.expect('MISSING_ERC20_ADDRESS_FOR_SPOT'),
-                        ),
-                        Event::SpotAssetAdded(
-                            events::SpotAssetAdded {
-                                asset_id,
-                                risk_factor_tiers,
-                                risk_factor_first_tier_boundary,
-                                risk_factor_tier_size,
-                                resolution_factor,
-                                quorum,
-                                contract_address: erc20_address.expect('MISSING_ERC20_ADDRESS'),
-                            },
-                        ),
-                    )
-                },
-            };
-
-            asset_entry.write(Option::Some(asset_config));
-
-            self.timely_data.write(asset_id, Default::default());
-
-            let mut prev_risk_factor = 0_u16;
-            for risk_factor in risk_factor_tiers {
-                assert(prev_risk_factor < *risk_factor, UNSORTED_RISK_FACTOR_TIERS);
-                self
-                    .risk_factor_tiers
-                    .entry(asset_id) // New function checks that `risk_factor` is lower than 1000.
-                    .push(RiskFactorTrait::new(*risk_factor));
-                prev_risk_factor = *risk_factor;
-            }
-
-            self.emit(asset_added_event);
         }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets_manager.cairo
@@ -1,0 +1,425 @@
+use perpetuals::core::types::asset::AssetId;
+use perpetuals::core::types::risk_factor::RiskFactor;
+use starknet::ContractAddress;
+use starkware_utils::signature::stark::PublicKey;
+use starkware_utils::storage::iterable_map::{
+    IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
+};
+
+#[starknet::interface]
+pub trait IAssetsExternal<TContractState> {
+    fn add_oracle_to_asset(
+        ref self: TContractState,
+        asset_id: AssetId,
+        oracle_public_key: PublicKey,
+        oracle_name: felt252,
+        asset_name: felt252,
+    );
+    fn add_synthetic_asset(
+        ref self: TContractState,
+        asset_id: AssetId,
+        risk_factor_tiers: Span<u16>,
+        risk_factor_first_tier_boundary: u128,
+        risk_factor_tier_size: u128,
+        quorum: u8,
+        resolution_factor: u64,
+    );
+    fn add_vault_collateral_asset(
+        ref self: TContractState,
+        asset_id: AssetId,
+        erc20_contract_address: ContractAddress,
+        quantum: u64,
+        risk_factor_tiers: Span<u16>,
+        risk_factor_first_tier_boundary: u128,
+        risk_factor_tier_size: u128,
+        quorum: u8,
+    );
+    fn deactivate_synthetic(ref self: TContractState, synthetic_id: AssetId);
+    fn remove_oracle_from_asset(
+        ref self: TContractState, asset_id: AssetId, oracle_public_key: PublicKey,
+    );
+    fn update_synthetic_quorum(ref self: TContractState, synthetic_id: AssetId, quorum: u8);
+
+    // View functions
+    fn get_risk_factor_tiers(self: @TContractState, asset_id: AssetId) -> Span<RiskFactor>;
+}
+
+#[starknet::contract]
+pub(crate) mod AssetsManager {
+    use core::num::traits::{Pow, Zero};
+    use core::panic_with_felt252;
+    use openzeppelin::access::accesscontrol::AccessControlComponent;
+    use openzeppelin::interfaces::erc20::{IERC20MetadataDispatcher, IERC20MetadataDispatcherTrait};
+    use openzeppelin::introspection::src5::SRC5Component;
+    use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
+    use perpetuals::core::types::asset::synthetic::{
+        AssetConfig, AssetType, SyntheticTrait, TimelyData,
+    };
+    use perpetuals::core::types::asset::{AssetId, AssetStatus};
+    use perpetuals::core::types::risk_factor::{RiskFactor, RiskFactorTrait};
+    use starknet::ContractAddress;
+    use starknet::storage::{
+        Map, MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
+        StoragePointerReadAccess, StoragePointerWriteAccess, Vec, VecTrait,
+    };
+    use starkware_utils::components::pausable::PausableComponent;
+    use starkware_utils::components::roles::RolesComponent;
+    use starkware_utils::constants::{TWO_POW_128, TWO_POW_40};
+    use starkware_utils::signature::stark::PublicKey;
+    use starkware_utils::storage::iterable_map::{
+        IterableMap, IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
+    };
+    use starkware_utils::storage::utils::SubFromStorage;
+    use starkware_utils::time::time::TimeDelta;
+    use crate::core::components::assets::errors::{
+        ASSET_NAME_TOO_LONG, ASSET_REGISTERED_AS_COLLATERAL, INACTIVE_ASSET, INVALID_SAME_QUORUM,
+        INVALID_ZERO_ASSET_ID, INVALID_ZERO_ASSET_NAME, INVALID_ZERO_ORACLE_NAME,
+        INVALID_ZERO_PUBLIC_KEY, INVALID_ZERO_QUORUM, INVALID_ZERO_RESOLUTION_FACTOR,
+        INVALID_ZERO_RF_FIRST_BOUNDRY, INVALID_ZERO_RF_TIERS_LEN, INVALID_ZERO_RF_TIER_SIZE,
+        NOT_SYNTHETIC, ORACLE_ALREADY_EXISTS, ORACLE_NAME_TOO_LONG, ORACLE_NOT_EXISTS,
+        SYNTHETIC_ALREADY_EXISTS, SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS,
+        UNSORTED_RISK_FACTOR_TIERS,
+    };
+    use crate::core::components::assets::events;
+    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_ASSETS;
+    use crate::core::components::external_components::named_component::ITypedComponent;
+    use crate::core::types::price::SN_PERPS_SCALE;
+    use super::IAssetsExternal;
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    pub enum Event {
+        #[flat]
+        PausableEvent: PausableComponent::Event,
+        #[flat]
+        OperatorNonceEvent: OperatorNonceComponent::Event,
+        #[flat]
+        AccessControlEvent: AccessControlComponent::Event,
+        #[flat]
+        SRC5Event: SRC5Component::Event,
+        #[flat]
+        RolesEvent: RolesComponent::Event,
+        OracleAdded: events::OracleAdded,
+        SyntheticAdded: events::SyntheticAdded,
+        SyntheticChanged: events::SyntheticChanged,
+        SpotAssetAdded: events::SpotAssetAdded,
+        SyntheticAssetDeactivated: events::SyntheticAssetDeactivated,
+        OracleRemoved: events::OracleRemoved,
+        AssetQuorumUpdated: events::AssetQuorumUpdated,
+    }
+
+    #[storage]
+    #[allow(starknet::colliding_storage_paths)]
+    pub struct Storage {
+        #[substorage(v0)]
+        accesscontrol: AccessControlComponent::Storage,
+        #[substorage(v0)]
+        operator_nonce: OperatorNonceComponent::Storage,
+        #[substorage(v0)]
+        pausable: PausableComponent::Storage,
+        #[substorage(v0)]
+        pub roles: RolesComponent::Storage,
+        #[substorage(v0)]
+        src5: SRC5Component::Storage,
+        num_of_active_synthetic_assets: usize,
+        #[rename("synthetic_config")]
+        asset_config: Map<AssetId, Option<AssetConfig>>,
+        #[rename("synthetic_timely_data")]
+        timely_data: IterableMap<AssetId, TimelyData>,
+        risk_factor_tiers: Map<AssetId, Vec<RiskFactor>>,
+        #[allow(starknet::colliding_storage_paths)]
+        #[rename("risk_factor_tiers")]
+        unchecked_access_risk_factor_tiers: Map<AssetId, Map<u64, RiskFactor>>,
+        asset_oracle: Map<AssetId, Map<PublicKey, felt252>>,
+        max_oracle_price_validity: TimeDelta,
+        collateral_id: Option<AssetId>,
+        max_price_interval: TimeDelta,
+        max_funding_interval: TimeDelta,
+        max_funding_rate: u32,
+    }
+
+    component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+    component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
+    component!(path: RolesComponent, storage: roles, event: RolesEvent);
+    component!(path: SRC5Component, storage: src5, event: SRC5Event);
+    component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
+
+    #[abi(embed_v0)]
+    impl TypedComponent of ITypedComponent<ContractState> {
+        fn component_type(ref self: ContractState) -> felt252 {
+            EXTERNAL_COMPONENT_ASSETS
+        }
+    }
+
+    #[abi(embed_v0)]
+    impl AssetsManagerImpl of IAssetsExternal<ContractState> {
+        /// Add oracle to a synthetic asset.
+        fn add_oracle_to_asset(
+            ref self: ContractState,
+            asset_id: AssetId,
+            oracle_public_key: PublicKey,
+            oracle_name: felt252,
+            asset_name: felt252,
+        ) {
+            let asset_config = self.asset_config.read(asset_id).expect(SYNTHETIC_NOT_EXISTS);
+            assert(asset_config.status != AssetStatus::INACTIVE, INACTIVE_ASSET);
+
+            // Validate the oracle does not exist.
+            let asset_oracle_entry = self.asset_oracle.entry(asset_id).entry(oracle_public_key);
+            let asset_oracle_data = asset_oracle_entry.read();
+            assert(asset_oracle_data.is_zero(), ORACLE_ALREADY_EXISTS);
+
+            assert(oracle_public_key.is_non_zero(), INVALID_ZERO_PUBLIC_KEY);
+            assert(asset_name.is_non_zero(), INVALID_ZERO_ASSET_NAME);
+            assert(oracle_name.is_non_zero(), INVALID_ZERO_ORACLE_NAME);
+
+            // Validate the size of the oracle name.
+            if let Option::Some(oracle_name) = oracle_name.try_into() {
+                assert(oracle_name < TWO_POW_40, ORACLE_NAME_TOO_LONG);
+            } else {
+                panic_with_felt252(ORACLE_NAME_TOO_LONG);
+            }
+
+            // Validate the size of the asset name.
+            assert(asset_name.into() < TWO_POW_128, ASSET_NAME_TOO_LONG);
+
+            // Add the oracle to the asset.
+            let shifted_asset_name = TWO_POW_40.into() * asset_name;
+            asset_oracle_entry.write(shifted_asset_name + oracle_name);
+
+            self.emit(events::OracleAdded { asset_id, asset_name, oracle_public_key, oracle_name });
+        }
+
+        fn add_synthetic_asset(
+            ref self: ContractState,
+            asset_id: AssetId,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+            quorum: u8,
+            resolution_factor: u64,
+        ) {
+            self
+                ._add_asset(
+                    :asset_id,
+                    :risk_factor_tiers,
+                    :risk_factor_first_tier_boundary,
+                    :risk_factor_tier_size,
+                    :quorum,
+                    :resolution_factor,
+                    asset_type: AssetType::SYNTHETIC,
+                    quantum: 0,
+                    erc20_address: Option::None,
+                );
+        }
+
+        fn add_vault_collateral_asset(
+            ref self: ContractState,
+            asset_id: AssetId,
+            erc20_contract_address: ContractAddress,
+            quantum: u64,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+            quorum: u8,
+        ) {
+            assert(quantum == 1, 'INVALID_SHARE_QUANTUM');
+            let erc20Contract = IERC20MetadataDispatcher {
+                contract_address: erc20_contract_address,
+            };
+            let underlying_decimals = erc20Contract.decimals();
+            let underlying_resolution = 10_u128.pow(underlying_decimals.into());
+            assert(underlying_resolution == SN_PERPS_SCALE, 'INVALID_UNDERLYING');
+            let calculated_resolution: u64 = (10_u256.pow(underlying_decimals.into())
+                / quantum.into())
+                .try_into()
+                .unwrap();
+            assert(
+                calculated_resolution == SN_PERPS_SCALE.try_into().unwrap(),
+                'INVALID_SHARE_RESOLUTION',
+            );
+            self
+                ._add_asset(
+                    :asset_id,
+                    :risk_factor_tiers,
+                    :risk_factor_first_tier_boundary,
+                    :risk_factor_tier_size,
+                    :quorum,
+                    resolution_factor: calculated_resolution,
+                    asset_type: AssetType::VAULT_SHARE_COLLATERAL,
+                    :quantum,
+                    erc20_address: Option::Some(erc20_contract_address),
+                );
+        }
+
+        fn deactivate_synthetic(ref self: ContractState, synthetic_id: AssetId) {
+            let mut config = self.asset_config.read(synthetic_id).expect(SYNTHETIC_NOT_EXISTS);
+            assert(config.status == AssetStatus::ACTIVE, SYNTHETIC_NOT_ACTIVE);
+            assert(config.asset_type == AssetType::SYNTHETIC, NOT_SYNTHETIC);
+            config.status = AssetStatus::INACTIVE;
+            self.asset_config.entry(synthetic_id).write(Option::Some(config));
+            self.num_of_active_synthetic_assets.sub_and_write(1);
+
+            self.emit(events::SyntheticAssetDeactivated { asset_id: synthetic_id });
+        }
+
+        fn remove_oracle_from_asset(
+            ref self: ContractState, asset_id: AssetId, oracle_public_key: PublicKey,
+        ) {
+            // Validate the oracle exists.
+            let asset_oracle_entry = self.asset_oracle.entry(asset_id).entry(oracle_public_key);
+            assert(asset_oracle_entry.read().is_non_zero(), ORACLE_NOT_EXISTS);
+            asset_oracle_entry.write(Zero::zero());
+            self.emit(events::OracleRemoved { asset_id, oracle_public_key });
+        }
+
+        fn update_synthetic_quorum(ref self: ContractState, synthetic_id: AssetId, quorum: u8) {
+            let mut asset_config = self
+                .asset_config
+                .read(synthetic_id)
+                .expect(SYNTHETIC_NOT_EXISTS);
+            assert(asset_config.status != AssetStatus::INACTIVE, INACTIVE_ASSET);
+            assert(quorum.is_non_zero(), INVALID_ZERO_QUORUM);
+            let old_quorum = asset_config.quorum;
+            assert(old_quorum != quorum, INVALID_SAME_QUORUM);
+            asset_config.quorum = quorum;
+            self.asset_config.write(synthetic_id, Option::Some(asset_config));
+            self
+                .emit(
+                    events::AssetQuorumUpdated {
+                        asset_id: synthetic_id, new_quorum: quorum, old_quorum,
+                    },
+                );
+        }
+
+        fn get_risk_factor_tiers(self: @ContractState, asset_id: AssetId) -> Span<RiskFactor> {
+            let mut tiers = array![];
+            let risk_factor_tiers = self.risk_factor_tiers.entry(asset_id);
+            for i in 0..risk_factor_tiers.len() {
+                tiers.append(risk_factor_tiers.at(i).read());
+            }
+            tiers.span()
+        }
+    }
+
+    #[generate_trait]
+    impl AssetsManagerInternalImpl of IAssetsManagerInternal {
+        fn _add_asset(
+            ref self: ContractState,
+            asset_id: AssetId,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+            quorum: u8,
+            resolution_factor: u64,
+            asset_type: AssetType,
+            quantum: u64,
+            erc20_address: Option<ContractAddress>,
+        ) {
+            let asset_entry = self.asset_config.entry(asset_id);
+            assert(asset_entry.read().is_none(), SYNTHETIC_ALREADY_EXISTS);
+            if let Option::Some(collateral_id) = self.collateral_id.read() {
+                assert(collateral_id != asset_id, ASSET_REGISTERED_AS_COLLATERAL);
+            }
+
+            assert(asset_id.is_non_zero(), INVALID_ZERO_ASSET_ID);
+            assert(risk_factor_tiers.len().is_non_zero(), INVALID_ZERO_RF_TIERS_LEN);
+            assert(risk_factor_first_tier_boundary.is_non_zero(), INVALID_ZERO_RF_FIRST_BOUNDRY);
+            assert(risk_factor_tier_size.is_non_zero(), INVALID_ZERO_RF_TIER_SIZE);
+            assert(quorum.is_non_zero(), INVALID_ZERO_QUORUM);
+            assert(resolution_factor.is_non_zero(), INVALID_ZERO_RESOLUTION_FACTOR);
+
+            let (asset_config, asset_added_event): (AssetConfig, Event) = match asset_type {
+                AssetType::SYNTHETIC => {
+                    (
+                        SyntheticTrait::synthetic(
+                            AssetStatus::PENDING,
+                            risk_factor_first_tier_boundary,
+                            risk_factor_tier_size,
+                            quorum,
+                            resolution_factor,
+                        ),
+                        Event::SyntheticAdded(
+                            events::SyntheticAdded {
+                                asset_id,
+                                risk_factor_tiers,
+                                risk_factor_first_tier_boundary,
+                                risk_factor_tier_size,
+                                resolution_factor,
+                                quorum,
+                            },
+                        ),
+                    )
+                },
+                AssetType::VAULT_SHARE_COLLATERAL => {
+                    assert(risk_factor_tiers.len() == 1, 'INVALID_VAULT_RF_TIERS');
+
+                    (
+                        SyntheticTrait::vault_share(
+                            AssetStatus::PENDING,
+                            risk_factor_first_tier_boundary,
+                            risk_factor_tier_size,
+                            quorum,
+                            resolution_factor,
+                            quantum,
+                            erc20_address.expect('MISSING_ERC20_ADDRESS_FOR_VAULT'),
+                        ),
+                        Event::SpotAssetAdded(
+                            events::SpotAssetAdded {
+                                asset_id,
+                                risk_factor_tiers,
+                                risk_factor_first_tier_boundary,
+                                risk_factor_tier_size,
+                                resolution_factor,
+                                quorum,
+                                contract_address: erc20_address.expect('MISSING_ERC20_ADDRESS'),
+                            },
+                        ),
+                    )
+                },
+                AssetType::SPOT_COLLATERAL => {
+                    assert(risk_factor_tiers.len() == 1, 'INVALID_SPOT_RF_TIERS');
+                    (
+                        SyntheticTrait::spot(
+                            AssetStatus::PENDING,
+                            risk_factor_first_tier_boundary,
+                            risk_factor_tier_size,
+                            quorum,
+                            resolution_factor,
+                            quantum,
+                            erc20_address.expect('MISSING_ERC20_ADDRESS_FOR_SPOT'),
+                        ),
+                        Event::SpotAssetAdded(
+                            events::SpotAssetAdded {
+                                asset_id,
+                                risk_factor_tiers,
+                                risk_factor_first_tier_boundary,
+                                risk_factor_tier_size,
+                                resolution_factor,
+                                quorum,
+                                contract_address: erc20_address.expect('MISSING_ERC20_ADDRESS'),
+                            },
+                        ),
+                    )
+                },
+            };
+
+            asset_entry.write(Option::Some(asset_config));
+
+            self.timely_data.write(asset_id, Default::default());
+
+            let mut prev_risk_factor = 0_u16;
+            for risk_factor in risk_factor_tiers {
+                assert(prev_risk_factor < *risk_factor, UNSORTED_RISK_FACTOR_TIERS);
+                self
+                    .risk_factor_tiers
+                    .entry(asset_id) // New function checks that `risk_factor` is lower than 1000.
+                    .push(RiskFactorTrait::new(*risk_factor));
+                prev_risk_factor = *risk_factor;
+            }
+
+            self.emit(asset_added_event);
+        }
+    }
+}
+

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -12,6 +12,47 @@ use starkware_utils::time::time::{TimeDelta, Timestamp};
 #[starknet::interface]
 pub trait IAssets<TContractState> {
     // Write functions.
+    fn funding_tick(
+        ref self: TContractState,
+        operator_nonce: u64,
+        funding_ticks: Span<FundingTick>,
+        timestamp: Timestamp,
+    );
+    fn price_tick(
+        ref self: TContractState,
+        operator_nonce: u64,
+        asset_id: AssetId,
+        oracle_price: u128,
+        signed_prices: Span<SignedPrice>,
+    );
+
+    fn update_synthetic_asset_risk_factor(
+        ref self: TContractState,
+        operator_nonce: u64,
+        asset_id: AssetId,
+        risk_factor_tiers: Span<u16>,
+        risk_factor_first_tier_boundary: u128,
+        risk_factor_tier_size: u128,
+    );
+
+    // View functions.
+    fn get_collateral_token_contract(self: @TContractState) -> IERC20Dispatcher;
+    fn get_collateral_quantum(self: @TContractState) -> u64;
+    fn get_last_funding_tick(self: @TContractState) -> Timestamp;
+    fn get_last_price_validation(self: @TContractState) -> Timestamp;
+    fn get_num_of_active_synthetic_assets(self: @TContractState) -> usize;
+    fn get_collateral_id(self: @TContractState) -> AssetId;
+    fn get_asset_config(self: @TContractState, synthetic_id: AssetId) -> AssetConfig;
+    fn get_timely_data(self: @TContractState, synthetic_id: AssetId) -> TimelyData;
+    fn get_max_price_interval(self: @TContractState) -> TimeDelta;
+    fn get_max_funding_interval(self: @TContractState) -> TimeDelta;
+    fn get_max_oracle_price_validity(self: @TContractState) -> TimeDelta;
+    fn get_max_funding_rate(self: @TContractState) -> u32;
+}
+
+
+#[starknet::interface]
+pub trait IAssetsManager<TContractState> {
     fn add_oracle_to_asset(
         ref self: TContractState,
         asset_id: AssetId,
@@ -28,56 +69,22 @@ pub trait IAssets<TContractState> {
         quorum: u8,
         resolution_factor: u64,
     );
-    fn update_synthetic_asset_risk_factor(
-        ref self: TContractState,
-        operator_nonce: u64,
-        asset_id: AssetId,
-        risk_factor_tiers: Span<u16>,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
-    );
     fn add_vault_collateral_asset(
         ref self: TContractState,
         asset_id: AssetId,
         erc20_contract_address: ContractAddress,
         quantum: u64,
-        resolution_factor: u64,
         risk_factor_tiers: Span<u16>,
         risk_factor_first_tier_boundary: u128,
         risk_factor_tier_size: u128,
         quorum: u8,
     );
     fn deactivate_synthetic(ref self: TContractState, synthetic_id: AssetId);
-    fn funding_tick(
-        ref self: TContractState,
-        operator_nonce: u64,
-        funding_ticks: Span<FundingTick>,
-        timestamp: Timestamp,
-    );
-    fn price_tick(
-        ref self: TContractState,
-        operator_nonce: u64,
-        asset_id: AssetId,
-        oracle_price: u128,
-        signed_prices: Span<SignedPrice>,
-    );
     fn remove_oracle_from_asset(
         ref self: TContractState, asset_id: AssetId, oracle_public_key: PublicKey,
     );
     fn update_synthetic_quorum(ref self: TContractState, synthetic_id: AssetId, quorum: u8);
 
     // View functions.
-    fn get_collateral_token_contract(self: @TContractState) -> IERC20Dispatcher;
-    fn get_collateral_quantum(self: @TContractState) -> u64;
-    fn get_last_funding_tick(self: @TContractState) -> Timestamp;
-    fn get_last_price_validation(self: @TContractState) -> Timestamp;
-    fn get_max_funding_interval(self: @TContractState) -> TimeDelta;
-    fn get_max_funding_rate(self: @TContractState) -> u32;
-    fn get_max_price_interval(self: @TContractState) -> TimeDelta;
-    fn get_max_oracle_price_validity(self: @TContractState) -> TimeDelta;
-    fn get_num_of_active_synthetic_assets(self: @TContractState) -> usize;
-    fn get_collateral_id(self: @TContractState) -> AssetId;
-    fn get_asset_config(self: @TContractState, synthetic_id: AssetId) -> AssetConfig;
-    fn get_timely_data(self: @TContractState, synthetic_id: AssetId) -> TimelyData;
     fn get_risk_factor_tiers(self: @TContractState, asset_id: AssetId) -> Span<RiskFactor>;
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/external_components/external_component_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/external_components/external_component_manager.cairo
@@ -14,6 +14,7 @@ pub mod ExternalComponents {
     use starkware_utils::components::replaceability::interface::IReplaceable;
     use starkware_utils::components::roles::RolesComponent;
     use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
+    use crate::core::components::assets::assets_manager::IAssetsExternalLibraryDispatcher;
     use crate::core::components::deleverage::deleverage_manager::IDeleverageManagerLibraryDispatcher;
     use crate::core::components::deposit::deposit_manager::IDepositExternalLibraryDispatcher;
     use crate::core::components::external_components::events;
@@ -26,8 +27,8 @@ pub mod ExternalComponents {
     use crate::core::components::vaults::vaults_contract::IVaultExternalLibraryDispatcher;
     use crate::core::components::withdrawal::withdrawal_manager::IWithdrawalManagerLibraryDispatcher;
     use super::super::interface::{
-        EXTERNAL_COMPONENT_DEPOSITS, EXTERNAL_COMPONENT_LIQUIDATIONS, EXTERNAL_COMPONENT_TRANSFERS,
-        EXTERNAL_COMPONENT_VAULT, EXTERNAL_COMPONENT_WITHDRAWALS,
+        EXTERNAL_COMPONENT_ASSETS, EXTERNAL_COMPONENT_DEPOSITS, EXTERNAL_COMPONENT_LIQUIDATIONS,
+        EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT, EXTERNAL_COMPONENT_WITHDRAWALS,
     };
     use super::super::named_component::ITypedComponentDispatcherTrait;
 
@@ -148,6 +149,17 @@ pub mod ExternalComponents {
             assert(class_hash.is_non_zero(), 'NO_DEPOSIT_MANAGER');
             IDepositExternalLibraryDispatcher { class_hash: class_hash }
         }
+
+        fn _get_assets_manager_dispatcher(
+            self: @ComponentState<TContractState>,
+        ) -> IAssetsExternalLibraryDispatcher {
+            let class_hash = self
+                .external_component_implementations
+                .entry(EXTERNAL_COMPONENT_ASSETS)
+                .read();
+            assert(class_hash.is_non_zero(), 'NO_ASSETS_MANAGER');
+            IAssetsExternalLibraryDispatcher { class_hash: class_hash }
+        }
     }
 
     #[generate_trait]
@@ -185,7 +197,8 @@ pub mod ExternalComponents {
                 || (component_type == EXTERNAL_COMPONENT_DEPOSITS)
                 || (component_type == EXTERNAL_COMPONENT_TRANSFERS)
                 || (component_type == EXTERNAL_COMPONENT_LIQUIDATIONS)
-                || (component_type == EXTERNAL_COMPONENT_DELEVERAGES) {
+                || (component_type == EXTERNAL_COMPONENT_DELEVERAGES)
+                || (component_type == EXTERNAL_COMPONENT_ASSETS) {
                 let now = Time::now();
                 let activation_time = now.add(update_delay);
                 let entry = self.registered_external_components.entry(component_type);

--- a/workspace/apps/perpetuals/contracts/src/core/components/external_components/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/external_components/interface.cairo
@@ -7,6 +7,7 @@ pub const EXTERNAL_COMPONENT_TRANSFERS: felt252 = 'TRANSFERS';
 pub const EXTERNAL_COMPONENT_LIQUIDATIONS: felt252 = 'LIQUIDATIONS';
 pub const EXTERNAL_COMPONENT_DELEVERAGES: felt252 = 'DELEVERAGES';
 pub const EXTERNAL_COMPONENT_DEPOSITS: felt252 = 'DEPOSITS';
+pub const EXTERNAL_COMPONENT_ASSETS: felt252 = 'ASSETS';
 
 #[starknet::interface]
 pub trait IExternalComponents<TContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -96,6 +96,9 @@ pub mod Core {
     impl AssetsImpl = AssetsComponent::AssetsImpl<ContractState>;
 
     #[abi(embed_v0)]
+    impl AssetsManagerImpl = AssetsComponent::AssetsManagerImpl<ContractState>;
+
+    #[abi(embed_v0)]
     impl ReplaceabilityImpl =
         ReplaceabilityComponent::ReplaceabilityImpl<ContractState>;
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -1,4 +1,7 @@
 use core::num::traits::Zero;
+use perpetuals::core::components::assets::assets_manager::{
+    IAssetsExternalDispatcher, IAssetsExternalDispatcherTrait,
+};
 use perpetuals::core::components::assets::interface::{IAssetsDispatcher, IAssetsDispatcherTrait};
 use perpetuals::core::components::deposit::interface::{IDepositDispatcher, IDepositDispatcherTrait};
 use perpetuals::core::components::positions::interface::{
@@ -184,7 +187,7 @@ fn test_deleverage_only_operator() {
 #[should_panic(expected: "ONLY_APP_GOVERNOR")]
 fn test_add_oracle_to_asset_only_app_governor() {
     let (cfg, contract_address) = setup();
-    let dispatcher = IAssetsDispatcher { contract_address };
+    let dispatcher = IAssetsExternalDispatcher { contract_address };
     dispatcher
         .add_oracle_to_asset(
             asset_id: cfg.synthetic_cfg.synthetic_id,
@@ -198,7 +201,7 @@ fn test_add_oracle_to_asset_only_app_governor() {
 #[should_panic(expected: "ONLY_APP_GOVERNOR")]
 fn test_add_synthetic_asset_only_app_governor() {
     let (cfg, contract_address) = setup();
-    let dispatcher = IAssetsDispatcher { contract_address };
+    let dispatcher = IAssetsExternalDispatcher { contract_address };
     dispatcher
         .add_synthetic_asset(
             asset_id: cfg.synthetic_cfg.synthetic_id,
@@ -214,7 +217,7 @@ fn test_add_synthetic_asset_only_app_governor() {
 #[should_panic(expected: "ONLY_APP_GOVERNOR")]
 fn test_deactivate_synthetic_only_app_governor() {
     let (cfg, contract_address) = setup();
-    let dispatcher = IAssetsDispatcher { contract_address };
+    let dispatcher = IAssetsExternalDispatcher { contract_address };
     dispatcher.deactivate_synthetic(synthetic_id: cfg.synthetic_cfg.synthetic_id);
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -4,11 +4,15 @@ use core::fmt::Debug;
 use core::nullable::{FromNullableResult, match_nullable};
 use core::num::traits::WideMul;
 use external_components::interface::{
-    EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_DEPOSITS, EXTERNAL_COMPONENT_LIQUIDATIONS,
-    EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT, EXTERNAL_COMPONENT_WITHDRAWALS,
+    EXTERNAL_COMPONENT_ASSETS, EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_DEPOSITS,
+    EXTERNAL_COMPONENT_LIQUIDATIONS, EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT,
+    EXTERNAL_COMPONENT_WITHDRAWALS,
 };
 use openzeppelin::interfaces::erc20::IERC20Dispatcher;
 use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
+use perpetuals::core::components::assets::assets_manager::{
+    IAssetsExternalDispatcher, IAssetsExternalDispatcherTrait,
+};
 use perpetuals::core::components::assets::interface::{IAssetsDispatcher, IAssetsDispatcherTrait};
 use perpetuals::core::components::deposit::deposit_manager::deposit_hash;
 use perpetuals::core::components::deposit::interface::{
@@ -495,6 +499,10 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             .unwrap()
             .contract_class();
 
+        let assets_external_component = snforge_std::declare("AssetsManager")
+            .unwrap()
+            .contract_class();
+
         let collateral_quantum = COLLATERAL_QUANTUM;
         let perpetuals_config: PerpetualsConfig = PerpetualsConfigTrait::new(
             collateral_token_address: token_state.address, :collateral_quantum,
@@ -561,6 +569,12 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             );
 
         external_components_dispatcher
+            .register_external_component(
+                component_type: EXTERNAL_COMPONENT_ASSETS,
+                component_address: *assets_external_component.class_hash,
+            );
+
+        external_components_dispatcher
             .activate_external_component(
                 component_type: EXTERNAL_COMPONENT_DELEVERAGES,
                 component_address: *deleverage_external_component.class_hash,
@@ -590,6 +604,12 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             .activate_external_component(
                 component_type: EXTERNAL_COMPONENT_DEPOSITS,
                 component_address: *deposit_external_component.class_hash,
+            );
+
+        external_components_dispatcher
+            .activate_external_component(
+                component_type: EXTERNAL_COMPONENT_ASSETS,
+                component_address: *assets_external_component.class_hash,
             );
 
         stop_cheat_caller_address(contract_address: perpetuals_contract);
@@ -635,15 +655,16 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         );
 
         let asset_id = asset_info.asset_id;
-        let assets_dispatcher = IAssetsDispatcher { contract_address: self.perpetuals_contract };
+        let assets_external_dispatcher = IAssetsExternalDispatcher {
+            contract_address: self.perpetuals_contract,
+        };
 
         self.set_app_governor_as_caller();
-        assets_dispatcher
+        assets_external_dispatcher
             .add_vault_collateral_asset(
                 asset_id,
                 erc20_contract_address: vault.contract_address,
                 quantum: 1,
-                resolution_factor: asset_info.resolution_factor,
                 risk_factor_tiers: risk_factor_1,
                 :risk_factor_first_tier_boundary,
                 :risk_factor_tier_size,
@@ -663,7 +684,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
 
         for oracle in asset_info.oracles {
             self.set_app_governor_as_caller();
-            assets_dispatcher
+            assets_external_dispatcher
                 .add_oracle_to_asset(
                     asset_info.asset_id,
                     *oracle.key_pair.public_key,
@@ -1578,8 +1599,11 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         ref self: PerpsTestsFacade, synthetic_info: @SyntheticInfo, initial_price: u128,
     ) {
         let dispatcher = IAssetsDispatcher { contract_address: self.perpetuals_contract };
+        let asset_external_dispatcher = IAssetsExternalDispatcher {
+            contract_address: self.perpetuals_contract,
+        };
         self.set_app_governor_as_caller();
-        dispatcher
+        asset_external_dispatcher
             .add_synthetic_asset(
                 *synthetic_info.asset_id,
                 risk_factor_tiers: *synthetic_info.risk_factor_data.tiers,
@@ -1608,7 +1632,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
 
         for oracle in synthetic_info.oracles {
             self.set_app_governor_as_caller();
-            dispatcher
+            asset_external_dispatcher
                 .add_oracle_to_asset(
                     *synthetic_info.asset_id,
                     *oracle.key_pair.public_key,
@@ -1622,13 +1646,16 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
 
     fn deactivate_synthetic(ref self: PerpsTestsFacade, synthetic_id: AssetId) {
         self.set_app_governor_as_caller();
-        let dispatcher = IAssetsDispatcher { contract_address: self.perpetuals_contract };
-        dispatcher.deactivate_synthetic(:synthetic_id);
+        let assets_dispatcher = IAssetsDispatcher { contract_address: self.perpetuals_contract };
+        let asset_external_dispatcher = IAssetsExternalDispatcher {
+            contract_address: self.perpetuals_contract,
+        };
+        asset_external_dispatcher.deactivate_synthetic(:synthetic_id);
         assert_deactivate_synthetic_asset_event_with_expected(
             spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
             asset_id: synthetic_id,
         );
-        assert_eq!(dispatcher.get_asset_config(:synthetic_id).status, AssetStatus::INACTIVE);
+        assert_eq!(assets_dispatcher.get_asset_config(:synthetic_id).status, AssetStatus::INACTIVE);
     }
 
     fn reduce_inactive_asset_position(

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
@@ -1,5 +1,7 @@
 use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
-use perpetuals::core::components::assets::interface::IAssetsDispatcher;
+use perpetuals::core::components::assets::interface::{
+    IAssetsManagerDispatcher, IAssetsManagerDispatcherTrait,
+};
 use perpetuals::tests::constants::*;
 use perpetuals::tests::flow_tests::infra::*;
 use perpetuals::tests::flow_tests::perps_tests_facade::*;
@@ -39,7 +41,7 @@ fn test_registering_vault_shares_with_more_than_one_risk_tier_fails() {
     );
 
     let asset_id = asset_info.asset_id;
-    let assets_dispatcher = IAssetsDispatcher {
+    let assets_dispatcher = IAssetsManagerDispatcher {
         contract_address: state.facade.perpetuals_contract,
     };
 
@@ -53,7 +55,6 @@ fn test_registering_vault_shares_with_more_than_one_risk_tier_fails() {
             asset_id,
             erc20_contract_address: vault.contract_address,
             quantum: 1,
-            resolution_factor: asset_info.resolution_factor,
             risk_factor_tiers: risk_factor_1,
             :risk_factor_first_tier_boundary,
             :risk_factor_tier_size,

--- a/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
@@ -4,7 +4,7 @@ use core::poseidon::PoseidonTrait;
 use openzeppelin::presets::interfaces::{
     AccountUpgradeableABIDispatcher, AccountUpgradeableABIDispatcherTrait,
 };
-use perpetuals::core::components::assets::interface::IAssets;
+use perpetuals::core::components::assets::interface::{IAssets, IAssetsManager};
 use perpetuals::core::components::operator_nonce::interface::IOperatorNonce;
 use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
 use perpetuals::core::components::positions::interface::IPositions;
@@ -42,9 +42,10 @@ use starkware_utils_testing::test_utils::{
 };
 use crate::core::components::deposit::interface::IDeposit;
 use crate::core::components::external_components::interface::{
-    EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_DEPOSITS, EXTERNAL_COMPONENT_LIQUIDATIONS,
-    EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT, EXTERNAL_COMPONENT_WITHDRAWALS,
-    IExternalComponents, IExternalComponentsDispatcher, IExternalComponentsDispatcherTrait,
+    EXTERNAL_COMPONENT_ASSETS, EXTERNAL_COMPONENT_DELEVERAGES, EXTERNAL_COMPONENT_DEPOSITS,
+    EXTERNAL_COMPONENT_LIQUIDATIONS, EXTERNAL_COMPONENT_TRANSFERS, EXTERNAL_COMPONENT_VAULT,
+    EXTERNAL_COMPONENT_WITHDRAWALS, IExternalComponents, IExternalComponentsDispatcher,
+    IExternalComponentsDispatcherTrait,
 };
 use super::constants::{FORCED_ACTION_TIMELOCK, PREMIUM_COST};
 
@@ -401,7 +402,6 @@ pub fn setup_state_with_pending_vault_share(
             asset_id: *cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: *cfg.vault_share_cfg.contract_address,
             quantum: *cfg.vault_share_cfg.quantum,
-            resolution_factor: *cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: *cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: *cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: *cfg.vault_share_cfg.risk_factor_tier_size,
@@ -527,6 +527,8 @@ pub fn init_state(cfg: @PerpetualsInitConfig, token_state: @TokenState) -> Core:
         .unwrap()
         .contract_class();
 
+    let assets_external_component = snforge_std::declare("AssetsManager").unwrap().contract_class();
+
     cheat_caller_address(
         contract_address: test_address(),
         caller_address: *cfg.governance_admin,
@@ -565,6 +567,11 @@ pub fn init_state(cfg: @PerpetualsInitConfig, token_state: @TokenState) -> Core:
             component_type: EXTERNAL_COMPONENT_DEPOSITS,
             component_address: *deposit_external_component.class_hash,
         );
+    state
+        .register_external_component(
+            component_type: EXTERNAL_COMPONENT_ASSETS,
+            component_address: *assets_external_component.class_hash,
+        );
 
     state
         .activate_external_component(
@@ -596,6 +603,11 @@ pub fn init_state(cfg: @PerpetualsInitConfig, token_state: @TokenState) -> Core:
         .activate_external_component(
             component_type: EXTERNAL_COMPONENT_DEPOSITS,
             component_address: *deposit_external_component.class_hash,
+        );
+    state
+        .activate_external_component(
+            component_type: EXTERNAL_COMPONENT_ASSETS,
+            component_address: *assets_external_component.class_hash,
         );
 
     stop_cheat_caller_address(contract_address: test_address());
@@ -835,6 +847,7 @@ pub fn register_external_components_by_dispatcher(
     let deposit_external_component = snforge_std::declare("DepositManager")
         .unwrap()
         .contract_class();
+    let assets_external_component = snforge_std::declare("AssetsManager").unwrap().contract_class();
 
     cheat_caller_address(
         :contract_address, caller_address: GOVERNANCE_ADMIN(), span: CheatSpan::Indefinite,
@@ -870,6 +883,11 @@ pub fn register_external_components_by_dispatcher(
             component_type: EXTERNAL_COMPONENT_DEPOSITS,
             component_address: *deposit_external_component.class_hash,
         );
+    external_components_dispatcher
+        .register_external_component(
+            component_type: EXTERNAL_COMPONENT_ASSETS,
+            component_address: *assets_external_component.class_hash,
+        );
     start_cheat_block_timestamp_global(Time::now().add(Time::seconds(*cfg.upgrade_delay)).into());
     external_components_dispatcher
         .activate_external_component(
@@ -900,6 +918,11 @@ pub fn register_external_components_by_dispatcher(
         .activate_external_component(
             component_type: EXTERNAL_COMPONENT_DEPOSITS,
             component_address: *deposit_external_component.class_hash,
+        );
+    external_components_dispatcher
+        .activate_external_component(
+            component_type: EXTERNAL_COMPONENT_ASSETS,
+            component_address: *assets_external_component.class_hash,
         );
     stop_cheat_caller_address(:contract_address);
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -1,6 +1,7 @@
 use core::num::traits::{Pow, Zero};
 use perpetuals::core::components::assets::interface::{
-    IAssets, IAssetsDispatcher, IAssetsDispatcherTrait,
+    IAssets, IAssetsDispatcher, IAssetsDispatcherTrait, IAssetsManager, IAssetsManagerDispatcher,
+    IAssetsManagerDispatcherTrait,
 };
 use perpetuals::core::components::deposit::deposit_manager::deposit_hash;
 use perpetuals::core::components::deposit::interface::{
@@ -67,18 +68,23 @@ use crate::tests::event_test_utils::assert_add_spot_event_with_expected;
 
 #[test]
 fn test_constructor() {
+    // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = initialized_contract_state(cfg: @cfg, token_state: @token_state);
+
+    let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
+    let assets_dispatcher = IAssetsDispatcher { contract_address };
+
     assert!(state.roles.is_governance_admin(GOVERNANCE_ADMIN()));
     assert!(state.replaceability.get_upgrade_delay() == UPGRADE_DELAY);
-    assert!(state.assets.get_max_price_interval() == MAX_PRICE_INTERVAL);
-    assert!(state.assets.get_max_funding_interval() == MAX_FUNDING_INTERVAL);
-    assert!(state.assets.get_max_funding_rate() == MAX_FUNDING_RATE);
-    assert!(state.assets.get_max_oracle_price_validity() == MAX_ORACLE_PRICE_VALIDITY);
+    assert!(assets_dispatcher.get_max_price_interval() == MAX_PRICE_INTERVAL);
+    assert!(assets_dispatcher.get_max_funding_interval() == MAX_FUNDING_INTERVAL);
+    assert!(assets_dispatcher.get_max_funding_rate() == MAX_FUNDING_RATE);
+    assert!(assets_dispatcher.get_max_oracle_price_validity() == MAX_ORACLE_PRICE_VALIDITY);
     assert!(state.deposits.get_cancel_delay() == CANCEL_DELAY);
-    assert!(state.assets.get_last_funding_tick() == Time::now());
-    assert!(state.assets.get_last_price_validation() == Time::now());
+    assert!(assets_dispatcher.get_last_funding_tick() == Time::now());
+    assert!(assets_dispatcher.get_last_price_validation() == Time::now());
 
     assert!(
         state
@@ -231,6 +237,7 @@ fn test_signature_validation() {
 
     let dispatcher = ICoreSafeDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
+    let assets_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let deposit_dispatcher = IDepositDispatcher { contract_address };
     let position_dispatcher = IPositionsDispatcher { contract_address };
 
@@ -256,7 +263,7 @@ fn test_signature_validation() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    assets_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -267,7 +274,7 @@ fn test_signature_validation() {
         );
 
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    assets_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_2,
             :risk_factor_tiers,
@@ -279,7 +286,7 @@ fn test_signature_validation() {
 
     // Add to oracle.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    assets_manager_dispatcher
         .add_oracle_to_asset(
             asset_id: synthetic_id_1,
             oracle_public_key: oracle1.key_pair.public_key,
@@ -288,7 +295,7 @@ fn test_signature_validation() {
         );
 
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    assets_manager_dispatcher
         .add_oracle_to_asset(
             asset_id: synthetic_id_2,
             oracle_public_key: oracle1.key_pair.public_key,
@@ -889,6 +896,7 @@ fn test_rf_update_valid_same_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -901,7 +909,7 @@ fn test_rf_update_valid_same_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -931,6 +939,7 @@ fn test_rf_update_valid_same_short_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -943,7 +952,7 @@ fn test_rf_update_valid_same_short_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -975,6 +984,7 @@ fn test_rf_update_invalid_same_short_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -988,7 +998,7 @@ fn test_rf_update_invalid_same_short_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1019,6 +1029,7 @@ fn test_rf_update_invalid_super_short_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1032,7 +1043,7 @@ fn test_rf_update_invalid_super_short_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1062,6 +1073,7 @@ fn test_rf_update_valid_super_short_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1075,7 +1087,7 @@ fn test_rf_update_valid_super_short_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1106,6 +1118,7 @@ fn test_rf_update_valid_same_super_short_array_increase() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1119,7 +1132,7 @@ fn test_rf_update_valid_same_super_short_array_increase() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1150,6 +1163,7 @@ fn test_rf_update_invalid_same_short_array_increase() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1163,7 +1177,7 @@ fn test_rf_update_invalid_same_short_array_increase() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1194,6 +1208,7 @@ fn test_rf_update_valid_lower_array() {
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
     let asset_dispatcher = IAssetsDispatcher { contract_address };
+    let assets_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
 
@@ -1206,7 +1221,7 @@ fn test_rf_update_valid_lower_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    assets_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1228,7 +1243,7 @@ fn test_rf_update_valid_lower_array() {
         );
 
     let synthetic_config = asset_dispatcher.get_asset_config(synthetic_id: synthetic_id_1);
-    let tiers = asset_dispatcher.get_risk_factor_tiers(asset_id: synthetic_id_1);
+    let tiers = assets_manager_dispatcher.get_risk_factor_tiers(asset_id: synthetic_id_1);
     for i in 0..risk_factor_tiers_2.len() {
         assert!(*tiers[i] == RiskFactorTrait::new(*risk_factor_tiers_2[i]));
     }
@@ -1245,6 +1260,7 @@ fn test_rf_update_invalid_higher_last_element_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1258,7 +1274,7 @@ fn test_rf_update_invalid_higher_last_element_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1289,6 +1305,7 @@ fn test_rf_update_invalid_median_last_element_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1302,7 +1319,7 @@ fn test_rf_update_invalid_median_last_element_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1332,6 +1349,7 @@ fn test_rf_update_valid_more_frequent_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1346,7 +1364,7 @@ fn test_rf_update_valid_more_frequent_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1379,6 +1397,7 @@ fn test_rf_update_invalid_more_frequent_array() {
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
     let mut spy = snforge_std::spy_events();
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1393,7 +1412,7 @@ fn test_rf_update_invalid_more_frequent_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1433,6 +1452,7 @@ fn test_rf_update_valid_less_frequent_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1447,7 +1467,7 @@ fn test_rf_update_valid_less_frequent_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1478,6 +1498,7 @@ fn test_rf_update_invalid_less_frequent_array() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1492,7 +1513,7 @@ fn test_rf_update_invalid_less_frequent_array() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1525,6 +1546,7 @@ fn test_rf_update_valid_different_step_size() {
     let mut spy = snforge_std::spy_events();
 
     let asset_dispatcher = IAssetsDispatcher { contract_address };
+    let assets_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
 
@@ -1539,7 +1561,7 @@ fn test_rf_update_valid_different_step_size() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    assets_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -1561,7 +1583,7 @@ fn test_rf_update_valid_different_step_size() {
         );
 
     let synthetic_config = asset_dispatcher.get_asset_config(synthetic_id: synthetic_id_1);
-    let tiers = asset_dispatcher.get_risk_factor_tiers(asset_id: synthetic_id_1);
+    let tiers = assets_manager_dispatcher.get_risk_factor_tiers(asset_id: synthetic_id_1);
     for i in 0..risk_factor_tiers_2.len() {
         assert!(*tiers[i] == RiskFactorTrait::new(*risk_factor_tiers_2[i]));
     }
@@ -1591,6 +1613,7 @@ fn test_rf_update_invalid_different_step_size() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let contract_address = init_by_dispatcher(cfg: @cfg, token_state: @token_state);
 
+    let asset_manager_dispatcher = IAssetsManagerDispatcher { contract_address };
     let asset_dispatcher = IAssetsDispatcher { contract_address };
 
     let synthetic_id_1 = SYNTHETIC_ASSET_ID_1();
@@ -1605,7 +1628,7 @@ fn test_rf_update_invalid_different_step_size() {
 
     // Add synthetic assets.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
-    asset_dispatcher
+    asset_manager_dispatcher
         .add_synthetic_asset(
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -4027,7 +4050,6 @@ fn test_unsuccessful_add_vault_share_asset_zero_quantum() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: vault_share_state.address,
             quantum: 0,
-            resolution_factor: 1_000_000_000,
             risk_factor_tiers: risk_factor_1,
             :risk_factor_first_tier_boundary,
             :risk_factor_tier_size,
@@ -4036,9 +4058,7 @@ fn test_unsuccessful_add_vault_share_asset_zero_quantum() {
 }
 
 #[test]
-#[should_panic(
-    expected: "Entry point selector 0x4c4fb1ab068f6039d5780c68dd0fa2f8742cceb3426d19667778ca7f3518a9 not found in contract 0x1724987234973219347210837402",
-)]
+#[should_panic(expected: 'ENTRYPOINT_NOT_FOUND')]
 fn test_unsuccessful_add_vault_share_asset_not_erc20() {
     // Setup state, token:
     let cfg: PerpetualsInitConfig = Default::default();
@@ -4057,7 +4077,6 @@ fn test_unsuccessful_add_vault_share_asset_not_erc20() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: test_address(),
             quantum: 1,
-            resolution_factor: 1_000_000_000,
             risk_factor_tiers: risk_factor_1,
             :risk_factor_first_tier_boundary,
             :risk_factor_tier_size,
@@ -4084,7 +4103,6 @@ fn test_successful_add_vault_share_asset() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
@@ -4135,7 +4153,6 @@ fn test_successful_vault_token_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
@@ -4278,7 +4295,6 @@ fn test_successful_vault_token_cancel_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
@@ -4385,7 +4401,6 @@ fn test_successful_vault_share_process_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves governance asset management into a new external `AssetsManager` component and wires it via `ExternalComponents`, updating interfaces and tests accordingly.
> 
> - **Contracts**:
>   - **Externalization**: Introduces `assets/assets_manager.cairo` contract implementing `IAssetsExternal` to handle governance actions: `add_oracle_to_asset`, `add_synthetic_asset`, `add_vault_collateral_asset`, `deactivate_synthetic`, `remove_oracle_from_asset`, `update_synthetic_quorum`, and view `get_risk_factor_tiers`.
>   - **Assets component**: Keeps operator-sequenced flows (`funding_tick`, `price_tick`, `update_synthetic_asset_risk_factor`, views) and delegates management calls through `ExternalComponents._get_assets_manager_dispatcher()` via new `IAssetsManager` facade.
>   - **External Components wiring**:
>     - Adds `EXTERNAL_COMPONENT_ASSETS` and dispatcher getter `_get_assets_manager_dispatcher()`.
>     - Enables registration/activation paths for the new component.
>   - **Core**: Embeds `AssetsManagerImpl` alongside existing `AssetsImpl`.
> - **Interfaces**:
>   - Splits responsibilities between `IAssets` (ops) and `IAssetsManager` (governance). Changes `add_vault_collateral_asset` signature to drop `resolution_factor` (derived from ERC20 decimals).
> - **Tests**:
>   - Update to register/activate `ASSETS` external component and use `IAssetsExternalDispatcher`/`IAssetsManagerDispatcher` where applicable.
>   - Adjust expectations (e.g., `ENTRYPOINT_NOT_FOUND` for non-ERC20).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b120b3f87c21c753632f2f3a44ae86554ba10971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/146)
<!-- Reviewable:end -->
