### PR TITLE
move runs to namespace instead of regulat ubuntu runner by github.

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cairo_tests:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2xlarge-ubuntu-24-04-amd64
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the `cairo_tests` job to run on `namespace-profile-2xlarge-ubuntu-24-04-amd64` instead of `ubuntu-latest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae326863ee8421845dd17e5dd793d7e0926ee427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/152)
<!-- Reviewable:end -->
