### PR TITLE
chore: reduce contract size

### DIFF
--- a/Scarb.toml
+++ b/Scarb.toml
@@ -15,11 +15,11 @@ test = "snforge test --max-n-steps 10000000000"
 [profile.dev.cairo]
 unstable-add-statements-code-locations-debug-info = true
 unstable-add-statements-functions-debug-info = true
-inlining-strategy = "avoid"
+inlining-strategy = 20
 panic-backtrace = true
 
 [profile.release.cairo]
-inlining-strategy = "avoid"
+inlining-strategy = 20
 
 [workspace.tool.scarb]
 allow-prebuilt-plugins = ["snforge_std"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches Cairo `inlining-strategy` from "avoid" to `20` in dev and release profiles to help reduce contract size.
> 
> - **Config**:
>   - Update `Scarb.toml`:
>     - In `[profile.dev.cairo]`, set `inlining-strategy = 20` (was `"avoid"`).
>     - In `[profile.release.cairo]`, set `inlining-strategy = 20` (was `"avoid"`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 903266fdad6aba1bb6cbfb309250fab9fc9433be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/153)
<!-- Reviewable:end -->
