### PR TITLE
test(perpetuals): add force trade tests

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -595,3 +595,97 @@ pub fn assert_update_asset_quorum_event_with_expected(
         expected_event_name: "AssetQuorumUpdated",
     );
 }
+
+pub fn assert_forced_trade_request_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    order_a_position_id: PositionId,
+    order_a_base_asset_id: AssetId,
+    order_a_base_amount: i64,
+    order_a_quote_asset_id: AssetId,
+    order_a_quote_amount: i64,
+    fee_a_asset_id: AssetId,
+    fee_a_amount: u64,
+    order_b_position_id: PositionId,
+    order_b_base_asset_id: AssetId,
+    order_b_base_amount: i64,
+    order_b_quote_asset_id: AssetId,
+    order_b_quote_amount: i64,
+    fee_b_asset_id: AssetId,
+    fee_b_amount: u64,
+    order_a_hash: felt252,
+    order_b_hash: felt252,
+) {
+    let expected_event = events::ForcedTradeRequest {
+        order_a_position_id,
+        order_a_base_asset_id,
+        order_a_base_amount,
+        order_a_quote_asset_id,
+        order_a_quote_amount,
+        fee_a_asset_id,
+        fee_a_amount,
+        order_b_position_id,
+        order_b_base_asset_id,
+        order_b_base_amount,
+        order_b_quote_asset_id,
+        order_b_quote_amount,
+        fee_b_asset_id,
+        fee_b_amount,
+        order_a_hash,
+        order_b_hash,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("ForcedTradeRequest"),
+        expected_event_name: "ForcedTradeRequest",
+    );
+}
+
+pub fn assert_forced_trade_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    order_a_position_id: PositionId,
+    order_a_base_asset_id: AssetId,
+    order_a_base_amount: i64,
+    order_a_quote_asset_id: AssetId,
+    order_a_quote_amount: i64,
+    fee_a_asset_id: AssetId,
+    fee_a_amount: u64,
+    order_b_position_id: PositionId,
+    order_b_base_asset_id: AssetId,
+    order_b_base_amount: i64,
+    order_b_quote_asset_id: AssetId,
+    order_b_quote_amount: i64,
+    fee_b_asset_id: AssetId,
+    fee_b_amount: u64,
+    actual_amount_base_a: i64,
+    actual_amount_quote_a: i64,
+    order_a_hash: felt252,
+    order_b_hash: felt252,
+) {
+    let expected_event = events::ForcedTrade {
+        order_a_position_id,
+        order_a_base_asset_id,
+        order_a_base_amount,
+        order_a_quote_asset_id,
+        order_a_quote_amount,
+        fee_a_asset_id,
+        fee_a_amount,
+        order_b_position_id,
+        order_b_base_asset_id,
+        order_b_base_amount,
+        order_b_quote_asset_id,
+        order_b_quote_amount,
+        fee_b_asset_id,
+        fee_b_amount,
+        actual_amount_base_a,
+        actual_amount_quote_a,
+        order_a_hash,
+        order_b_hash,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("ForcedTrade"),
+        expected_event_name: "ForcedTrade",
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds coverage for forced trade flows and supporting event helpers.
> 
> - New helpers in `event_test_utils.cairo`: `assert_forced_trade_request_event_with_expected` and `assert_forced_trade_event_with_expected`
> - Unit tests in `unit_tests.cairo` validate:
>   - Successful `forced_trade_request` (premium charged) and `forced_trade` execution after timelock
>   - Operator can execute before timelock; non-operator blocked with `FORCED_WAIT_REQUIRED`
>   - Duplicate execution blocked with `REQUEST_ALREADY_PROCESSED` (both operator-after-user and user-after-operator cases)
>   - Insufficient premium reverts (ERC20 insufficient balance)
>   - Balance updates and emitted events (`Trade`, `ForcedTradeRequest`, `ForcedTrade`) match expectations
> - Minor imports: `BalanceTrait`, `ForcedTrade` type
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23267c9496cdd0d6f9b77114c7c1bb4f903cc3ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/156)
<!-- Reviewable:end -->
