### PR TITLE
chore(perpetuals): rename abis

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -78,12 +78,12 @@ classDiagram
         add_oracle_to_asset()
         add_synthetic_asset()
         add_vault_collateral_asset()
-        update_synthetic_asset_risk_factor()
+        update_asset_risk_factor()
         deactivate_synthetic()
         funding_tick()
         price_tick()
         remove_oracle_from_asset()
-        update_synthetic_quorum()
+        update_asset_id_quorum()
 
         get_collateral_token_contract() -> IERC20Dispatcher
         get_collateral_quantum() -> u64
@@ -1774,7 +1774,7 @@ Only APP\_GOVERNOR can execute.
 - INVALID_VAULT_RF_TIERS
 
 
-###### Update Synthetic Asset Risk Factor
+###### Update Asset Risk Factor
 
 Update asset risk factors. This function must be sequenced by the operator to prevent liquidation failures if submitted out of order.
 
@@ -1941,9 +1941,9 @@ Only APP\_GOVERNOR can execute.
 ###### Update Synthetic Quorum
 
 ```rust
-fn update_synthetic_quorum(
+fn update_asset_quorum(
     ref self: ContractState,
-    synthetic_id: AssetId,
+    asset_id: AssetId,
     quorum: u8
 )
 ```
@@ -1961,7 +1961,7 @@ Only APP\_GOVERNOR can execute.
 **Logic:**
 
 1. Run validations
-2. Update `quorum` of the `synthetic_id` config.
+2. Update `quorum` of the `asset_id` config.
 
 **Emits:**
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -295,7 +295,6 @@ pub mod AssetsComponent {
             asset_id: AssetId,
             erc20_contract_address: ContractAddress,
             quantum: u64,
-            resolution_factor: u64,
             risk_factor_tiers: Span<u16>,
             risk_factor_first_tier_boundary: u128,
             risk_factor_tier_size: u128,
@@ -309,7 +308,6 @@ pub mod AssetsComponent {
                     asset_id: asset_id,
                     erc20_contract_address: erc20_contract_address,
                     quantum: quantum,
-                    resolution_factor: resolution_factor,
                     risk_factor_tiers: risk_factor_tiers,
                     risk_factor_first_tier_boundary: risk_factor_first_tier_boundary,
                     risk_factor_tier_size: risk_factor_tier_size,
@@ -317,7 +315,7 @@ pub mod AssetsComponent {
                 );
         }
 
-        fn update_synthetic_asset_risk_factor(
+        fn update_asset_risk_factor(
             ref self: ComponentState<TContractState>,
             operator_nonce: u64,
             asset_id: AssetId,
@@ -332,7 +330,7 @@ pub mod AssetsComponent {
             let external_components = get_dep_component!(@self, ExternalComponents);
             external_components
                 ._get_assets_manager_dispatcher()
-                .update_synthetic_asset_risk_factor(
+                .update_asset_risk_factor(
                     operator_nonce: operator_nonce,
                     asset_id: asset_id,
                     risk_factor_tiers: risk_factor_tiers,
@@ -361,14 +359,14 @@ pub mod AssetsComponent {
                 .remove_oracle_from_asset(asset_id: asset_id, oracle_public_key: oracle_public_key);
         }
 
-        fn update_synthetic_quorum(
-            ref self: ComponentState<TContractState>, synthetic_id: AssetId, quorum: u8,
+        fn update_asset_quorum(
+            ref self: ComponentState<TContractState>, asset_id: AssetId, quorum: u8,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
             let external_components = get_dep_component!(@self, ExternalComponents);
             external_components
                 ._get_assets_manager_dispatcher()
-                .update_synthetic_quorum(synthetic_id: synthetic_id, quorum: quorum);
+                .update_asset_quorum(:asset_id, :quorum);
         }
 
         // View functions for manager

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -57,7 +57,7 @@ pub trait IAssetsManager<TContractState> {
         quorum: u8,
         resolution_factor: u64,
     );
-    fn update_synthetic_asset_risk_factor(
+    fn update_asset_risk_factor(
         ref self: TContractState,
         operator_nonce: u64,
         asset_id: AssetId,
@@ -70,7 +70,6 @@ pub trait IAssetsManager<TContractState> {
         asset_id: AssetId,
         erc20_contract_address: ContractAddress,
         quantum: u64,
-        resolution_factor: u64,
         risk_factor_tiers: Span<u16>,
         risk_factor_first_tier_boundary: u128,
         risk_factor_tier_size: u128,
@@ -80,7 +79,7 @@ pub trait IAssetsManager<TContractState> {
     fn remove_oracle_from_asset(
         ref self: TContractState, asset_id: AssetId, oracle_public_key: PublicKey,
     );
-    fn update_synthetic_quorum(ref self: TContractState, synthetic_id: AssetId, quorum: u8);
+    fn update_asset_quorum(ref self: TContractState, asset_id: AssetId, quorum: u8);
 
     // View functions.
     fn get_max_price_interval(self: @TContractState) -> TimeDelta;

--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -525,7 +525,7 @@ pub fn assert_add_oracle_event_with_expected(
     );
 }
 
-pub fn assert_update_synthetic_quorum_event_with_expected(
+pub fn assert_update_asset_quorum_event_with_expected(
     spied_event: @(ContractAddress, Event), asset_id: AssetId, new_quorum: u8, old_quorum: u8,
 ) {
     let expected_event = assets_events::AssetQuorumUpdated { asset_id, new_quorum, old_quorum };

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -667,7 +667,6 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 asset_id,
                 erc20_contract_address: vault.contract_address,
                 quantum: 1,
-                resolution_factor: asset_info.resolution_factor,
                 risk_factor_tiers: risk_factor_1,
                 :risk_factor_first_tier_boundary,
                 :risk_factor_tier_size,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
@@ -54,7 +54,6 @@ fn test_registering_vault_shares_with_more_than_one_risk_tier_fails() {
             asset_id,
             erc20_contract_address: vault.contract_address,
             quantum: 1,
-            resolution_factor: asset_info.resolution_factor,
             risk_factor_tiers: risk_factor_1,
             :risk_factor_first_tier_boundary,
             :risk_factor_tier_size,

--- a/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
@@ -402,7 +402,6 @@ pub fn setup_state_with_pending_vault_share(
             asset_id: *cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: *cfg.vault_share_cfg.contract_address,
             quantum: *cfg.vault_share_cfg.quantum,
-            resolution_factor: *cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: *cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: *cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: *cfg.vault_share_cfg.risk_factor_tier_size,

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -41,7 +41,7 @@ use perpetuals::tests::event_test_utils::{
     assert_set_owner_account_event_with_expected, assert_set_public_key_event_with_expected,
     assert_set_public_key_request_event_with_expected, assert_trade_event_with_expected,
     assert_transfer_event_with_expected, assert_transfer_request_event_with_expected,
-    assert_update_synthetic_quorum_event_with_expected,
+    assert_update_asset_quorum_event_with_expected,
 };
 use perpetuals::tests::test_utils::{
     Oracle, OracleTrait, PerpetualsInitConfig, User, UserTrait, add_synthetic_to_position,
@@ -904,7 +904,7 @@ fn test_rf_update_valid_same_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -946,7 +946,7 @@ fn test_rf_update_valid_same_short_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             :risk_factor_tiers,
@@ -991,7 +991,7 @@ fn test_rf_update_invalid_same_short_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1035,7 +1035,7 @@ fn test_rf_update_invalid_super_short_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1078,7 +1078,7 @@ fn test_rf_update_valid_super_short_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1122,7 +1122,7 @@ fn test_rf_update_valid_same_super_short_array_increase() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1166,7 +1166,7 @@ fn test_rf_update_invalid_same_short_array_increase() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1210,7 +1210,7 @@ fn test_rf_update_valid_lower_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     assets_manager_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1262,7 +1262,7 @@ fn test_rf_update_invalid_higher_last_element_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1306,7 +1306,7 @@ fn test_rf_update_invalid_median_last_element_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1350,7 +1350,7 @@ fn test_rf_update_valid_more_frequent_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1397,7 +1397,7 @@ fn test_rf_update_invalid_more_frequent_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1451,7 +1451,7 @@ fn test_rf_update_valid_less_frequent_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1496,7 +1496,7 @@ fn test_rf_update_invalid_less_frequent_array() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1544,7 +1544,7 @@ fn test_rf_update_valid_different_step_size() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     assets_manager_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -1610,7 +1610,7 @@ fn test_rf_update_invalid_different_step_size() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     // Test:
     asset_dispatcher
-        .update_synthetic_asset_risk_factor(
+        .update_asset_risk_factor(
             operator_nonce: 0,
             asset_id: synthetic_id_1,
             risk_factor_tiers: risk_factor_tiers_2,
@@ -3825,7 +3825,7 @@ fn test_successful_add_and_remove_oracle() {
             :asset_name,
         );
 
-    state.update_synthetic_quorum(:synthetic_id, quorum: 2);
+    state.update_asset_quorum(asset_id: synthetic_id, quorum: 2);
 
     // Add another oracle for the same asset id.
     let asset_name = 'ASSET_NAME';
@@ -3843,7 +3843,7 @@ fn test_successful_add_and_remove_oracle() {
     state.remove_oracle_from_asset(asset_id: synthetic_id, oracle_public_key: key_pair.public_key);
 
     let events = spy.get_events().emitted_by(test_address()).events;
-    assert_update_synthetic_quorum_event_with_expected(
+    assert_update_asset_quorum_event_with_expected(
         spied_event: events[1], asset_id: synthetic_id, new_quorum: 2, old_quorum: 1,
     );
     assert_add_oracle_event_with_expected(
@@ -4007,7 +4007,6 @@ fn test_unsuccessful_add_vault_share_asset_zero_quantum() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: vault_share_state.address,
             quantum: 0,
-            resolution_factor: 1_000_000_000,
             risk_factor_tiers: risk_factor_1,
             :risk_factor_first_tier_boundary,
             :risk_factor_tier_size,
@@ -4035,7 +4034,6 @@ fn test_unsuccessful_add_vault_share_asset_not_erc20() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: test_address(),
             quantum: 1,
-            resolution_factor: 1_000_000_000,
             risk_factor_tiers: risk_factor_1,
             :risk_factor_first_tier_boundary,
             :risk_factor_tier_size,
@@ -4062,7 +4060,6 @@ fn test_successful_add_vault_share_asset() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
@@ -4113,7 +4110,6 @@ fn test_successful_vault_token_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
@@ -4256,7 +4252,6 @@ fn test_successful_vault_token_cancel_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
@@ -4363,7 +4358,6 @@ fn test_successful_vault_share_process_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            resolution_factor: cfg.vault_share_cfg.resolution_factor,
             risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
             risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
             risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Renames synthetic-focused APIs to asset-wide (`update_asset_risk_factor`, `update_asset_quorum`) and removes `resolution_factor` from `add_vault_collateral_asset` (now computed/validated), updating contracts, interfaces, docs, and tests.
> 
> - **Contracts (assets manager/components/interfaces)**:
>   - Rename `update_synthetic_asset_risk_factor` -> `update_asset_risk_factor` and `update_synthetic_quorum` -> `update_asset_quorum` (use `asset_id`).
>   - Change `add_vault_collateral_asset` signature: remove `resolution_factor`; compute/validate from underlying ERC20 decimals and `quantum`; emit with calculated `resolution_factor`.
>   - Keep validations/events; write paths adjusted to use `asset_id`.
> - **Docs/spec**:
>   - Update headings and function signatures to `update_asset_risk_factor` and `update_asset_quorum` (with `asset_id`).
>   - Document vault collateral addition without `resolution_factor` param and its validations.
> - **Tests**:
>   - Update event/assert helpers and calls to `update_asset_quorum`.
>   - Remove `resolution_factor` arg where adding vault collateral assets.
>   - Replace calls to `update_synthetic_asset_risk_factor` with `update_asset_risk_factor` across unit/flow tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a91981b4538c818aa2a5f4dbd98cfc28129b03a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/161)
<!-- Reviewable:end -->
