### PR TITLE
feat(perpetuals): impl add spot asset

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -326,6 +326,33 @@ pub mod AssetsComponent {
                 );
         }
 
+        fn add_spot_asset(
+            ref self: ComponentState<TContractState>,
+            asset_id: AssetId,
+            erc20_contract_address: ContractAddress,
+            quantum: u64,
+            resolution_factor: u64,
+            risk_factor_tiers: Span<u16>,
+            risk_factor_first_tier_boundary: u128,
+            risk_factor_tier_size: u128,
+            quorum: u8,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+            let external_components = get_dep_component!(@self, ExternalComponents);
+            external_components
+                ._get_assets_manager_dispatcher()
+                .add_spot_asset(
+                    :asset_id,
+                    :erc20_contract_address,
+                    :quantum,
+                    :resolution_factor,
+                    :risk_factor_tiers,
+                    :risk_factor_first_tier_boundary,
+                    :risk_factor_tier_size,
+                    :quorum,
+                );
+        }
+
         fn update_asset_risk_factor(
             ref self: ComponentState<TContractState>,
             operator_nonce: u64,

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/events.cairo
@@ -46,6 +46,7 @@ pub struct SpotAssetAdded {
     pub resolution_factor: u64,
     pub quorum: u8,
     pub contract_address: ContractAddress,
+    pub quantum: u64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -78,6 +78,17 @@ pub trait IAssetsManager<TContractState> {
         risk_factor_tier_size: u128,
         quorum: u8,
     );
+    fn add_spot_asset(
+        ref self: TContractState,
+        asset_id: AssetId,
+        erc20_contract_address: ContractAddress,
+        quantum: u64,
+        resolution_factor: u64,
+        risk_factor_tiers: Span<u16>,
+        risk_factor_first_tier_boundary: u128,
+        risk_factor_tier_size: u128,
+        quorum: u8,
+    );
     fn deactivate_synthetic(ref self: TContractState, synthetic_id: AssetId);
     fn remove_oracle_from_asset(
         ref self: TContractState, asset_id: AssetId, oracle_public_key: PublicKey,

--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -521,6 +521,7 @@ pub fn assert_add_spot_event_with_expected(
     resolution_factor: u64,
     quorum: u8,
     contract_address: ContractAddress,
+    quantum: u64,
 ) {
     let expected_event = assets_events::SpotAssetAdded {
         asset_id,
@@ -530,6 +531,7 @@ pub fn assert_add_spot_event_with_expected(
         resolution_factor,
         quorum,
         contract_address,
+        quantum,
     };
     assert_expected_event_emitted(
         :spied_event,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -682,6 +682,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             resolution_factor: asset_info.resolution_factor,
             quorum: asset_info.oracles.len().try_into().unwrap(),
             contract_address: vault.contract_address,
+            quantum: 1,
         );
 
         for oracle in asset_info.oracles {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements `add_spot_asset` end-to-end (interfaces, manager, component), adds validations and storage writes, updates `SpotAssetAdded` to include `quantum`, and adds/updates tests.
> 
> - **Contracts / Assets**:
>   - **Spot Asset Registration**: Implement `add_spot_asset` in `core/components/assets/assets_manager.cairo` with validations, creation via `SyntheticTrait::spot`, storage writes (`asset_config`, `timely_data`, `risk_factor_tiers`), and event emit.
>   - **Forwarding Method**: Add `add_spot_asset` to `core/components/assets/assets.cairo` to call external dispatcher.
>   - **Interfaces**: Add `add_spot_asset` to `core/components/assets/assets_manager.cairo::IAssetsExternal` and `core/components/assets/interface.cairo::IAssetsManager`.
>   - **Events**: Extend `SpotAssetAdded` with `quantum` and update emissions accordingly (including `add_vault_collateral_asset`).
> - **Tests**:
>   - Update `tests/event_test_utils.cairo` and `flow_tests/perps_tests_facade.cairo` to assert `quantum` in `SpotAssetAdded`.
>   - Add unit tests for successful spot addition and failure cases (zero `quantum`, asset already exists).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1639bb03dd62124e55d3b7e7d265b3f79fbc7ce6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/162)
<!-- Reviewable:end -->
