### PR TITLE
fix(perpetuals): funding tick assert only synthetic

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -146,10 +146,9 @@ pub mod AssetsComponent {
             for funding_tick in funding_ticks {
                 let synthetic_id = *funding_tick.asset_id;
                 assert(synthetic_id > prev_synthetic_id, FUNDING_TICKS_NOT_SORTED);
-                assert(
-                    self._get_asset_config(:synthetic_id).status == AssetStatus::ACTIVE,
-                    SYNTHETIC_NOT_ACTIVE,
-                );
+                let asset_config = self._get_asset_config(:synthetic_id);
+                assert(asset_config.asset_type == AssetType::SYNTHETIC, NOT_SYNTHETIC);
+                assert(asset_config.status == AssetStatus::ACTIVE, SYNTHETIC_NOT_ACTIVE);
                 self
                     ._process_funding_tick(
                         :time_diff,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Validate `funding_tick` only processes active synthetic assets (assert `asset_type == SYNTHETIC`), and add unit tests for collateral and vault-share cases.
> 
> - **Contracts (`assets.cairo`)**:
>   - Tighten `funding_tick` validation: fetch `asset_config`, assert `asset_type == AssetType::SYNTHETIC` (`NOT_SYNTHETIC`) and `status == ACTIVE` before processing.
> - **Tests**:
>   - Add `test_funding_tick_collateral_asset` expecting `SYNTHETIC_NOT_EXISTS` when collateral ID is used.
>   - Add `test_funding_tick_vault_share_asset` expecting `NOT_SYNTHETIC` for vault-share collateral asset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aa4e48e3b1329cdb47403fa580757067c84ce94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/163)
<!-- Reviewable:end -->
