### PR TITLE
chore(perpetuals): get collateral token contract address

### DIFF
--- a/devnet_tests/perpetuals_test_utils.py
+++ b/devnet_tests/perpetuals_test_utils.py
@@ -107,9 +107,9 @@ class PerpetualsTestUtils:
         (asset_id,) = await self.operator_contract.functions["get_collateral_id"].call()
         return asset_id["value"]
 
-    async def get_collateral_token_contract(self) -> int:
+    async def get_base_collateral_token_contract(self) -> int:
         (token_contract,) = await self.operator_contract.functions[
-            "get_collateral_token_contract"
+            "get_base_collateral_token_contract"
         ].call()
         return token_contract["contract_address"]
 
@@ -160,13 +160,13 @@ class PerpetualsTestUtils:
             """Fund an account with collateral tokens using the rich USDC holder account."""
             # Get the ERC20 contract
             abi, cairo_version = await ContractAbiResolver(
-                address=await self.get_collateral_token_contract(),
+                address=await self.get_base_collateral_token_contract(),
                 client=self.rich_usdc_holder_account.client,
                 proxy_config=ProxyConfig(),
             ).resolve()
 
             erc20_contract = Contract(
-                address=await self.get_collateral_token_contract(),
+                address=await self.get_base_collateral_token_contract(),
                 abi=abi,
                 provider=self.rich_usdc_holder_account,
                 cairo_version=cairo_version,
@@ -183,13 +183,13 @@ class PerpetualsTestUtils:
         # Approve deposit
         async def _approve_deposit(account: Account, amount: int):
             abi, cairo_version = await ContractAbiResolver(
-                address=await self.get_collateral_token_contract(),
+                address=await self.get_base_collateral_token_contract(),
                 client=account.client,
                 proxy_config=ProxyConfig(),
             ).resolve()
 
             erc20_contract = Contract(
-                address=await self.get_collateral_token_contract(),
+                address=await self.get_base_collateral_token_contract(),
                 abi=abi,
                 provider=account,
                 cairo_version=cairo_version,

--- a/devnet_tests/system_test.py
+++ b/devnet_tests/system_test.py
@@ -40,8 +40,8 @@ async def test_view_functions(test_utils: PerpetualsTestUtils):
     collateral_asset_id = await test_utils.get_collateral_asset_id()
     assert collateral_asset_id == 1
 
-    # Test get_collateral_token_contract
-    token_contract = await test_utils.get_collateral_token_contract()
+    # Test get_base_collateral_token_contract
+    token_contract = await test_utils.get_base_collateral_token_contract()
     assert token_contract > 0
 
     # Test get_num_of_active_synthetic_assets

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -85,7 +85,8 @@ classDiagram
         remove_oracle_from_asset()
         update_asset_id_quorum()
 
-        get_collateral_token_contract() -> IERC20Dispatcher
+        get_base_collateral_token_contract() -> IERC20Dispatcher
+        get_collateral_token_contract_address(asset_id: AssetId) -> ContractAddress
         get_collateral_quantum() -> u64
         get_last_funding_tick() -> Timestamp
         get_last_price_validation() -> Timestamp

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -13,8 +13,8 @@ pub mod AssetsComponent {
         ALREADY_INITIALIZED, ASSET_NOT_EXISTS, COLLATERAL_NOT_REGISTERED, FUNDING_EXPIRED,
         FUNDING_TICKS_NOT_SORTED, INACTIVE_ASSET, INVALID_FUNDING_TICK_LEN, INVALID_MEDIAN,
         INVALID_PRICE_TIMESTAMP, INVALID_TIMESTAMP, INVALID_ZERO_ASSET_ID, INVALID_ZERO_QUANTUM,
-        INVALID_ZERO_TOKEN_ADDRESS, NOT_SYNTHETIC, QUORUM_NOT_REACHED, SIGNED_PRICES_UNSORTED,
-        SYNTHETIC_EXPIRED_PRICE, SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS,
+        INVALID_ZERO_TOKEN_ADDRESS, NOT_COLLATERAL, NOT_SYNTHETIC, QUORUM_NOT_REACHED,
+        SIGNED_PRICES_UNSORTED, SYNTHETIC_EXPIRED_PRICE, SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS,
         ZERO_MAX_FUNDING_INTERVAL, ZERO_MAX_FUNDING_RATE, ZERO_MAX_ORACLE_PRICE,
         ZERO_MAX_PRICE_INTERVAL, oracle_public_key_not_registered,
     };
@@ -191,7 +191,19 @@ pub mod AssetsComponent {
             self._set_price(:asset_id, :oracle_price);
         }
 
-        fn get_collateral_token_contract(
+        fn get_collateral_token_contract_address(
+            self: @ComponentState<TContractState>, asset_id: AssetId,
+        ) -> ContractAddress {
+            // Base collateral is not registered in `asset_config`.
+            if asset_id == self.get_collateral_id() {
+                self.get_base_collateral_token_contract().contract_address
+            } else {
+                let token_contract = self._get_asset_config(asset_id).token_contract;
+                token_contract.expect(NOT_COLLATERAL)
+            }
+        }
+
+        fn get_base_collateral_token_contract(
             self: @ComponentState<TContractState>,
         ) -> IERC20Dispatcher {
             self.collateral_token_contract.read()

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -27,7 +27,10 @@ pub trait IAssets<TContractState> {
     );
 
     // View functions.
-    fn get_collateral_token_contract(self: @TContractState) -> IERC20Dispatcher;
+    fn get_collateral_token_contract_address(
+        self: @TContractState, asset_id: AssetId,
+    ) -> ContractAddress;
+    fn get_base_collateral_token_contract(self: @TContractState) -> IERC20Dispatcher;
     fn get_collateral_quantum(self: @TContractState) -> u64;
     fn get_last_funding_tick(self: @TContractState) -> Timestamp;
     fn get_last_price_validation(self: @TContractState) -> Timestamp;

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -231,7 +231,7 @@ pub(crate) mod DepositManager {
             let (token_contract, quantum, position_diff) = if (self
                 .assets
                 .get_collateral_id() == asset_id) {
-                let token_contract = self.assets.get_collateral_token_contract();
+                let token_contract = self.assets.get_base_collateral_token_contract();
                 let quantum = self.assets.get_collateral_quantum();
                 let position_diff = PositionDiff {
                     collateral_diff: quantized_amount.into(), asset_diff: Option::None,
@@ -313,7 +313,7 @@ pub(crate) mod DepositManager {
             self.positions.get_position_snapshot(:position_id);
             assert(quantized_amount.is_non_zero(), errors::ZERO_AMOUNT);
             let (token_contract, quantum) = if (self.assets.get_collateral_id() == asset_id) {
-                let token_contract = self.assets.get_collateral_token_contract();
+                let token_contract = self.assets.get_base_collateral_token_contract();
                 let quantum = self.assets.get_collateral_quantum();
                 (token_contract, quantum)
             } else {
@@ -384,7 +384,7 @@ pub(crate) mod DepositManager {
             cancel_delay: TimeDelta,
         ) {
             let (token_contract, quantum) = if (self.assets.get_collateral_id() == asset_id) {
-                let token_contract = self.assets.get_collateral_token_contract();
+                let token_contract = self.assets.get_base_collateral_token_contract();
                 let quantum = self.assets.get_collateral_quantum();
                 (token_contract, quantum)
             } else {

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -155,7 +155,7 @@ pub mod Vaults {
             assert(
                 erc4626_dispatcher
                     .asset() == assets
-                    .get_collateral_token_contract()
+                    .get_base_collateral_token_contract()
                     .contract_address,
                 'VAULT_ASSET_MISMATCH',
             );

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -246,7 +246,7 @@ pub(crate) mod VaultsManager {
             let vault_dispatcher = IERC4626Dispatcher {
                 contract_address: vault_share_config.token_contract.expect('NOT_ERC4626'),
             };
-            let collateral_token_dispatcher = self.assets.get_collateral_token_contract();
+            let collateral_token_dispatcher = self.assets.get_base_collateral_token_contract();
             let current_collateral_balance = collateral_token_dispatcher
                 .balance_of(starknet::get_contract_address());
 
@@ -495,7 +495,7 @@ pub(crate) mod VaultsManager {
                 contract_address: vault_asset.token_contract.expect('NOT_ERC20'),
             };
 
-            let pnl_collateral_dispatcher = self.assets.get_collateral_token_contract();
+            let pnl_collateral_dispatcher = self.assets.get_base_collateral_token_contract();
             let perps_contract_balance_before = pnl_collateral_dispatcher
                 .balance_of(starknet::get_contract_address());
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -342,7 +342,7 @@ pub(crate) mod WithdrawalManager {
             // Transfer premium_cost (forced fee) from the caller to the sequencer address.
             let premium_cost = self.premium_cost.read();
             let quantum = self.assets.get_collateral_quantum();
-            let token_contract = self.assets.get_collateral_token_contract();
+            let token_contract = self.assets.get_base_collateral_token_contract();
 
             assert(
                 token_contract
@@ -458,7 +458,7 @@ pub(crate) mod WithdrawalManager {
             self.positions.apply_diff(:position_id, :position_diff);
             let quantum = self.assets.get_collateral_quantum();
             let withdraw_unquantized_amount = quantum * amount;
-            let token_contract = self.assets.get_collateral_token_contract();
+            let token_contract = self.assets.get_base_collateral_token_contract();
             assert(
                 token_contract.transfer(:recipient, amount: withdraw_unquantized_amount.into()),
                 TRANSFER_FAILED,

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -811,7 +811,7 @@ pub mod Core {
             // Transfer premium_cost (forced fee) from the caller to the sequencer address.
             let premium_cost = self.premium_cost.read();
             let quantum = self.assets.get_collateral_quantum();
-            let token_contract = self.assets.get_collateral_token_contract();
+            let token_contract = self.assets.get_base_collateral_token_contract();
             assert(
                 token_contract
                     .transfer_from(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose `get_collateral_token_contract_address(asset_id)` and rename `get_collateral_token_contract` to `get_base_collateral_token_contract`, updating all call sites, tests, and spec.
> 
> - **Contracts (Assets)**:
>   - Add view `get_collateral_token_contract_address(asset_id)` returning `ContractAddress` (handles base collateral vs. spot collateral).
>   - Rename `get_collateral_token_contract` -> `get_base_collateral_token_contract` and wire through interface.
>   - Import/use new `NOT_COLLATERAL` error where relevant.
> - **Integrations**:
>   - Replace calls to `get_collateral_token_contract` with `get_base_collateral_token_contract` in `deposit_manager.cairo`, `withdrawal_manager.cairo`, `vaults.cairo`, `vaults_contract.cairo`, and `core.cairo`.
> - **Tests**:
>   - Update devnet tests to use `get_base_collateral_token_contract` and adjust deposit helpers accordingly.
> - **Docs**:
>   - Spec updated to document `get_base_collateral_token_contract` and new `get_collateral_token_contract_address(asset_id)` API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19e7ef5ece89e12bf3687f4e5bca98884b26243d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/164)
<!-- Reviewable:end -->
