### PR TITLE
refactor: python infra

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from typing import Iterator, Callable
+from typing import Iterator, Callable, Union
 import pytest_asyncio
 import contextlib
 import time
@@ -9,23 +9,9 @@ from starknet_py.net.models.chains import StarknetChainId
 from test_utils.starknet_test_utils import KeyPair
 from starknet_py.net.account.account import Account
 from starknet_py.net.models.address import Address
-from starknet_py.contract import Contract
-from test_utils.starknet_test_utils import load_contract
-from scripts.script_utils import get_project_root
-from pathlib import Path
-import os
 from starknet_py.proxy.contract_abi_resolver import ContractAbiResolver, ProxyConfig
 from starknet_py.net.client_models import ResourceBoundsMapping, ResourceBounds
-from starknet_test_util import AccountNonceManager
-from starknet_py.cairo.felt import encode_shortstring
-
-
-perpetuals_Core = "perpetuals_Core"
-deposits_contract = "perpetuals_DepositManager"
-withdrawals_contract = "perpetuals_WithdrawalManager"
-
-deposits_component_type = "DEPOSITS"
-withdrawals_component_type = "WITHDRAWALS"
+from starknet_py.contract import Contract
 
 resource_bounds = ResourceBoundsMapping(
     l1_gas=ResourceBounds(max_amount=10**15, max_price_per_unit=10**12),
@@ -33,14 +19,111 @@ resource_bounds = ResourceBoundsMapping(
     l2_gas=ResourceBounds(max_amount=10**15, max_price_per_unit=10**12),
 )
 
-OPERATOR_DUMMY_KEY = 1
-DEPLOYER_DUMMY_KEY = 2
-APP_GOVERNOR_DUMMY_KEY = 3
-RICH_USDC_HOLDER_DUMMY_KEY = 4
-
 # Random block number for the forked network
+# When changing the forked number, need to update NOW_TIMESTAMP
+# and EXTENDED_ACTIVE_SYNTHETIC_ASSET_IDS
 FORK_BLOCK = 4415803
-NOW = 1765971224
+NOW_TIMESTAMP = 1765971224
+
+# Required for funding tick when forking from mainnet.
+# This list must be sorted in ascending order.
+EXTENDED_ACTIVE_SYNTHETIC_ASSET_IDS = [
+    255399919616426605400900257294843904,
+    255399919633304379671818952480129024,
+    255399919636945194886730150859243520,
+    270915948027776046540867925536931840,
+    338824487460085561411166284290195456,
+    338883663474438343746899177019277312,
+    338905303280690764515996647076921344,
+    339127382605583335846376969292742656,
+    339128557725978860634015450544472064,
+    339167696437051981397172032081231872,
+    339189412421329087967425821086318592,
+    339248760150559911178053148269871104,
+    339249788878727834962578719796887552,
+    344097595806435454645696181259206656,
+    344278863660798979802850626929426432,
+    344400637349001255728961162330505216,
+    349208209667358115027548008674754560,
+    349553874717371921940984895618678784,
+    354684143347689286618180522700963840,
+    359653178029624005735478030701166592,
+    359754745788483493062461101120159744,
+    359855675003405245145646005674311680,
+    359977924063000458297011360688504832,
+    359998998794517018713123529349398528,
+    364785659509114736355216580319117312,
+    370260563196593831237922481296637952,
+    370321410161845694364216165796937728,
+    375656867931341909315028931361898496,
+    380625508329364671305743144700608512,
+    380663843873413173657742089127985152,
+    385960324586951584765944650413375488,
+    390746430762672347138718348219514880,
+    396000038112596647361460946256003072,
+    396101378379648832210803477251620864,
+    396101380212403101135280116273774592,
+    396323605930722754555422238098587648,
+    401211989740530901651818111897174016,
+    401212385921352564110845035577081856,
+    401334549526471356934815741500194816,
+    401395555207980563015918882817835008,
+    401415362247400203280702639630712832,
+    401415448619475043208479622807158784,
+    406403816491335810657189215283970048,
+    411778891792336016648512811332272128,
+    411817625024622139428925067103305728,
+    416789435879299995223824283975286784,
+    416789436818522072078212394507042816,
+    416992418108949182116875998607704064,
+    417113878881044044170394349040828416,
+    427174429141597609995520190256775168,
+    431877150642355703025313311742754816,
+    432365923161760081025958177373421568,
+    432549653271839585844452234968956928,
+    432568984945910917982054318042251264,
+    432590218091046889185300129471528960,
+    432590218096110157059814614722674688,
+    432670881640427675234041645227835392,
+    432690441716627433572355962568704000,
+    437477565754482165017662333485318144,
+    437557744680566327621078168874516480,
+    437638715834618327041098343530889216,
+    437761440258352922500030743109959680,
+    437822852025511902434950189083000832,
+    437823079767580094335063891128614912,
+    442933058567680452956063953642848256,
+    448024668544195796360802891422760960,
+    453216002551035381248377800238301184,
+    453276691323521307730974454904258560,
+    453276858440817581570030792557461504,
+    458247228599093253039736795210711040,
+    458267273324209361917147961830146048,
+    458550751644561930336286859415519232,
+    458591633377628216554099757268598784,
+    468711525804946640478875348763672576,
+    468915544507303112068184696028135424,
+    468976147866535357546823156383088640,
+]
+
+PERPETUALS_CONTRACT_ADDRESS = 0x062DA0780FAE50D68CECAA5A051606DC21217BA290969B302DB4DD99D2E9B470
+OPERATOR_ADDRESS = 0x048DDC53F41523D2A6B40C3DFF7F69F4BBAC799CD8B2E3FC50D3DE1D4119441F
+UPGRADE_GOVERNOR_ADDRESS = 0x0562BBB386BB3EF6FFB94878EC77C0779487F277DEA89568F1CD7CDF958EDDE7
+APP_GOVERNOR_ADDRESS = 0x3CCFFE0137EA21294C1CC28F6C29DD495F5B9F1101EC86AE53EF51178AEFA2
+GOVERNANCE_ADMIN_ADDRESS = 0x522E5BA327BFBD85138B29BDE060A5340A460706B00AE2E10E6D2A16FBF8C57
+RICH_USDC_HOLDER_ADDRESS = 0x054A6DF48915BE451CD6650C3697C5789B934EB2A89D90CBB71E3234F24F0311
+
+
+@pytest.fixture(scope="session")
+def accounts_to_impersonate() -> dict[str, tuple[int, int]]:
+    # dict[account_name] = (address, dummy_key)
+    return {
+        "operator": (OPERATOR_ADDRESS, 1),
+        "upgrade_governor": (UPGRADE_GOVERNOR_ADDRESS, 2),
+        "app_governor": (APP_GOVERNOR_ADDRESS, 3),
+        "governance_admin": (GOVERNANCE_ADMIN_ADDRESS, 4),
+        "rich_usdc_holder": (RICH_USDC_HOLDER_ADDRESS, 5),
+    }
 
 
 def wait_for_devnet(port: int, timeout: int = 60) -> bool:
@@ -86,46 +169,6 @@ def starknet_test_utils_factory():
 
 
 @pytest.fixture(scope="session")
-def operator_address() -> int:
-    """
-    Return the constant address of the 'operator' contract as an int.
-    """
-    return 0x048DDC53F41523D2A6B40C3DFF7F69F4BBAC799CD8B2E3FC50D3DE1D4119441F
-
-
-@pytest.fixture(scope="session")
-def contract_address() -> int:
-    """
-    Return the constant address of the 'main' contract as an int.
-    """
-    return 0x062DA0780FAE50D68CECAA5A051606DC21217BA290969B302DB4DD99D2E9B470
-
-
-@pytest.fixture(scope="session")
-def deployer_address() -> int:
-    """
-    Return the constant address of the 'deployer' contract as an int.
-    """
-    return 0x0562BBB386BB3EF6FFB94878EC77C0779487F277DEA89568F1CD7CDF958EDDE7
-
-
-@pytest.fixture(scope="session")
-def app_governor_address() -> int:
-    """
-    Return the constant address of the 'app governor' contract as an int.
-    """
-    return 0x3CCFFE0137EA21294C1CC28F6C29DD495F5B9F1101EC86AE53EF51178AEFA2
-
-
-@pytest.fixture(scope="session")
-def rich_usdc_holder_address() -> int:
-    """
-    Return the constant address of the 'rich USDC holder' contract as an int.
-    """
-    return 0x054A6DF48915BE451CD6650C3697C5789B934EB2A89D90CBB71E3234F24F0311
-
-
-@pytest.fixture(scope="session")
 def starknet_forked(
     starknet_test_utils_factory: Callable[..., Iterator[StarknetTestUtils]]
 ) -> Iterator[StarknetTestUtils]:
@@ -138,250 +181,89 @@ def starknet_forked(
 
 
 @pytest.fixture(scope="session")
-def accounts_to_impersonate(
-    operator_address: int,
-    deployer_address: int,
-    app_governor_address: int,
-    rich_usdc_holder_address: int,
-) -> list[int]:
-    return [operator_address, deployer_address, app_governor_address, rich_usdc_holder_address]
-
-
-@pytest.fixture(scope="session")
 def starknet_forked_with_impersonated_accounts(
     starknet_forked: StarknetTestUtils,
-    accounts_to_impersonate: list[int],
+    accounts_to_impersonate: dict[str, tuple[int, int]],
 ) -> StarknetTestUtils:
     """
     Impersonate the operator account in the forked Starknet instance.
     """
     client = starknet_forked.starknet.get_client()
-    for address in accounts_to_impersonate:
+    for address, _ in accounts_to_impersonate.values():
         client.impersonate_account_sync(address)
 
     return starknet_forked
 
 
 @pytest.fixture(scope="session")
-def operator_account(
+def accounts(
     starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    operator_address: int,
-) -> Account:
+    accounts_to_impersonate: dict[str, tuple[int, int]],
+) -> dict[str, Account]:
     """
-    Return an Account instance for the impersonated operator account.
+    Return a dictionary of Account instances for the impersonated accounts.
     """
-    client = starknet_forked_with_impersonated_accounts.starknet.get_client()
-    operator_account = Account(
-        client=client,
-        address=Address(operator_address),
-        # Use a dummy private key since the account is impersonated.
-        key_pair=KeyPair.from_private_key(OPERATOR_DUMMY_KEY),
-        chain=StarknetChainId.MAINNET,
-    )
-    return operator_account
-
-
-@pytest.fixture(scope="session")
-def deployer_account(
-    starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    deployer_address: int,
-) -> Account:
-    """
-    Return an Account instance for the impersonated deployer account.
-    """
-    client = starknet_forked_with_impersonated_accounts.starknet.get_client()
-    deployer_account = Account(
-        client=client,
-        address=Address(deployer_address),
-        # Use a dummy private key since the account is impersonated.
-        key_pair=KeyPair.from_private_key(DEPLOYER_DUMMY_KEY),
-        chain=StarknetChainId.MAINNET,
-    )
-    return deployer_account
-
-
-@pytest.fixture(scope="session")
-def app_governor_account(
-    starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    app_governor_address: int,
-) -> Account:
-    """
-    Return an Account instance for the impersonated app governor account.
-    """
-    client = starknet_forked_with_impersonated_accounts.starknet.get_client()
-    app_governor_account = Account(
-        client=client,
-        address=Address(app_governor_address),
-        # Use a dummy private key since the account is impersonated.
-        key_pair=KeyPair.from_private_key(APP_GOVERNOR_DUMMY_KEY),
-        chain=StarknetChainId.MAINNET,
-    )
-    return app_governor_account
-
-
-@pytest.fixture(scope="session")
-def rich_usdc_holder_account(
-    starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    rich_usdc_holder_address: int,
-) -> Account:
-    """
-    Return an Account instance for the impersonated rich USDC holder account.
-    """
-    client = starknet_forked_with_impersonated_accounts.starknet.get_client()
-    rich_usdc_holder_account = Account(
-        client=client,
-        address=Address(rich_usdc_holder_address),
-        # Use a dummy private key since the account is impersonated.
-        key_pair=KeyPair.from_private_key(RICH_USDC_HOLDER_DUMMY_KEY),
-        chain=StarknetChainId.MAINNET,
-    )
-    return rich_usdc_holder_account
-
-
-@pytest.fixture(scope="session")
-def setup_account() -> AccountNonceManager:
-    """
-    Return an AccountNonceManager for managing nonces of impersonated accounts.
-    """
-    return AccountNonceManager(account_number=0, nonce=0)
-
-
-async def declare_contract(
-    contract_name: str,
-    account: Account,
-    setup_account: AccountNonceManager,
-) -> int:
-    compiled_contract_casm = load_contract(
-        contract_name=f"{contract_name}.compiled_contract_class",
-        base_path=Path(os.path.join(get_project_root(), "target", "release")),
-    )
-    compiled_contract = load_contract(
-        contract_name=f"{contract_name}.contract_class",
-        base_path=Path(os.path.join(get_project_root(), "target", "release")),
-    )
-    declare_result = await Contract.declare_v3(
-        account=account,
-        compiled_contract=compiled_contract,
-        compiled_contract_casm=compiled_contract_casm,
-        auto_estimate=False,
-        nonce=setup_account.bump_nonce(),
-        resource_bounds=resource_bounds,
-    )
-    await declare_result.wait_for_acceptance(check_interval=0.1)
-    return declare_result.class_hash
+    return {
+        account: Account(
+            client=starknet_forked_with_impersonated_accounts.starknet.get_client(),
+            address=Address(address),
+            # Use a dummy private key since the account is impersonated.
+            key_pair=KeyPair.from_private_key(dummy_key),
+            chain=StarknetChainId.MAINNET,
+        )
+        for account, (address, dummy_key) in accounts_to_impersonate.items()
+    }
 
 
 @pytest_asyncio.fixture(scope="session")
-async def declare_perpetuals_core_contract(
-    starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    setup_account: AccountNonceManager,
-) -> int:
-    account = starknet_forked_with_impersonated_accounts.starknet.accounts[
-        setup_account.account_number
-    ]
-    return await declare_contract(perpetuals_Core, account, setup_account)
-
-
-@pytest_asyncio.fixture(scope="session")
-async def upgrade_perpetuals_core_contract(
-    declare_perpetuals_core_contract: int,
-    contract_address: int,
-    deployer_account: Account,
-    operator_account: Account,
-    app_governor_account: Account,
-    starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    setup_account: AccountNonceManager,
+async def contracts(
+    accounts: dict[str, Account],
 ) -> dict[str, Contract]:
-    abi, cairo_version = await ContractAbiResolver(
-        address=contract_address,
-        client=deployer_account.client,
-        proxy_config=ProxyConfig(),
-    ).resolve()
+    """
+    Return a dictionary of Contract instances for the contracts.
+    """
+    return await contracts_inner_fixture(PERPETUALS_CONTRACT_ADDRESS, accounts)
 
-    deployer_contract = Contract(
-        address=contract_address,
-        abi=abi,
-        provider=deployer_account,
-        cairo_version=cairo_version,
-    )
 
-    invocation = await deployer_contract.functions["add_new_implementation"].invoke_v3(
-        {
-            "impl_hash": declare_perpetuals_core_contract,
-            "eic_data": None,
-            "final": False,
-        },
-        auto_estimate=True,
-    )
-    await invocation.wait_for_acceptance(check_interval=0.1)
-
-    invocation = await deployer_contract.functions["replace_to"].invoke_v3(
-        {
-            "impl_hash": declare_perpetuals_core_contract,
-            "eic_data": None,
-            "final": False,
-        },
-        auto_estimate=True,
-    )
-    await invocation.wait_for_acceptance(check_interval=0.1)
-
-    abi, cairo_version = await ContractAbiResolver(
-        address=contract_address,
-        client=operator_account.client,
-        proxy_config=ProxyConfig(),
-    ).resolve()
-
-    operator_contract = Contract(
-        address=contract_address,
-        abi=abi,
-        provider=operator_account,
-        cairo_version=cairo_version,
-    )
-
-    app_governor_contract = Contract(
-        address=contract_address,
-        abi=abi,
-        provider=app_governor_account,
-        cairo_version=cairo_version,
-    )
-
-    deployer_contract = Contract(
-        address=contract_address,
-        abi=abi,
-        provider=deployer_account,
-        cairo_version=cairo_version,
-    )
-
-    async def register_and_activate_external_component(contract_name: str, component_type: str):
-        account = starknet_forked_with_impersonated_accounts.starknet.accounts[
-            setup_account.account_number
-        ]
-        component_address = await declare_contract(contract_name, account, setup_account)
-        invocation = await deployer_contract.functions["register_external_component"].invoke_v3(
-            encode_shortstring(component_type),
-            component_address,
-            auto_estimate=True,
-        )
-        await invocation.wait_for_acceptance(check_interval=0.1)
-
-        invocation = await deployer_contract.functions["activate_external_component"].invoke_v3(
-            encode_shortstring(component_type),
-            component_address,
-            auto_estimate=True,
-        )
-        await invocation.wait_for_acceptance(check_interval=0.1)
-
-    await register_and_activate_external_component(deposits_contract, deposits_component_type)
-    await register_and_activate_external_component(withdrawals_contract, withdrawals_component_type)
-
-    return {"operator_contract": operator_contract, "app_governor_contract": app_governor_contract}
+async def contracts_inner_fixture(
+    contract_address: int,
+    accounts: Union[dict[str, Account], list[Account]],
+) -> Union[dict[str, Contract], dict[Account, Contract]]:
+    result = {}
+    if isinstance(accounts, dict):
+        for account_name, account in accounts.items():
+            abi, cairo_version = await ContractAbiResolver(
+                address=contract_address,
+                client=account.client,
+                proxy_config=ProxyConfig(),
+            ).resolve()
+            result[account_name] = Contract(
+                address=contract_address,
+                abi=abi,
+                provider=account,
+                cairo_version=cairo_version,
+            )
+    elif isinstance(accounts, list):
+        for account in accounts:
+            abi, cairo_version = await ContractAbiResolver(
+                address=contract_address,
+                client=account.client,
+                proxy_config=ProxyConfig(),
+            ).resolve()
+            result[account] = Contract(
+                address=contract_address,
+                abi=abi,
+                provider=account,
+                cairo_version=cairo_version,
+            )
+    return result
 
 
 @pytest.fixture(scope="session")
 def test_utils(
-    upgrade_perpetuals_core_contract: dict,
     starknet_forked_with_impersonated_accounts: StarknetTestUtils,
-    rich_usdc_holder_account: Account,
+    accounts: dict[str, Account],
+    contracts: dict[str, Contract],
 ):
     """
     Session-scoped PerpetualsTestUtils instance.
@@ -391,6 +273,9 @@ def test_utils(
 
     return PerpetualsTestUtils(
         starknet_forked_with_impersonated_accounts,
-        upgrade_perpetuals_core_contract,
-        rich_usdc_holder_account,
+        PERPETUALS_CONTRACT_ADDRESS,
+        NOW_TIMESTAMP,
+        EXTENDED_ACTIVE_SYNTHETIC_ASSET_IDS,
+        accounts,
+        contracts,
     )

--- a/devnet_tests/perpetuals_test_utils.py
+++ b/devnet_tests/perpetuals_test_utils.py
@@ -1,7 +1,10 @@
 import asyncio
 import bisect
 import os
+from pathlib import Path
 import random
+from test_utils.starknet_test_utils import load_contract
+from scripts.script_utils import get_project_root
 from poseidon_py.poseidon_hash import poseidon_hash_many
 from starknet_py.cairo.felt import encode_shortstring
 from starknet_py.contract import Contract
@@ -11,7 +14,14 @@ from starknet_py.net.models.chains import StarknetChainId
 from starknet_py.proxy.contract_abi_resolver import ContractAbiResolver, ProxyConfig
 from test_utils.starknet_test_utils import StarknetTestUtils
 from typing import Dict, Tuple, Optional
-from conftest import NOW
+from conftest import contracts_inner_fixture, resource_bounds
+from typing import Union
+from starknet_py.contract import DeclareResult, DeployResult
+from starknet_py.net.account.account import Account
+from starknet_py.net.models.chains import StarknetChainId
+
+
+### Constants ###
 
 # Required for hash computations.
 ORDER_ARGS_HASH = 0x36DA8D51815527CABFAA9C982F564C80FA7429616739306036F1F9B608DD112
@@ -42,138 +52,51 @@ SIGNER_PUBLIC_KEY_STR = "signer_public_key"
 TIMESTAMP_STR = "timestamp"
 ORACLE_PRICE_STR = "oracle_price"
 
-# Required for funding tick when forking from mainnet.
-# This list is relavent for block number 4415803.
-# When changing the forked block number, this list needs to be updated to support funding tick.
-# This list must be sorted in ascending order.
-EXTENDED_SYNTHETIC_ASSET_IDS = [
-    255399919616426605400900257294843904,
-    255399919633304379671818952480129024,
-    255399919636945194886730150859243520,
-    270915948027776046540867925536931840,
-    338824487460085561411166284290195456,
-    338883663474438343746899177019277312,
-    338905303280690764515996647076921344,
-    339127382605583335846376969292742656,
-    339128557725978860634015450544472064,
-    339167696437051981397172032081231872,
-    339189412421329087967425821086318592,
-    339248760150559911178053148269871104,
-    339249788878727834962578719796887552,
-    344097595806435454645696181259206656,
-    344278863660798979802850626929426432,
-    344400637349001255728961162330505216,
-    349208209667358115027548008674754560,
-    349553874717371921940984895618678784,
-    354684143347689286618180522700963840,
-    359653178029624005735478030701166592,
-    359754745788483493062461101120159744,
-    359855675003405245145646005674311680,
-    359977924063000458297011360688504832,
-    359998998794517018713123529349398528,
-    364785659509114736355216580319117312,
-    370260563196593831237922481296637952,
-    370321410161845694364216165796937728,
-    375656867931341909315028931361898496,
-    380625508329364671305743144700608512,
-    380663843873413173657742089127985152,
-    385960324586951584765944650413375488,
-    390746430762672347138718348219514880,
-    396000038112596647361460946256003072,
-    396101378379648832210803477251620864,
-    396101380212403101135280116273774592,
-    396323605930722754555422238098587648,
-    401211989740530901651818111897174016,
-    401212385921352564110845035577081856,
-    401334549526471356934815741500194816,
-    401395555207980563015918882817835008,
-    401415362247400203280702639630712832,
-    401415448619475043208479622807158784,
-    406403816491335810657189215283970048,
-    411778891792336016648512811332272128,
-    411817625024622139428925067103305728,
-    416789435879299995223824283975286784,
-    416789436818522072078212394507042816,
-    416992418108949182116875998607704064,
-    417113878881044044170394349040828416,
-    427174429141597609995520190256775168,
-    431877150642355703025313311742754816,
-    432365923161760081025958177373421568,
-    432549653271839585844452234968956928,
-    432568984945910917982054318042251264,
-    432590218091046889185300129471528960,
-    432590218096110157059814614722674688,
-    432670881640427675234041645227835392,
-    432690441716627433572355962568704000,
-    437477565754482165017662333485318144,
-    437557744680566327621078168874516480,
-    437638715834618327041098343530889216,
-    437761440258352922500030743109959680,
-    437822852025511902434950189083000832,
-    437823079767580094335063891128614912,
-    442933058567680452956063953642848256,
-    448024668544195796360802891422760960,
-    453216002551035381248377800238301184,
-    453276691323521307730974454904258560,
-    453276858440817581570030792557461504,
-    458247228599093253039736795210711040,
-    458267273324209361917147961830146048,
-    458550751644561930336286859415519232,
-    458591633377628216554099757268598784,
-    468711525804946640478875348763672576,
-    468915544507303112068184696028135424,
-    468976147866535357546823156383088640,
-]
-
-
-def formatted_position_id(value: int) -> dict:
-    return {VALUE_STR: value}
-
-
-def formatted_asset_id(value: int) -> dict:
-    return {VALUE_STR: value}
-
-
-def formatted_timestamp(seconds: int) -> dict:
-    return {SECONDS_STR: seconds}
-
-
-def formatted_funding_index(value: int) -> dict:
-    return {VALUE_STR: value}
-
 
 class PerpetualsTestUtils:
     def __init__(
         self,
         StarknetTestUtils: StarknetTestUtils,
-        upgrade_perpetuals_core_contract: dict,
-        rich_usdc_holder_account: Account,
+        perpetuals_contract_address: int,
+        now_timestamp: int,
+        extended_active_synthetic_asset_ids: list[int],
+        accounts: dict[str, Account],
+        contracts: dict[str, Contract],
     ):
         self.starknet_test_utils = StarknetTestUtils
-        self.operator_contract = upgrade_perpetuals_core_contract["operator_contract"]
-        self.app_governor_contract = upgrade_perpetuals_core_contract["app_governor_contract"]
-        self.rich_usdc_holder_account = rich_usdc_holder_account
+        self.known_accounts = accounts
+        self.known_contracts = contracts
 
+        self.perpetuals_contract_address = perpetuals_contract_address
+        self.now_timestamp = now_timestamp
         self.operator_nonce = None
-        self.accounts_number = 0
-        self.asset_ids = EXTENDED_SYNTHETIC_ASSET_IDS
-        self.account_contracts = {}
-        self.account_key_pairs = {}  # key_pairs[account] = (public_key, private_key)
-        self.account_positions = {}
+        self.asset_ids = extended_active_synthetic_asset_ids
+
+        self.new_accounts_number = 0
+        self.new_accounts = []
+
+        # new_account_contracts[account] = contract
+        self.new_account_contracts = {}
+
+        # new_account_key_pairs[account] = (public_key, private_key)
+        self.new_account_key_pairs = {}
+
+        # new_account_positions[account] = position_id
+        self.new_account_positions = {}
 
         random_seed = int(os.getenv("RANDOM_SEED", "0"))
         random.seed(random_seed)
 
-    ## Helper functions
+    ### Helper functions ###
 
     def get_account_public_key(self, account: Account) -> int:
-        return self.account_key_pairs[account][0]
+        return self.new_account_key_pairs[account][0]
 
     def get_account_address(self, account: Account) -> int:
         return account.address
 
     def get_account_position_id(self, account: Account) -> int:
-        return self.account_positions[account]
+        return self.new_account_positions[account]
 
     def create_signed_price(
         self, account: Account, oracle_price: int, timestamp: int, asset_name: int, oracle_name: int
@@ -182,7 +105,7 @@ class PerpetualsTestUtils:
         price_timestamp_payload = oracle_price * TWO_POW_32 + timestamp
         msg_hash = pedersen_hash(asset_oracle_payload, price_timestamp_payload)
 
-        signature = message_signature(msg_hash, self.account_key_pairs[account][1])
+        signature = message_signature(msg_hash, self.new_account_key_pairs[account][1])
         return {
             SIGNATURE_STR: signature,
             SIGNER_PUBLIC_KEY_STR: self.get_account_public_key(account),
@@ -214,33 +137,37 @@ class PerpetualsTestUtils:
         }
 
     async def new_account(self) -> Account:
-        if self.accounts_number >= len(self.starknet_test_utils.starknet.accounts):
+        if self.new_accounts_number >= len(self.starknet_test_utils.starknet.accounts):
             raise ValueError("No more accounts available")
 
-        account = self.starknet_test_utils.starknet.accounts[self.accounts_number]
-        self.account_key_pairs[account] = (account.signer.public_key, account.signer.private_key)
-        self.accounts_number += 1
+        account = self.starknet_test_utils.starknet.accounts[self.new_accounts_number]
+        self.new_accounts.append(account)
+        self.new_account_key_pairs[account] = (
+            account.signer.public_key,
+            account.signer.private_key,
+        )
+        self.new_accounts_number += 1
 
         abi, cairo_version = await ContractAbiResolver(
-            address=self.operator_contract.address,
+            address=self.perpetuals_contract_address,
             client=account.client,
             proxy_config=ProxyConfig(),
         ).resolve()
 
         account_contract = Contract(
-            address=self.operator_contract.address,
+            address=self.perpetuals_contract_address,
             abi=abi,
             provider=account,
             cairo_version=cairo_version,
         )
-        self.account_contracts[account] = account_contract
+        self.new_account_contracts[account] = account_contract
 
         return account
 
-    ## View functions
+    ### View functions ###
 
     async def get_operator_nonce(self) -> int:
-        (nonce,) = await self.operator_contract.functions["get_operator_nonce"].call()
+        (nonce,) = await self.known_contracts["operator"].functions["get_operator_nonce"].call()
         return nonce
 
     async def consume_operator_nonce(self) -> int:
@@ -253,51 +180,61 @@ class PerpetualsTestUtils:
         return nonce
 
     async def get_collateral_asset_id(self) -> int:
-        (asset_id,) = await self.operator_contract.functions["get_collateral_id"].call()
+        (asset_id,) = await self.known_contracts["operator"].functions["get_collateral_id"].call()
         return asset_id["value"]
 
     async def get_base_collateral_token_contract(self) -> int:
-        (token_contract,) = await self.operator_contract.functions[
-            "get_base_collateral_token_contract"
-        ].call()
+        (token_contract,) = (
+            await self.known_contracts["operator"].functions["get_collateral_token_contract"].call()
+        )
         return token_contract["contract_address"]
 
     async def get_position_total_value(self, position_id: int) -> int:
-        (tv_tr,) = await self.operator_contract.functions["get_position_tv_tr"].call(
-            formatted_position_id(position_id)
+        (tv_tr,) = (
+            await self.known_contracts["operator"]
+            .functions["get_position_tv_tr"]
+            .call(formatted_position_id(position_id))
         )
         return tv_tr["total_value"]
 
     async def get_num_of_active_synthetic_assets(self) -> int:
-        (num_of_active_synthetic_assets,) = await self.operator_contract.functions[
-            "get_num_of_active_synthetic_assets"
-        ].call()
+        (num_of_active_synthetic_assets,) = (
+            await self.known_contracts["operator"]
+            .functions["get_num_of_active_synthetic_assets"]
+            .call()
+        )
         return num_of_active_synthetic_assets
 
     async def get_asset_timely_data(self, asset_id: int) -> dict:
-        (asset_timely_data,) = await self.operator_contract.functions["get_timely_data"].call(
-            formatted_asset_id(asset_id)
+        (asset_timely_data,) = (
+            await self.known_contracts["operator"]
+            .functions["get_timely_data"]
+            .call(formatted_asset_id(asset_id))
         )
         return asset_timely_data
 
-    ## Storage-mutating functions
+    ### Storage-mutating functions ###
 
     async def new_position(self, account: Account, tries: int = 3) -> int:
         error = None
         while tries > 0:
             position_id = random.randint(1, MAX_UINT32)
             try:
-                invocation = await self.operator_contract.functions["new_position"].invoke_v3(
-                    await self.consume_operator_nonce(),
-                    formatted_position_id(position_id),
-                    self.get_account_public_key(account),
-                    self.get_account_address(account),
-                    True,
-                    auto_estimate=True,
+                invocation = (
+                    await self.known_contracts["operator"]
+                    .functions["new_position"]
+                    .invoke_v3(
+                        await self.consume_operator_nonce(),
+                        formatted_position_id(position_id),
+                        self.get_account_public_key(account),
+                        self.get_account_address(account),
+                        True,
+                        auto_estimate=True,
+                    )
                 )
                 await invocation.wait_for_acceptance(check_interval=0.1)
                 # Success! Store and return the position_id
-                self.account_positions[account] = position_id
+                self.new_account_positions[account] = position_id
                 return position_id
 
             except Exception as e:
@@ -316,14 +253,14 @@ class PerpetualsTestUtils:
             # Get the ERC20 contract
             abi, cairo_version = await ContractAbiResolver(
                 address=await self.get_base_collateral_token_contract(),
-                client=self.rich_usdc_holder_account.client,
+                client=self.known_accounts["rich_usdc_holder"].client,
                 proxy_config=ProxyConfig(),
             ).resolve()
 
             erc20_contract = Contract(
                 address=await self.get_base_collateral_token_contract(),
                 abi=abi,
-                provider=self.rich_usdc_holder_account,
+                provider=self.known_accounts["rich_usdc_holder"],
                 cairo_version=cairo_version,
             )
 
@@ -351,7 +288,7 @@ class PerpetualsTestUtils:
             )
 
             invocation = await erc20_contract.functions["approve"].invoke_v3(
-                self.operator_contract.address, amount, auto_estimate=True
+                self.perpetuals_contract_address, amount, auto_estimate=True
             )
             await invocation.wait_for_acceptance(check_interval=0.1)
 
@@ -360,7 +297,7 @@ class PerpetualsTestUtils:
         # Deposit
         salt = random.randint(0, MAX_UINT32)
         invocation = (
-            await self.account_contracts[account]
+            await self.new_account_contracts[account]
             .functions["deposit_asset"]
             .invoke_v3(
                 formatted_asset_id(await self.get_collateral_asset_id()),
@@ -374,14 +311,18 @@ class PerpetualsTestUtils:
 
         # Process deposit
         async def _process_deposit(account: Account, amount: int, salt: int):
-            invocation = await self.operator_contract.functions["process_deposit"].invoke_v3(
-                await self.consume_operator_nonce(),
-                self.get_account_address(account),
-                formatted_asset_id(await self.get_collateral_asset_id()),
-                formatted_position_id(self.get_account_position_id(account)),
-                amount,
-                salt,
-                auto_estimate=True,
+            invocation = (
+                await self.known_contracts["operator"]
+                .functions["process_deposit"]
+                .invoke_v3(
+                    await self.consume_operator_nonce(),
+                    self.get_account_address(account),
+                    formatted_asset_id(await self.get_collateral_asset_id()),
+                    formatted_position_id(self.get_account_position_id(account)),
+                    amount,
+                    salt,
+                    auto_estimate=True,
+                )
             )
             await invocation.wait_for_acceptance(check_interval=0.1)
 
@@ -420,10 +361,10 @@ class PerpetualsTestUtils:
         ]
 
         message_hash = poseidon_hash_many(message)
-        signature = message_signature(message_hash, self.account_key_pairs[account][1])
+        signature = message_signature(message_hash, self.new_account_key_pairs[account][1])
 
         invocation = (
-            await self.account_contracts[account]
+            await self.new_account_contracts[account]
             .functions["withdraw_request"]
             .invoke_v3(
                 signature,
@@ -439,26 +380,34 @@ class PerpetualsTestUtils:
 
         # Process withdrawal request
         async def _process_withdraw(account: Account, amount: int, expiration: int, salt: int):
-            invocation = await self.operator_contract.functions["withdraw"].invoke_v3(
-                await self.consume_operator_nonce(),
-                self.get_account_address(account),
-                formatted_position_id(self.get_account_position_id(account)),
-                amount,
-                formatted_timestamp(expiration),
-                salt,
-                auto_estimate=True,
+            invocation = (
+                await self.known_contracts["operator"]
+                .functions["withdraw"]
+                .invoke_v3(
+                    await self.consume_operator_nonce(),
+                    self.get_account_address(account),
+                    formatted_position_id(self.get_account_position_id(account)),
+                    amount,
+                    formatted_timestamp(expiration),
+                    salt,
+                    auto_estimate=True,
+                )
             )
             await invocation.wait_for_acceptance(check_interval=0.1)
 
         await _process_withdraw(account, amount, expiration, salt)
 
     async def price_tick(self, asset_id: int, oracle_price: int, signed_prices: list[dict]):
-        invocation = await self.operator_contract.functions["price_tick"].invoke_v3(
-            await self.get_operator_nonce(),
-            formatted_asset_id(asset_id),
-            oracle_price,
-            signed_prices,
-            auto_estimate=True,
+        invocation = (
+            await self.known_contracts["operator"]
+            .functions["price_tick"]
+            .invoke_v3(
+                await self.get_operator_nonce(),
+                formatted_asset_id(asset_id),
+                oracle_price,
+                signed_prices,
+                auto_estimate=True,
+            )
         )
         await invocation.wait_for_acceptance(check_interval=0.1)
 
@@ -472,16 +421,18 @@ class PerpetualsTestUtils:
     ):
         asset_id = random.randint(1, MAX_UINT32)
         try:
-            invocation = await self.app_governor_contract.functions[
-                "add_synthetic_asset"
-            ].invoke_v3(
-                formatted_asset_id(asset_id),
-                risk_factor_tiers,
-                risk_factor_first_tier_boundary,
-                risk_factor_tier_size,
-                quorum,
-                resolution_factor,
-                auto_estimate=True,
+            invocation = (
+                await self.known_contracts["app_governor"]
+                .functions["add_synthetic_asset"]
+                .invoke_v3(
+                    formatted_asset_id(asset_id),
+                    risk_factor_tiers,
+                    risk_factor_first_tier_boundary,
+                    risk_factor_tier_size,
+                    quorum,
+                    resolution_factor,
+                    auto_estimate=True,
+                )
             )
             await invocation.wait_for_acceptance(check_interval=0.1)
             bisect.insort(self.asset_ids, asset_id)
@@ -492,12 +443,16 @@ class PerpetualsTestUtils:
     async def add_oracle_to_asset(
         self, asset_id: int, oracle_public_key: int, oracle_name: int, asset_name: int
     ):
-        invocation = await self.app_governor_contract.functions["add_oracle_to_asset"].invoke_v3(
-            formatted_asset_id(asset_id),
-            oracle_public_key,
-            oracle_name,
-            asset_name,
-            auto_estimate=True,
+        invocation = (
+            await self.known_contracts["app_governor"]
+            .functions["add_oracle_to_asset"]
+            .invoke_v3(
+                formatted_asset_id(asset_id),
+                oracle_public_key,
+                oracle_name,
+                asset_name,
+                auto_estimate=True,
+            )
         )
         await invocation.wait_for_acceptance(check_interval=0.1)
 
@@ -559,11 +514,15 @@ class PerpetualsTestUtils:
                 )
 
         # Execute funding tick
-        invocation = await self.operator_contract.functions["funding_tick"].invoke_v3(
-            await self.get_operator_nonce(),
-            new_funding_indices,
-            formatted_timestamp(NOW),
-            auto_estimate=True,
+        invocation = (
+            await self.known_contracts["operator"]
+            .functions["funding_tick"]
+            .invoke_v3(
+                await self.get_operator_nonce(),
+                new_funding_indices,
+                formatted_timestamp(self.now_timestamp),
+                auto_estimate=True,
+            )
         )
         await invocation.wait_for_acceptance(check_interval=0.1)
 
@@ -631,19 +590,144 @@ class PerpetualsTestUtils:
 
         message_hash_a = poseidon_hash_many(message_a)
         message_hash_b = poseidon_hash_many(message_b)
-        signature_a = message_signature(message_hash_a, self.account_key_pairs[account_a][1])
-        signature_b = message_signature(message_hash_b, self.account_key_pairs[account_b][1])
+        signature_a = message_signature(message_hash_a, self.new_account_key_pairs[account_a][1])
+        signature_b = message_signature(message_hash_b, self.new_account_key_pairs[account_b][1])
 
-        invocation = await self.operator_contract.functions["trade"].invoke_v3(
-            await self.get_operator_nonce(),
-            signature_a,
-            signature_b,
-            order_a,
-            order_b,
-            actual_amount_base_a,
-            actual_amount_quote_a,
-            actual_fee_a,
-            actual_fee_b,
+        invocation = (
+            await self.known_contracts["operator"]
+            .functions["trade"]
+            .invoke_v3(
+                await self.get_operator_nonce(),
+                signature_a,
+                signature_b,
+                order_a,
+                order_b,
+                actual_amount_base_a,
+                actual_amount_quote_a,
+                actual_fee_a,
+                actual_fee_b,
+                auto_estimate=True,
+            )
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+    async def upgrade_perpetuals_contract(
+        self,
+        eic_data: Optional[dict] = None,
+    ):
+        """
+        Upgrade the perpetuals contract to a new implementation.
+        """
+        upgrade_governor_contract = self.known_contracts["upgrade_governor"]
+        new_class_hash = (
+            await declare_contract("perpetuals_Core", self.known_accounts["upgrade_governor"])
+        ).class_hash
+
+        invocation = await upgrade_governor_contract.functions["add_new_implementation"].invoke_v3(
+            {
+                "impl_hash": new_class_hash,
+                "eic_data": eic_data,
+                "final": False,
+            },
             auto_estimate=True,
         )
         await invocation.wait_for_acceptance(check_interval=0.1)
+
+        invocation = await upgrade_governor_contract.functions["replace_to"].invoke_v3(
+            {
+                "impl_hash": new_class_hash,
+                "eic_data": eic_data,
+                "final": False,
+            },
+            auto_estimate=True,
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+        # After the upgrade, the ABI changes, so we need to re-fetch the contracts
+        self.known_contracts = await contracts_inner_fixture(
+            self.perpetuals_contract_address, self.known_accounts
+        )
+        self.new_account_contracts = await contracts_inner_fixture(
+            self.perpetuals_contract_address, self.new_accounts
+        )
+
+    async def register_and_activate_external_component(
+        self, contract_name: str, component_type: str
+    ):
+        component_declare_result = await declare_contract(
+            contract_name, self.known_accounts["upgrade_governor"]
+        )
+        invocation = (
+            await self.known_contracts["upgrade_governor"]
+            .functions["register_external_component"]
+            .invoke_v3(
+                encode_shortstring(component_type),
+                component_declare_result.class_hash,
+                auto_estimate=True,
+            )
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+        invocation = (
+            await self.known_contracts["upgrade_governor"]
+            .functions["activate_external_component"]
+            .invoke_v3(
+                encode_shortstring(component_type),
+                component_declare_result.class_hash,
+                auto_estimate=True,
+            )
+        )
+        await invocation.wait_for_acceptance(check_interval=0.1)
+
+
+### Utility functions ###
+async def declare_contract(
+    contract_name: str,
+    account: Account,
+) -> DeclareResult:
+    compiled_contract_casm = load_contract(
+        contract_name=f"{contract_name}.compiled_contract_class",
+        base_path=Path(os.path.join(get_project_root(), "target", "release")),
+    )
+    compiled_contract = load_contract(
+        contract_name=f"{contract_name}.contract_class",
+        base_path=Path(os.path.join(get_project_root(), "target", "release")),
+    )
+    declare_result = await Contract.declare_v3(
+        account=account,
+        compiled_contract=compiled_contract,
+        compiled_contract_casm=compiled_contract_casm,
+        auto_estimate=False,
+        resource_bounds=resource_bounds,
+    )
+    await declare_result.wait_for_acceptance(check_interval=0.1)
+    return declare_result
+
+
+async def deploy_contract(
+    declare_result: DeclareResult,
+    constructor_args: list[Union[dict, int, str, bool, list, tuple]],
+) -> DeployResult:
+    deploy_result = await declare_result.deploy_v3(
+        auto_estimate=False,
+        resource_bounds=resource_bounds,
+        constructor_args=constructor_args,
+    )
+    await deploy_result.wait_for_acceptance(check_interval=0.1)
+    return deploy_result
+
+
+def formatted_position_id(value: int) -> dict:
+    return {VALUE_STR: value}
+
+
+def formatted_asset_id(value: int) -> dict:
+    return {VALUE_STR: value}
+
+
+def formatted_timestamp(seconds: int) -> dict:
+    return {SECONDS_STR: seconds}
+
+
+def formatted_funding_index(value: int) -> dict:
+    return {VALUE_STR: value}

--- a/devnet_tests/system_test.py
+++ b/devnet_tests/system_test.py
@@ -1,7 +1,6 @@
 import pytest
 from starknet_py.cairo.felt import encode_shortstring
 from devnet_tests.perpetuals_test_utils import PerpetualsTestUtils
-from conftest import NOW
 
 
 @pytest.mark.asyncio
@@ -9,8 +8,8 @@ async def test_helper_functions(test_utils: PerpetualsTestUtils):
     """Test helper functions in PerpetualsTestUtils."""
 
     # Test that we can access the contracts
-    assert test_utils.operator_contract is not None
-    assert test_utils.app_governor_contract is not None
+    assert test_utils.known_contracts["operator"] is not None
+    assert test_utils.known_contracts["app_governor"] is not None
 
     # Test new_account
     account = await test_utils.new_account()
@@ -117,7 +116,7 @@ async def test_asset_management(test_utils: PerpetualsTestUtils):
 
     # Test price_tick
     oracle_price = 100000000
-    timestamp = NOW + 90
+    timestamp = test_utils.now_timestamp + 90
     signed_price = test_utils.create_signed_price(
         oracle_account,
         oracle_price,
@@ -166,7 +165,7 @@ async def test_trade(test_utils: PerpetualsTestUtils):
     base_amount_a = 37
     quote_amount_a = -5303580
     fee_amount = 0
-    expiration = NOW + 1000000000
+    expiration = test_utils.now_timestamp + 1000000000
     order_a = await test_utils.create_order(
         position_id_a, base_asset_id, base_amount_a, quote_amount_a, fee_amount, expiration
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes the devnet testing infrastructure and utilities for clarity and reuse.
> 
> - Centralizes fork config: adds `NOW_TIMESTAMP`, `EXTENDED_ACTIVE_SYNTHETIC_ASSET_IDS`, and `PERPETUALS_CONTRACT_ADDRESS`
> - Replaces per-account fixtures with dict-based `accounts` and `contracts` built via `contracts_inner_fixture` (supports dict or list of accounts); impersonation handled from `accounts_to_impersonate`
> - Overhauls `PerpetualsTestUtils` to use `known_accounts`/`known_contracts`, parameterized `perpetuals_contract_address`, `now_timestamp`, and asset IDs; renames internal tracking to `new_account_*`
> - Updates all calls to use contract map entries (e.g., `operator`, `app_governor`); switches to `get_collateral_token_contract`
> - Adds upgrade/ops utilities: `upgrade_perpetuals_contract`, `register_and_activate_external_component`, and shared `declare_contract`/`deploy_contract` using `resource_bounds`
> - Adjusts tests to new APIs and constants (e.g., `known_contracts[...]`, `now_timestamp`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acad8777c555520bcccf270ee96e9002298d6398. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/170)
<!-- Reviewable:end -->
