### PR TITLE
chore: use pathfinder rpc provider

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -130,7 +130,7 @@ def starknet_forked(
     starknet_test_utils_factory: Callable[..., Iterator[StarknetTestUtils]]
 ) -> Iterator[StarknetTestUtils]:
     with starknet_test_utils_factory(
-        fork_network="https://rpc.starknet.lava.build/",
+        fork_network="https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8",
         fork_block=FORK_BLOCK,
         starknet_chain_id=StarknetChainId.MAINNET,
     ) as val:

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/multi_trade_regression_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/multi_trade_regression_tests.cairo
@@ -241,7 +241,7 @@ fn replace_to_new_implementation() {
 }
 
 #[test]
-#[fork(url: "https://rpc.starknet.lava.build/", block_number: 1978107)]
+#[fork(url: "https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8", block_number: 1978107)]
 fn test_mainnet_data_three_trades_original_code() {
     // Setup:
     let core_dispatcher = ICoreDispatcher { contract_address: CONTRACT_ADDRESS };
@@ -333,7 +333,7 @@ fn test_mainnet_data_three_trades_original_code() {
 
 
 #[test]
-#[fork(url: "https://rpc.starknet.lava.build/", block_number: 1978107)]
+#[fork(url: "https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8", block_number: 1978107)]
 fn test_mainnet_data_three_trades_upgraded_code() {
     // Setup:
     let core_dispatcher = ICoreDispatcher { contract_address: CONTRACT_ADDRESS };
@@ -427,7 +427,7 @@ fn test_mainnet_data_three_trades_upgraded_code() {
 }
 
 #[test]
-#[fork(url: "https://rpc.starknet.lava.build/", block_number: 1978107)]
+#[fork(url: "https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8", block_number: 1978107)]
 fn test_mainnet_data_multi_trade_upgraded_code() {
     // Setup:
     let core_dispatcher = ICoreDispatcher { contract_address: CONTRACT_ADDRESS };

--- a/workspace/apps/perpetuals/contracts/src/tests/performance_tests/performance_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/performance_tests/performance_tests.cairo
@@ -558,7 +558,7 @@ fn replace_to_current_code() {
 /// tx: 0x07b042c11b78c947b958f5559f40feac97866bc8b1ecc9ec62818f1a1b177586 (12 trades)
 /// block number: 1844545
 #[test]
-#[fork(url: "https://rpc.starknet.lava.build/", block_number: 1844544)]
+#[fork(url: "https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8", block_number: 1844544)]
 fn test_performance() {
     replace_to_current_code();
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates test infrastructure to use Pathfinder mainnet RPC.
> 
> - Changes `fork_network` in `devnet_tests/conftest.py` to `https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8`
> - Updates `#[fork(url, ...)]` in regression and performance Cairo tests to the same Pathfinder endpoint
> - Block numbers and test logic remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36ea490f1aac457db05adf42778488017fecbe4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/171)
<!-- Reviewable:end -->
