### PR TITLE
feat: fulfillment cleanup

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/fulfillment.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/fulfillment.cairo
@@ -38,5 +38,10 @@ pub mod Fulfillement {
             }
             fulfillment_entry.write(total_amount);
         }
+        fn clean_fulfillment(ref self: ComponentState<TContractState>, hashes: Span<felt252>) {
+            for hash in hashes {
+                self.fulfillment.entry(*hash).write(Default::default());
+            }
+        }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/fulfillment/interface.cairo
@@ -10,5 +10,6 @@ pub trait IFulfillment<TContractState> {
         order_base_amount: i64,
         actual_base_amount: i64,
     );
+    fn clean_fulfillment(ref self: TContractState, hashes: Span<felt252>);
 }
 

--- a/workspace/apps/perpetuals/contracts/src/core/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/errors.cairo
@@ -22,6 +22,8 @@ pub const SYNTHETIC_IS_ACTIVE: felt252 = 'SYNTHETIC_IS_ACTIVE';
 pub const TRADE_ASSET_NOT_SYNTHETIC: felt252 = 'TRADE_ASSET_NOT_SYNTHETIC';
 pub const TRANSFER_FAILED: felt252 = 'TRANSFER_FAILED';
 pub const SAME_BASE_QUOTE_ASSET_IDS: felt252 = 'SAME_BASE_QUOTE_ASSET_IDS';
+pub const ORDER_IS_NOT_EXPIRED: felt252 = 'ORDER_IS_NOT_EXPIRED';
+pub const LENGTH_MISMATCH: felt252 = 'LENGTH_MISMATCH';
 
 pub fn fulfillment_exceeded_err(position_id: PositionId) -> ByteArray {
     format!("FULFILLMENT_EXCEEDED position_id: {:?}", position_id)

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -71,6 +71,9 @@ pub trait ICore<TContractState> {
         actual_fee_b: u64,
     );
     fn multi_trade(ref self: TContractState, operator_nonce: u64, trades: Span<Settlement>);
+    fn clean_fulfillments(
+        ref self: TContractState, orders: Span<Order>, public_keys: Span<felt252>,
+    );
     fn liquidate(
         ref self: TContractState,
         operator_nonce: u64,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a way to clear stored order-fulfillment progress for expired orders.
> 
> - Adds Core method `clean_fulfillments(orders, public_keys)` with validations (`LENGTH_MISMATCH`, `ORDER_IS_NOT_EXPIRED`), computes hashes from `(order, public_key)`, and clears matching entries
> - Extends fulfillment component with `clean_fulfillment(hashes)` to reset entries in `fulfillment` map
> - Exposes `clean_fulfillments` in `ICore` and `clean_fulfillment` in `IFulfillment`; adds new errors `ORDER_IS_NOT_EXPIRED` and `LENGTH_MISMATCH`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9123870247a748419ede715fc3a8a3cb6357bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/172)
<!-- Reviewable:end -->
