### PR TITLE
fix: upgrade contract and funding tick

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -173,9 +173,10 @@ def starknet_forked(
     starknet_test_utils_factory: Callable[..., Iterator[StarknetTestUtils]]
 ) -> Iterator[StarknetTestUtils]:
     with starknet_test_utils_factory(
-        fork_network="https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_8",
+        fork_network="https://rpc.pathfinder.equilibrium.co/mainnet/rpc/v0_10",
         fork_block=FORK_BLOCK,
         starknet_chain_id=StarknetChainId.MAINNET,
+        start_time=NOW_TIMESTAMP,
     ) as val:
         yield val
 

--- a/devnet_tests/system_test.py
+++ b/devnet_tests/system_test.py
@@ -1,6 +1,39 @@
 import pytest
+import pytest_asyncio
 from starknet_py.cairo.felt import encode_shortstring
 from devnet_tests.perpetuals_test_utils import PerpetualsTestUtils
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def upgade_test_utils(test_utils: PerpetualsTestUtils):
+    """Upgrade the perpetuals contract to the latest version and register the external components."""
+
+    # Fund the accounts
+    await test_utils.fund_account(
+        test_utils.known_accounts["upgrade_governor"].address, 10_000_000_000 * 10**18
+    )
+
+    # Upgrade the perpetuals contract to the latest version
+    await test_utils.upgrade_perpetuals_contract()
+
+    # Register and activate the external components
+    await test_utils.register_and_activate_external_component("perpetuals_VaultsManager", "VAULTS")
+    await test_utils.register_and_activate_external_component(
+        "perpetuals_WithdrawalManager", "WITHDRAWALS"
+    )
+    await test_utils.register_and_activate_external_component(
+        "perpetuals_TransferManager", "TRANSFERS"
+    )
+    await test_utils.register_and_activate_external_component(
+        "perpetuals_LiquidationManager", "LIQUIDATIONS"
+    )
+    await test_utils.register_and_activate_external_component(
+        "perpetuals_DeleverageManager", "DELEVERAGES"
+    )
+    await test_utils.register_and_activate_external_component(
+        "perpetuals_DepositManager", "DEPOSITS"
+    )
+    await test_utils.register_and_activate_external_component("perpetuals_AssetsManager", "ASSETS")
 
 
 @pytest.mark.asyncio
@@ -116,7 +149,7 @@ async def test_asset_management(test_utils: PerpetualsTestUtils):
 
     # Test price_tick
     oracle_price = 100000000
-    timestamp = test_utils.now_timestamp + 90
+    timestamp = test_utils.now_timestamp
     signed_price = test_utils.create_signed_price(
         oracle_account,
         oracle_price,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces full devnet E2E coverage and utilities while updating fork configuration.
> 
> - **New system tests** in `devnet_tests/system_test.py` that fund accounts, upgrade the Perpetuals contract, register/activate external components, and validate flows: helper access, view queries, deposit/withdraw, asset/oracle management with `price_tick`, `funding_tick`, and `trade`
> - **JSON-RPC helpers** in `perpetuals_test_utils.py`: `fund_account` and `get_account_balance` for devnet minting and balance checks
> - **API alignment**: use `get_base_collateral_token_contract` in test utils and set `price_tick` timestamp to `now_timestamp`
> - **Fork setup update** in `conftest.py`: switch to `.../mainnet/rpc/v0_10` and pass `start_time=NOW_TIMESTAMP` to stabilize funding/timestamps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9fd0c9f8698817958b2341c5b744c4f6d53eeca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/173)
<!-- Reviewable:end -->
