### PR TITLE
test: add python infra for usdc mig phase 1

### DIFF
--- a/devnet_tests/conftest.py
+++ b/devnet_tests/conftest.py
@@ -114,7 +114,7 @@ GOVERNANCE_ADMIN_ADDRESS = 0x522E5BA327BFBD85138B29BDE060A5340A460706B00AE2E10E6
 RICH_USDC_HOLDER_ADDRESS = 0x054A6DF48915BE451CD6650C3697C5789B934EB2A89D90CBB71E3234F24F0311
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def accounts_to_impersonate() -> dict[str, tuple[int, int]]:
     # dict[account_name] = (address, dummy_key)
     return {
@@ -147,11 +147,11 @@ def wait_for_devnet(port: int, timeout: int = 60) -> bool:
     return False
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def starknet_test_utils_factory():
     """
-    Session-scoped factory for creating StarknetTestUtils instances.
-    Overrides the function-scoped fixture from test_utils.fixtures.
+    Factory for creating StarknetTestUtils instances.
+    Overrides the fixture from test_utils.fixtures.
     """
 
     @contextlib.contextmanager
@@ -168,7 +168,7 @@ def starknet_test_utils_factory():
     return _factory
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def starknet_forked(
     starknet_test_utils_factory: Callable[..., Iterator[StarknetTestUtils]]
 ) -> Iterator[StarknetTestUtils]:
@@ -181,7 +181,7 @@ def starknet_forked(
         yield val
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def starknet_forked_with_impersonated_accounts(
     starknet_forked: StarknetTestUtils,
     accounts_to_impersonate: dict[str, tuple[int, int]],
@@ -196,7 +196,7 @@ def starknet_forked_with_impersonated_accounts(
     return starknet_forked
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def accounts(
     starknet_forked_with_impersonated_accounts: StarknetTestUtils,
     accounts_to_impersonate: dict[str, tuple[int, int]],
@@ -216,7 +216,7 @@ def accounts(
     }
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest_asyncio.fixture
 async def contracts(
     accounts: dict[str, Account],
 ) -> dict[str, Contract]:
@@ -260,15 +260,15 @@ async def contracts_inner_fixture(
     return result
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def test_utils(
     starknet_forked_with_impersonated_accounts: StarknetTestUtils,
     accounts: dict[str, Account],
     contracts: dict[str, Contract],
 ):
     """
-    Session-scoped PerpetualsTestUtils instance.
-    Shared across all tests to maintain nonce tracking.
+    Function-scoped PerpetualsTestUtils instance.
+    Each test gets its own instance with its own fork.
     """
     from devnet_tests.perpetuals_test_utils import PerpetualsTestUtils
 

--- a/devnet_tests/system_test.py
+++ b/devnet_tests/system_test.py
@@ -4,7 +4,7 @@ from starknet_py.cairo.felt import encode_shortstring
 from devnet_tests.perpetuals_test_utils import PerpetualsTestUtils
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def upgade_test_utils(test_utils: PerpetualsTestUtils):
     """Upgrade the perpetuals contract to the latest version and register the external components."""
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Shifts test infra to per-test isolation and adds vault/trading utilities with unified signing and nonce handling.
> 
> - Switches pytest fixtures from session-scoped to function-scoped in `conftest.py` (and in `system_test.py` fixture), so each test runs on its own forked devnet instance
> - `PerpetualsTestUtils` gains vault support: `invest_in_vault`, `redeem_from_vault`, ERC-4626 interactions (`get_vault_erc4626_contract`), and limit-order helpers
> - Introduces `sign_message` for typed-data style signatures; refactors `withdraw` and `trade` to use it
> - Refactors deposit processing into `__process_deposit` with dedicated flows (`process_base_collateral_deposit`, `process_non_base_collateral_deposit`, `process_vault_invest_deposit`)
> - Adds helpers for asset/config queries (`get_asset_config`, `get_asset_balance_of_position`) and consumes operator nonce via `consume_operator_nonce` in price/funding/trade paths
> - Minor: fixes import path to `devnet_tests.conftest`, removes a debug print, updates comments/docstrings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac39f8d12c472d9088947af0f739b9a733b91938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/177)
<!-- Reviewable:end -->
