### PR TITLE
refactor(perpetuals): remove duplicated events and reorder definitions

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit.cairo
@@ -23,6 +23,7 @@ pub(crate) mod Deposit {
     use starkware_utils::time::time::{Time, TimeDelta};
     use crate::core::components::assets::interface::IAssets;
     use crate::core::components::deposit::deposit_manager::IDepositExternalDispatcherTrait;
+    use crate::core::components::deposit::events;
     use crate::core::components::external_components::external_component_manager::ExternalComponents as ExternalComponentsComponent;
     use crate::core::components::external_components::external_component_manager::ExternalComponents::InternalTrait as ExternalComponentsInternalTrait;
     use crate::core::components::vaults::vaults::Vaults as VaultsComponent;
@@ -36,7 +37,11 @@ pub(crate) mod Deposit {
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
-    pub enum Event {}
+    pub enum Event {
+        Deposit: events::Deposit,
+        DepositCanceled: events::DepositCanceled,
+        DepositProcessed: events::DepositProcessed,
+    }
 
 
     #[embeddable_as(DepositImpl)]

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -58,31 +58,30 @@ pub(crate) mod DepositManager {
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::interface::IAssets;
-    use perpetuals::core::components::deposit::Deposit as DepositComponent;
+    use perpetuals::core::components::deposit::interface::DepositStatus;
+    use perpetuals::core::components::deposit::{Deposit as DepositComponent, errors, events};
+    use perpetuals::core::components::external_components::interface::EXTERNAL_COMPONENT_DEPOSITS;
+    use perpetuals::core::components::external_components::named_component::ITypedComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
     use perpetuals::core::types::asset::AssetId;
-    use perpetuals::core::types::position::PositionId;
+    use perpetuals::core::types::asset::synthetic::AssetType;
+    use perpetuals::core::types::position::{PositionDiff, PositionId};
     use starknet::storage::{StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess};
     use starknet::{ContractAddress, get_contract_address};
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
+    use starkware_utils::signature::stark::HashType;
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use starkware_utils::time::time::Time;
-    use crate::core::components::deposit::events;
-    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_DEPOSITS;
-    use crate::core::components::external_components::named_component::ITypedComponent;
-    use crate::core::components::snip::SNIP12MetadataImpl;
-    use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
-    use crate::core::types::asset::synthetic::AssetType;
-    use crate::core::types::position::PositionDiff;
-    use super::super::errors;
-    use super::{DepositStatus, HashType, IDepositExternal, TimeDelta, Timestamp, deposit_hash};
+    use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
+    use super::{IDepositExternal, deposit_hash};
 
 
     #[event]
@@ -110,9 +109,6 @@ pub(crate) mod DepositManager {
         RolesEvent: RolesComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
-        Deposit: events::Deposit,
-        DepositCanceled: events::DepositCanceled,
-        DepositProcessed: events::DepositProcessed,
     }
 
     #[storage]
@@ -272,6 +268,7 @@ pub(crate) mod DepositManager {
             self.deposits.registered_deposits.write(deposit_hash, DepositStatus::PROCESSED);
             self.positions.apply_diff(:position_id, :position_diff);
             self
+                .deposits
                 .emit(
                     events::DepositProcessed {
                         position_id,
@@ -360,6 +357,7 @@ pub(crate) mod DepositManager {
             );
 
             self
+                .deposits
                 .emit(
                     events::Deposit {
                         position_id,
@@ -423,6 +421,7 @@ pub(crate) mod DepositManager {
                 errors::TRANSFER_FAILED,
             );
             self
+                .deposits
                 .emit(
                     events::DepositCanceled {
                         position_id,

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer.cairo
@@ -1,1 +1,2 @@
+pub mod events;
 pub mod transfer_manager;

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/events.cairo
@@ -1,0 +1,32 @@
+use perpetuals::core::types::asset::AssetId;
+use perpetuals::core::types::position::PositionId;
+use starkware_utils::time::time::Timestamp;
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct TransferRequest {
+    #[key]
+    pub recipient: PositionId,
+    #[key]
+    pub position_id: PositionId,
+    pub collateral_id: AssetId,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    #[key]
+    pub transfer_request_hash: felt252,
+    pub salt: felt252,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct Transfer {
+    #[key]
+    pub recipient: PositionId,
+    #[key]
+    pub position_id: PositionId,
+    pub collateral_id: AssetId,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    #[key]
+    pub transfer_request_hash: felt252,
+    pub salt: felt252,
+}
+

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -3,34 +3,6 @@ use perpetuals::core::types::position::PositionId;
 use starkware_utils::signature::stark::Signature;
 use starkware_utils::time::time::Timestamp;
 
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct TransferRequest {
-    #[key]
-    pub recipient: PositionId,
-    #[key]
-    pub position_id: PositionId,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub transfer_request_hash: felt252,
-    pub salt: felt252,
-}
-
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct Transfer {
-    #[key]
-    pub recipient: PositionId,
-    #[key]
-    pub position_id: PositionId,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub transfer_request_hash: felt252,
-    pub salt: felt252,
-}
-
 #[starknet::interface]
 pub trait ITransferManager<TContractState> {
     fn transfer_request(
@@ -63,32 +35,33 @@ pub(crate) mod TransferManager {
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
     use perpetuals::core::components::assets::interface::IAssets;
+    use perpetuals::core::components::external_components::interface::EXTERNAL_COMPONENT_TRANSFERS;
+    use perpetuals::core::components::external_components::named_component::ITypedComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalImpl as OperatorNonceInternal;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::transfer::events::{Transfer, TransferRequest};
+    use perpetuals::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
+    use perpetuals::core::errors::{INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED};
     use perpetuals::core::types::asset::AssetId;
-    use perpetuals::core::types::position::{PositionId, PositionTrait};
+    use perpetuals::core::types::asset::synthetic::AssetType;
+    use perpetuals::core::types::position::{PositionDiff, PositionId, PositionTrait};
+    use perpetuals::core::types::transfer::TransferArgs;
     use starknet::storage::StoragePointerReadAccess;
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent::InternalTrait as RequestApprovalsInternal;
     use starkware_utils::components::roles::RolesComponent;
+    use starkware_utils::signature::stark::Signature;
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use starkware_utils::time::time::validate_expiration;
-    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_TRANSFERS;
-    use crate::core::components::external_components::named_component::ITypedComponent;
-    use crate::core::components::snip::SNIP12MetadataImpl;
-    use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
-    use crate::core::errors::{INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED};
-    use crate::core::types::asset::synthetic::AssetType;
-    use crate::core::types::position::PositionDiff;
-    use crate::core::types::transfer::TransferArgs;
-    use super::{ITransferManager, Signature, Timestamp, Transfer, TransferRequest};
+    use starkware_utils::time::time::{Timestamp, validate_expiration};
+    use super::ITransferManager;
 
     impl SnipImpl = SNIP12MetadataImpl;
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal.cairo
@@ -1,1 +1,2 @@
+pub mod events;
 pub mod withdrawal_manager;

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/events.cairo
@@ -1,0 +1,60 @@
+use perpetuals::core::types::asset::AssetId;
+use perpetuals::core::types::position::PositionId;
+use starknet::ContractAddress;
+use starkware_utils::time::time::Timestamp;
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct WithdrawRequest {
+    #[key]
+    pub position_id: PositionId,
+    #[key]
+    pub recipient: ContractAddress,
+    pub collateral_id: AssetId,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    #[key]
+    pub withdraw_request_hash: felt252,
+    pub salt: felt252,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct Withdraw {
+    #[key]
+    pub position_id: PositionId,
+    #[key]
+    pub recipient: ContractAddress,
+    pub collateral_id: AssetId,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    #[key]
+    pub withdraw_request_hash: felt252,
+    pub salt: felt252,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct ForcedWithdrawRequest {
+    #[key]
+    pub position_id: PositionId,
+    #[key]
+    pub recipient: ContractAddress,
+    pub collateral_id: AssetId,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    #[key]
+    pub forced_withdraw_request_hash: felt252,
+    pub salt: felt252,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct ForcedWithdraw {
+    #[key]
+    pub position_id: PositionId,
+    #[key]
+    pub recipient: ContractAddress,
+    pub collateral_id: AssetId,
+    pub amount: u64,
+    pub expiration: Timestamp,
+    #[key]
+    pub forced_withdraw_request_hash: felt252,
+    pub salt: felt252,
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -4,62 +4,6 @@ use starknet::ContractAddress;
 use starkware_utils::signature::stark::Signature;
 use starkware_utils::time::time::Timestamp;
 
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct WithdrawRequest {
-    #[key]
-    pub position_id: PositionId,
-    #[key]
-    pub recipient: ContractAddress,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub withdraw_request_hash: felt252,
-    pub salt: felt252,
-}
-
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct Withdraw {
-    #[key]
-    pub position_id: PositionId,
-    #[key]
-    pub recipient: ContractAddress,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub withdraw_request_hash: felt252,
-    pub salt: felt252,
-}
-
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct ForcedWithdrawRequest {
-    #[key]
-    pub position_id: PositionId,
-    #[key]
-    pub recipient: ContractAddress,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub forced_withdraw_request_hash: felt252,
-    pub salt: felt252,
-}
-
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct ForcedWithdraw {
-    #[key]
-    pub position_id: PositionId,
-    #[key]
-    pub recipient: ContractAddress,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub forced_withdraw_request_hash: felt252,
-    pub salt: felt252,
-}
-
 #[starknet::interface]
 pub trait IWithdrawalManager<TContractState> {
     fn withdraw_request(
@@ -113,18 +57,23 @@ pub(crate) mod WithdrawalManager {
     use perpetuals::core::components::assets::errors::{ASSET_NOT_EXISTS, INACTIVE_ASSET};
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::Deposit::InternalImpl as DepositInternal;
+    use perpetuals::core::components::external_components::interface::EXTERNAL_COMPONENT_WITHDRAWALS;
+    use perpetuals::core::components::external_components::named_component::ITypedComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalImpl as OperatorNonceInternal;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::withdrawal::events::{
+        ForcedWithdraw, ForcedWithdrawRequest, Withdraw, WithdrawRequest,
+    };
     use perpetuals::core::errors::{
         FORCED_WAIT_REQUIRED, INVALID_WITHDRAW_COLLATERAL, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED,
         TRANSFER_FAILED,
     };
-    use perpetuals::core::types::asset::AssetId;
-    use perpetuals::core::types::asset::synthetic::SyntheticTrait;
+    use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
+    use perpetuals::core::types::asset::{AssetId, AssetStatus};
     use perpetuals::core::types::balance::BalanceImpl;
     use perpetuals::core::types::position::{Position, PositionDiff, PositionId, PositionTrait};
     use perpetuals::core::types::price::PriceImpl;
@@ -139,19 +88,12 @@ pub(crate) mod WithdrawalManager {
     use starkware_utils::components::request_approvals::RequestApprovalsComponent::InternalTrait as RequestApprovalsInternal;
     use starkware_utils::components::roles::RolesComponent;
     use starkware_utils::hash::message_hash::OffchainMessageHash;
-    use starkware_utils::signature::stark::HashType;
+    use starkware_utils::signature::stark::{HashType, Signature};
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use starkware_utils::time::time::{Time, TimeDelta, validate_expiration};
-    use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_WITHDRAWALS;
-    use crate::core::components::external_components::named_component::ITypedComponent;
-    use crate::core::types::asset::AssetStatus;
-    use crate::core::types::asset::synthetic::AssetType;
-    use super::{
-        ForcedWithdraw, ForcedWithdrawRequest, IWithdrawalManager, Signature, Timestamp, Withdraw,
-        WithdrawRequest,
-    };
+    use starkware_utils::time::time::{Time, TimeDelta, Timestamp, validate_expiration};
+    use super::IWithdrawalManager;
 
     impl SnipImpl = SNIP12MetadataImpl;
 

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -9,14 +9,29 @@ pub mod Core {
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalTrait as AssetsInternal;
     use perpetuals::core::components::assets::errors::{NOT_SYNTHETIC, NO_SUCH_ASSET};
+    use perpetuals::core::components::assets::interface::IAssets;
+    use perpetuals::core::components::deleverage::deleverage_manager::IDeleverageManagerDispatcherTrait;
     use perpetuals::core::components::deposit::Deposit;
     use perpetuals::core::components::deposit::Deposit::InternalTrait as DepositInternal;
+    use perpetuals::core::components::external_components::external_component_manager::ExternalComponents as ExternalComponentsComponent;
+    use perpetuals::core::components::external_components::external_component_manager::ExternalComponents::InternalTrait as ExternalComponentsInternalTrait;
+    use perpetuals::core::components::fulfillment::fulfillment::Fulfillement;
+    use perpetuals::core::components::fulfillment::interface::IFulfillment;
+    use perpetuals::core::components::liquidation::liquidation_manager::ILiquidationManagerDispatcherTrait;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalTrait as OperatorNonceInternal;
     use perpetuals::core::components::positions::Positions;
     use perpetuals::core::components::positions::Positions::{
         FEE_POSITION, InternalTrait as PositionsInternalTrait,
     };
+    use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::transfer::events as transfer_events;
+    use perpetuals::core::components::transfer::transfer_manager::ITransferManagerDispatcherTrait;
+    use perpetuals::core::components::vaults::events as vault_events;
+    use perpetuals::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
+    use perpetuals::core::components::vaults::vaults_contract::IVaultExternalDispatcherTrait;
+    use perpetuals::core::components::withdrawal::events as withdraw_events;
+    use perpetuals::core::components::withdrawal::withdrawal_manager::IWithdrawalManagerDispatcherTrait;
     use perpetuals::core::errors::{
         AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_ZERO_TIMEOUT, LENGTH_MISMATCH,
         ORDER_IS_NOT_EXPIRED, TRADE_ASSET_NOT_SYNTHETIC, TRANSFER_FAILED,
@@ -24,11 +39,13 @@ pub mod Core {
     use perpetuals::core::events;
     use perpetuals::core::interface::{ICore, Settlement};
     use perpetuals::core::types::asset::AssetId;
+    use perpetuals::core::types::asset::synthetic::AssetType;
     use perpetuals::core::types::balance::Balance;
     use perpetuals::core::types::order::{ForcedTrade, LimitOrder, Order};
     use perpetuals::core::types::position::{PositionDiff, PositionId, PositionTrait};
     use perpetuals::core::types::price::PriceMulTrait;
     use perpetuals::core::types::vault::ConvertPositionToVault;
+    use perpetuals::core::utils::{validate_signature, validate_trade};
     use perpetuals::core::value_risk_calculator::PositionTVTR;
     use starknet::event::EventEmitter;
     use starknet::storage::{
@@ -50,22 +67,6 @@ pub mod Core {
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
     use starkware_utils::time::time::{Time, TimeDelta, Timestamp};
-    use crate::core::components::assets::interface::IAssets;
-    use crate::core::components::deleverage::deleverage_manager::IDeleverageManagerDispatcherTrait;
-    use crate::core::components::deposit::events as deposit_events;
-    use crate::core::components::external_components::external_component_manager::ExternalComponents as ExternalComponentsComponent;
-    use crate::core::components::external_components::external_component_manager::ExternalComponents::InternalTrait as ExternalComponentsInternalTrait;
-    use crate::core::components::fulfillment::fulfillment::Fulfillement;
-    use crate::core::components::fulfillment::interface::IFulfillment;
-    use crate::core::components::liquidation::liquidation_manager::ILiquidationManagerDispatcherTrait;
-    use crate::core::components::snip::SNIP12MetadataImpl;
-    use crate::core::components::transfer::transfer_manager::ITransferManagerDispatcherTrait;
-    use crate::core::components::vaults::events as vault_events;
-    use crate::core::components::vaults::vaults::{IVaults, Vaults as VaultsComponent};
-    use crate::core::components::vaults::vaults_contract::IVaultExternalDispatcherTrait;
-    use crate::core::components::withdrawal::withdrawal_manager::IWithdrawalManagerDispatcherTrait;
-    use crate::core::types::asset::synthetic::AssetType;
-    use crate::core::utils::{validate_signature, validate_trade};
 
 
     component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);
@@ -186,24 +187,24 @@ pub mod Core {
         RequestApprovalsEvent: RequestApprovalsComponent::Event,
         #[flat]
         PositionsEvent: Positions::Event,
-        Deleverage: events::Deleverage,
-        AssetPositionReduced: events::AssetPositionReduced,
-        Liquidate: events::Liquidate,
-        Trade: events::Trade,
-        Withdraw: events::Withdraw,
-        WithdrawRequest: events::WithdrawRequest,
-        ForcedTradeRequest: events::ForcedTradeRequest,
-        ForcedTrade: events::ForcedTrade,
         #[flat]
         FulfillmentEvent: Fulfillement::Event,
         #[flat]
         ExternalComponentsEvent: ExternalComponentsComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
-        //duplicated for ABI
-        Deposit: deposit_events::Deposit,
-        DepositCanceled: deposit_events::DepositCanceled,
-        DepositProcessed: deposit_events::DepositProcessed,
+        Deleverage: events::Deleverage,
+        AssetPositionReduced: events::AssetPositionReduced,
+        Liquidate: events::Liquidate,
+        Trade: events::Trade,
+        Withdraw: withdraw_events::Withdraw,
+        WithdrawRequest: withdraw_events::WithdrawRequest,
+        ForcedWithdraw: withdraw_events::ForcedWithdraw,
+        ForcedWithdrawRequest: withdraw_events::ForcedWithdrawRequest,
+        Transfer: transfer_events::Transfer,
+        TransferRequest: transfer_events::TransferRequest,
+        ForcedTradeRequest: events::ForcedTradeRequest,
+        ForcedTrade: events::ForcedTrade,
         InvestInVault: vault_events::InvestInVault,
     }
 

--- a/workspace/apps/perpetuals/contracts/src/core/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/events.cairo
@@ -1,35 +1,5 @@
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::position::PositionId;
-use starknet::ContractAddress;
-use starkware_utils::time::time::Timestamp;
-
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct WithdrawRequest {
-    #[key]
-    pub position_id: PositionId,
-    #[key]
-    pub recipient: ContractAddress,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub withdraw_request_hash: felt252,
-    pub salt: felt252,
-}
-
-#[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct Withdraw {
-    #[key]
-    pub position_id: PositionId,
-    #[key]
-    pub recipient: ContractAddress,
-    pub collateral_id: AssetId,
-    pub amount: u64,
-    pub expiration: Timestamp,
-    #[key]
-    pub withdraw_request_hash: felt252,
-    pub salt: felt252,
-}
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
 pub struct Trade {

--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -2,8 +2,9 @@ use perpetuals::core::components::assets::events as assets_events;
 use perpetuals::core::components::deposit::events as deposit_events;
 use perpetuals::core::components::positions::events as positions_events;
 use perpetuals::core::components::snip::SNIP12MetadataImpl;
-use perpetuals::core::components::withdrawal::withdrawal_manager::{
-    ForcedWithdraw, ForcedWithdrawRequest,
+use perpetuals::core::components::transfer::events::{Transfer, TransferRequest};
+use perpetuals::core::components::withdrawal::events::{
+    ForcedWithdraw, ForcedWithdrawRequest, Withdraw, WithdrawRequest,
 };
 use perpetuals::core::events;
 use perpetuals::core::types::asset::AssetId;
@@ -17,7 +18,6 @@ use starknet::ContractAddress;
 use starkware_utils::signature::stark::PublicKey;
 use starkware_utils::time::time::Timestamp;
 use starkware_utils_testing::test_utils::assert_expected_event_emitted;
-use crate::core::components::transfer::transfer_manager::{Transfer, TransferRequest};
 
 
 pub fn assert_new_position_event_with_expected(
@@ -129,7 +129,7 @@ pub fn assert_withdraw_request_event_with_expected(
     withdraw_request_hash: felt252,
     salt: felt252,
 ) {
-    let expected_event = events::WithdrawRequest {
+    let expected_event = WithdrawRequest {
         position_id, recipient, collateral_id, amount, expiration, withdraw_request_hash, salt,
     };
     assert_expected_event_emitted(
@@ -150,7 +150,7 @@ pub fn assert_withdraw_event_with_expected(
     withdraw_request_hash: felt252,
     salt: felt252,
 ) {
-    let expected_event = events::Withdraw {
+    let expected_event = Withdraw {
         position_id, recipient, collateral_id, amount, expiration, withdraw_request_hash, salt,
     };
     assert_expected_event_emitted(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Consolidates event definitions and removes duplicates across core components.
> 
> - Adds dedicated `transfer/events.cairo` and `withdrawal/events.cairo`; moves `Transfer*` and `Withdraw*` structs out of managers and `core/events.cairo`
> - Updates `Core` event enum to use `withdraw_events::*` and `transfer_events::*`; drops duplicated withdraw events
> - `Deposit` component now declares `Deposit*` events and emits via `self.deposits.emit(...)`; `DepositManager` updated to emit through `DepositComponent::Event` and cleans imports/time types
> - Refactors `TransferManager` and `WithdrawalManager` to reference new events modules; no logic changes intended
> - Test utilities updated to import and assert against new event paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8beb169c37a22dff119a589ca08f98701ef9944. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/179)
<!-- Reviewable:end -->
