### PR TITLE
feat(perpetuals): impl forced redeem from vault

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -1,5 +1,6 @@
 use perpetuals::core::types::asset::AssetId;
 use perpetuals::core::types::position::PositionId;
+use starkware_utils::time::time::Timestamp;
 
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
@@ -26,4 +27,62 @@ pub struct InvestInVault {
     pub shares_received: u64,
     pub user_investment: u64,
     pub correlation_id: felt252,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct ForcedRedeemFromVaultRequest {
+    #[key]
+    pub order_source_position: PositionId,
+    #[key]
+    pub order_receive_position: PositionId,
+    pub order_base_asset_id: AssetId,
+    pub order_base_amount: i64,
+    pub order_quote_asset_id: AssetId,
+    pub order_quote_amount: i64,
+    pub order_fee_asset_id: AssetId,
+    pub order_fee_amount: u64,
+    pub order_expiration: Timestamp,
+    pub order_salt: felt252,
+    #[key]
+    pub vault_approval_source_position: PositionId,
+    #[key]
+    pub vault_approval_receive_position: PositionId,
+    pub vault_approval_base_asset_id: AssetId,
+    pub vault_approval_base_amount: i64,
+    pub vault_approval_quote_asset_id: AssetId,
+    pub vault_approval_quote_amount: i64,
+    pub vault_approval_fee_asset_id: AssetId,
+    pub vault_approval_fee_amount: u64,
+    pub vault_approval_expiration: Timestamp,
+    pub vault_approval_salt: felt252,
+    #[key]
+    pub hash: felt252,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct ForcedRedeemFromVault {
+    #[key]
+    pub order_source_position: PositionId,
+    #[key]
+    pub order_receive_position: PositionId,
+    pub order_base_asset_id: AssetId,
+    pub order_base_amount: i64,
+    pub order_quote_asset_id: AssetId,
+    pub order_quote_amount: i64,
+    pub order_fee_asset_id: AssetId,
+    pub order_fee_amount: u64,
+    pub order_expiration: Timestamp,
+    pub order_salt: felt252,
+    #[key]
+    pub vault_approval_source_position: PositionId,
+    #[key]
+    pub vault_approval_receive_position: PositionId,
+    pub vault_approval_base_asset_id: AssetId,
+    pub vault_approval_base_amount: i64,
+    pub vault_approval_quote_asset_id: AssetId,
+    pub vault_approval_quote_amount: i64,
+    pub vault_approval_fee_asset_id: AssetId,
+    pub vault_approval_fee_amount: u64,
+    pub vault_approval_expiration: Timestamp,
+    pub vault_approval_salt: felt252,
 }

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -175,6 +175,19 @@ pub trait ICore<TContractState> {
         order_b: Order,
     );
     fn forced_trade(ref self: TContractState, operator_nonce: u64, order_a: Order, order_b: Order);
+    fn forced_redeem_from_vault_request(
+        ref self: TContractState,
+        signature: Signature,
+        vault_signature: Signature,
+        order: LimitOrder,
+        vault_approval: LimitOrder,
+    );
+    fn force_redeem_from_vault(
+        ref self: TContractState,
+        operator_nonce: u64,
+        order: LimitOrder,
+        vault_approval: LimitOrder,
+    );
     fn apply_interests(
         ref self: TContractState,
         operator_nonce: u64,

--- a/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
@@ -297,11 +297,55 @@ impl ForcedTradeStructHashImpl of StructHash<ForcedTrade> {
     }
 }
 
+#[derive(Copy, Drop, Hash, Serde)]
+pub struct ForcedRedeemFromVault {
+    pub order: LimitOrder,
+    pub vault_approval: LimitOrder,
+}
+
+/// selector!(
+///   "\"ForcedRedeemFromVault\"(
+///    \"order\":\"LimitOrder\",
+///    \"vault_approval\":\"LimitOrder\",
+///    )
+///   "\"LimitOrder\"(
+///    \"source_position\":\"PositionId\",
+///    \"receive_position\":\"PositionId\",
+///    \"base_asset_id\":\"AssetId\",
+///    \"base_amount\":\"i64\",
+///    \"quote_asset_id\":\"AssetId\",
+///    \"quote_amount\":\"i64\",
+///    \"fee_asset_id\":\"AssetId\",
+///    \"fee_amount\":\"u64\",
+///    \"expiration\":\"Timestamp\",
+///    \"salt\":\"felt\"
+///    )
+///    \"PositionId\"(
+///    \"value\":\"u32\"
+///    )"
+///    \"AssetId\"(
+///    \"value\":\"felt\"
+///    )"
+/// );
+
+const FORCED_REDEEM_FROM_VAULT_TYPE_HASH: HashType =
+    0x024da7c41d3d07be3249275f92e8e0e87cde33e9543002f1d10c75108e5f90b9;
+
+impl ForcedRedeemFromVaultStructHashImpl of StructHash<ForcedRedeemFromVault> {
+    fn hash_struct(self: @ForcedRedeemFromVault) -> HashType {
+        let hash_state = PoseidonTrait::new();
+        hash_state.update_with(FORCED_REDEEM_FROM_VAULT_TYPE_HASH).update_with(*self).finalize()
+    }
+}
+
 
 #[cfg(test)]
 mod tests {
     use starkware_utils::math::utils::to_base_16_string;
-    use super::{FORCED_TRADE_TYPE_HASH, LIMIT_ORDER_TYPE_HASH, ORDER_TYPE_HASH};
+    use super::{
+        FORCED_REDEEM_FROM_VAULT_TYPE_HASH, FORCED_TRADE_TYPE_HASH, LIMIT_ORDER_TYPE_HASH,
+        ORDER_TYPE_HASH,
+    };
 
     #[test]
     fn test_order_type_hash() {
@@ -323,5 +367,14 @@ mod tests {
             "\"ForcedTrade\"(\"order_a\":\"Order\",\"order_b\":\"Order\")\"Order\"(\"position_id\":\"PositionId\",\"base_asset_id\":\"AssetId\",\"base_amount\":\"i64\",\"quote_asset_id\":\"AssetId\",\"quote_amount\":\"i64\",\"fee_asset_id\":\"AssetId\",\"fee_amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"AssetId\"(\"value\":\"felt\")",
         );
         assert_eq!(to_base_16_string(FORCED_TRADE_TYPE_HASH), to_base_16_string(expected));
+    }
+    #[test]
+    fn test_forced_redeem_from_vault_type_hash() {
+        let expected = selector!(
+            "\"ForcedRedeemFromVault\"(\"order\":\"LimitOrder\",\"vault_approval\":\"LimitOrder\")\"LimitOrder\"(\"source_position\":\"PositionId\",\"receive_position\":\"PositionId\",\"base_asset_id\":\"AssetId\",\"base_amount\":\"i64\",\"quote_asset_id\":\"AssetId\",\"quote_amount\":\"i64\",\"fee_asset_id\":\"AssetId\",\"fee_amount\":\"u64\",\"expiration\":\"Timestamp\",\"salt\":\"felt\")\"PositionId\"(\"value\":\"u32\")\"AssetId\"(\"value\":\"felt\")\"Timestamp\"(\"seconds\":\"u64\")",
+        );
+        assert_eq!(
+            to_base_16_string(FORCED_REDEEM_FROM_VAULT_TYPE_HASH), to_base_16_string(expected),
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds new forced-action entrypoints that move funds/shares and bypass signature checks during execution, relying on prior request validation and timelock/nonce enforcement; mistakes here could enable unauthorized or incorrect redemptions.
> 
> **Overview**
> Adds a new *forced vault redemption* flow, letting users submit `forced_redeem_from_vault_request` (with both user and vault signatures) and later execute `force_redeem_from_vault` after a timelock (or immediately via operator + nonce). The request call registers/charges the forced-action fee and emits `ForcedRedeemFromVaultRequest`, while execution consumes the pending request, calls into the vault manager to redeem using order amounts as actuals, and emits `ForcedRedeemFromVault`.
> 
> Extends the vault manager contract with `force_redeem_from_vault` and refactors `_execute_redeem` to optionally skip signature validation (using `get_message_hash` instead) for forced execution. Introduces the `ForcedRedeemFromVault` SNIP-12 typed struct/hash, new vault events, ABI/interface updates, and spec documentation for the new flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ea6ef19fb9809135bf9d1c074dd3436494d5731. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/181)
<!-- Reviewable:end -->
