### PR TITLE
chore: bump OZ version

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -10,11 +10,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: "0.49.0"
-
+          starknet-foundry-version: "0.55.0"
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.2"
+          scarb-version: "2.15.1"
 
       - name: Build Contracts
         run: scarb build
@@ -44,8 +43,7 @@ jobs:
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.2"
-
+          scarb-version: "2.15.1"
       - name: Build Contracts
         run: scarb --release build
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.12.2
-starknet-foundry 0.49.0
+scarb 2.15.1
+starknet-foundry 0.55.0
 starknet-devnet 0.6.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,4 +179,4 @@ Executes signed user intents, processes deposits, performs liquidations, updates
 
 ---
 
-**Cairo:** 2.x (Edition 2024_07) | **Starknet:** 2.12.2 | **Last Updated:** 2025-10-22
+**Cairo:** 2.x (Edition 2024_07) | **Starknet:** 2.15.1 | **Last Updated:** 2026-01-01

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -151,13 +151,14 @@ dependencies = [
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.49.0"
+version = "0.55.0"
 source = "registry+https://scarbs.xyz/"
 checksum = "sha256:903150f0e9542e4277d417029eea4c03af0db398b581f9f7ae3ebbdac9afc657"
 
 [[package]]
 name = "snforge_std"
-version = "0.49.0"
+
+version = "0.55.0"
 source = "registry+https://scarbs.xyz/"
 checksum = "sha256:73d73653cc4356ec51b92a6bec9d8385b20318170c2f2ade7891e5185a0e7e64"
 dependencies = [

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,12 +2,12 @@
 members = ["workspace/apps/perpetuals/contracts", "workspace/vault/", "workspace/fulfillment"]
 
 [workspace.dependencies]
-starknet = "2.12.2"
-assert_macros = "2.12.2"
-openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", rev = "0e51722f231c0913915945d3df89e43cbb5cfc38" }
-snforge_std = "0.49.0"
-starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
-starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
+starknet = "2.15.1"
+assert_macros = "2.15.1"
+openzeppelin = "3.0.0"
+snforge_std = "0.55.0"
+starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "main" }
+starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "main" }
 
 [scripts]
 test = "snforge test --run-native"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Upgrade toolchain and dependencies**
> 
> - Bump `starknet-foundry` to `0.55.0`, `scarb` to `2.15.1`, and `snforge_std` to `0.55.0`
> - Update workspace deps: `starknet`/`assert_macros` → `2.15.1`, `openzeppelin` → `3.0.0`, switch `starkware_utils(_testing)` to `main` branch
> 
> **CI and environment**
> 
> - Update GitHub Actions workflow to use new `starknet-foundry` and `scarb` versions
> - Refresh `.tool-versions` accordingly
> 
> **Lockfile and docs**
> 
> - Regenerate `Scarb.lock` to reflect new versions
> - Update `AGENTS.md` version badges and last updated date
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44e1387f98ad9499106d895878de8b9e2596e02c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/188)
<!-- Reviewable:end -->
