### PR TITLE
fix(perps): move redeeming position XVS balance check after apply diff

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -588,12 +588,6 @@ pub(crate) mod VaultsManager {
                     position: vault_position, asset_id: self.assets.get_collateral_id(),
                 );
 
-            self
-                .positions
-                .validate_asset_balance_is_not_negative(
-                    position: redeeming_position, asset_id: order.base_asset_id,
-                );
-
             // user health checks
             if (self.positions.is_liquidatable(redeeming_position_id)) {
                 let (asset_id, qty) = redeeming_position_diff.asset_diff.unwrap();
@@ -634,6 +628,12 @@ pub(crate) mod VaultsManager {
                 .positions
                 .apply_diff(
                     position_id: redeeming_position_id, position_diff: redeeming_position_diff,
+                );
+
+            self
+                .positions
+                .validate_asset_balance_is_not_negative(
+                    position: redeeming_position, asset_id: order.base_asset_id,
                 );
 
             // no need to validate health as can only receive collateral


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorders validation in vault redemption to ensure balance checks reflect updated state.
> 
> - In `_execute_redeem`, removed pre-`apply_diff` `validate_asset_balance_is_not_negative` on the redeeming position and added the same check immediately after applying `redeeming_position_diff`
> - No interface or arithmetic changes; existing health checks and collateral return assertions remain intact
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cdc06895d192fcac38a100847f39ca106dee19b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/190)
<!-- Reviewable:end -->
