### PR TITLE
feat: add liquidate spot asset flow

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -994,6 +994,34 @@ pub mod Core {
         fn get_system_time(self: @ContractState) -> Timestamp {
             self.system_time.read()
         }
+        fn liquidate_spot_asset(
+            ref self: ContractState,
+            operator_nonce: u64,
+            liquidated_position_id: PositionId,
+            liquidator_order: LimitOrder,
+            liquidator_signature: Signature,
+            actual_amount_spot_collateral: i64,
+            actual_amount_base_collateral: i64,
+            actual_liquidator_fee: u64,
+            liquidated_fee_amount: u64,
+        ) {
+            self.pausable.assert_not_paused();
+            self.assets.validate_assets_integrity();
+            self.operator_nonce.use_checked_nonce(:operator_nonce);
+
+            self
+                .external_components
+                ._get_liquidation_manager_dispatcher()
+                .liquidate_spot_asset(
+                    :liquidated_position_id,
+                    :liquidator_order,
+                    :liquidator_signature,
+                    :actual_amount_spot_collateral,
+                    :actual_amount_base_collateral,
+                    :actual_liquidator_fee,
+                    :liquidated_fee_amount,
+                );
+        }
     }
 
     #[generate_trait]

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -168,4 +168,15 @@ pub trait ICore<TContractState> {
     fn forced_trade(ref self: TContractState, operator_nonce: u64, order_a: Order, order_b: Order);
     fn update_system_time(ref self: TContractState, operator_nonce: u64, new_timestamp: Timestamp);
     fn get_system_time(self: @TContractState) -> Timestamp;
+    fn liquidate_spot_asset(
+        ref self: TContractState,
+        operator_nonce: u64,
+        liquidated_position_id: PositionId,
+        liquidator_order: LimitOrder,
+        liquidator_signature: Signature,
+        actual_amount_spot_collateral: i64,
+        actual_amount_base_collateral: i64,
+        actual_liquidator_fee: u64,
+        liquidated_fee_amount: u64,
+    );
 }

--- a/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
@@ -28,6 +28,8 @@ pub trait ValidateableOrderTrait<T> {
     fn fee_amount(self: @T) -> u64;
     // The expiration time of the order.
     fn expiration(self: @T) -> Timestamp;
+    // The receive position of the order.
+    fn receive_position(self: @T) -> PositionId;
 
     fn validate_against_actual_amounts(
         self: @T, actual_amount_base: i64, actual_amount_quote: i64, actual_fee: u64,
@@ -112,6 +114,9 @@ pub impl LimitOrderValidationTraitImpl of ValidateableOrderTrait<LimitOrder> {
     }
     fn expiration(self: @LimitOrder) -> Timestamp {
         *self.expiration
+    }
+    fn receive_position(self: @LimitOrder) -> PositionId {
+        *self.receive_position
     }
 }
 
@@ -214,6 +219,9 @@ impl OrderValidationTraitImpl of ValidateableOrderTrait<Order> {
     }
     fn expiration(self: @Order) -> Timestamp {
         *self.expiration
+    }
+    fn receive_position(self: @Order) -> PositionId {
+        *self.position_id
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new spot-collateral liquidation flow and supporting order semantics.
> 
> - Implement `LiquidationManager::liquidate_spot_asset` with full validations (spot asset type, signatures, signs/ratios, fulfillment) and execution, including optional asset movement to `receive_position`
> - Expose `Core::liquidate_spot_asset` and `ICore::liquidate_spot_asset`, wiring pausable/assets/nonce checks and dispatch to the liquidation manager
> - Extend `ValidateableOrderTrait` for `Order`/`LimitOrder` with `receive_position()` and update liquidation internals to handle separate receive position; refactor `_validate_liquidate` (drops signature param)
> - Update `docs/spec.md` with a new **Liquidate Spot Asset** section, API, validations, logic, and errors, and add `liquidate_spot_asset()` to the Core diagram
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f04a0af01d882cd28e68ee6de9510f79800b8a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/192)
<!-- Reviewable:end -->
