### PR TITLE
test(multi-collateral): apply interests

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -67,7 +67,7 @@ pub mod Positions {
 
     #[storage]
     pub struct Storage {
-        positions: Map<PositionId, Position>,
+        pub positions: Map<PositionId, Position>,
     }
 
     #[event]

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -2091,6 +2091,15 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             .funding_tick(:operator_nonce, :funding_ticks, timestamp: Time::now());
     }
 
+    fn apply_interests(
+        ref self: PerpsTestsFacade, position_ids: Span<PositionId>, interest_amounts: Span<i64>,
+    ) {
+        let operator_nonce = self.get_nonce();
+        self.operator.set_as_caller(self.perpetuals_contract);
+        ICoreDispatcher { contract_address: self.perpetuals_contract }
+            .apply_interests(:operator_nonce, :position_ids, :interest_amounts);
+    }
+
     fn get_position_asset_balance(
         self: @PerpsTestsFacade, position_id: PositionId, synthetic_id: AssetId,
     ) -> Balance {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily adds/adjusts test harness and test cases; production change is limited to making `Positions::Storage.positions` public, which could increase internal coupling but shouldn’t affect runtime behavior.
> 
> **Overview**
> Adds a `PerpsTestsFacade.apply_interests` helper and a new suite of flow tests validating `Core.apply_interests` behavior across multiple positions, negative interest, sequential updates, and expected reverts when interest exceeds the max rate, is applied to zero-balance positions, or is applied twice without time advancing.
> 
> To enable these tests, `Positions` storage now exposes `positions` as `pub`, allowing direct state mutation of `last_interest_applied_time` in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a2015961af7eeb6b8e7bd3a1f6ccdf19833616d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/195)
<!-- Reviewable:end -->
