### PR TITLE
test(multi-collateral): liquidate spot tests

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -167,6 +167,13 @@ pub struct OrderInfo {
     hash: felt252,
 }
 
+#[derive(Copy, Drop)]
+pub struct LimitOrderInfo {
+    pub order: LimitOrder,
+    pub signature: Signature,
+    pub hash: felt252,
+}
+
 /// Account is a representation of any user account that can interact with the contracts.
 #[derive(Copy, Drop)]
 pub struct Account {
@@ -1680,6 +1687,189 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             actual_liquidator_fee: liquidator_fee,
             insurance_fund_fee_amount: liquidated_insurance_fee,
             liquidator_order_hash: liquidator_hash,
+        );
+    }
+
+    fn create_limit_order(
+        ref self: PerpsTestsFacade,
+        user: User,
+        base_asset_id: AssetId,
+        base_amount: i64,
+        quote_amount: i64,
+        fee_amount: u64,
+        receive_position_id: Option<PositionId>,
+    ) -> LimitOrderInfo {
+        let expiration = Time::now().add(delta: Time::weeks(1));
+        let salt = self.generate_salt();
+
+        let receive_position_id = match receive_position_id {
+            Some(id) => id,
+            None => user.position_id,
+        };
+
+        let order = LimitOrder {
+            source_position: user.position_id,
+            receive_position: receive_position_id,
+            base_asset_id,
+            base_amount,
+            quote_asset_id: self.collateral_id,
+            quote_amount,
+            fee_asset_id: self.collateral_id,
+            fee_amount,
+            expiration,
+            salt,
+        };
+        let message = order.get_message_hash(user.account.key_pair.public_key);
+        let signature = user.account.sign_message(:message);
+        LimitOrderInfo { order: order, signature: signature, hash: message }
+    }
+
+    fn liquidate_spot_asset(
+        ref self: PerpsTestsFacade,
+        liquidated_user: User,
+        liquidator_order_info: LimitOrderInfo,
+        actual_amount_spot_collateral: i64,
+        actual_amount_base_collateral: i64,
+        actual_liquidator_fee: u64,
+        liquidated_fee_amount: u64,
+    ) {
+        let liquidated_asset_id = liquidator_order_info.order.base_asset_id;
+        let dispatcher = IPositionsDispatcher { contract_address: self.perpetuals_contract };
+
+        // Get balances before liquidation
+        let liquidated_balance_before = dispatcher
+            .get_position_assets(position_id: liquidated_user.position_id);
+        let liquidated_collateral_balance_before = liquidated_balance_before.collateral_balance;
+        let liquidated_spot_balance_before = get_synthetic_balance(
+            assets: liquidated_balance_before.assets, asset_id: liquidated_asset_id,
+        );
+
+        let liquidator_balance_before = dispatcher
+            .get_position_assets(position_id: liquidator_order_info.order.source_position);
+        let liquidator_collateral_balance_before = liquidator_balance_before.collateral_balance;
+        let liquidator_spot_balance_before = get_synthetic_balance(
+            assets: liquidator_balance_before.assets, asset_id: liquidated_asset_id,
+        );
+
+        // Get receive position balance before if different from source
+        let is_receive_position_different = liquidator_order_info
+            .order
+            .source_position != liquidator_order_info
+            .order
+            .receive_position;
+        let liquidator_receive_balance_before = if is_receive_position_different {
+            dispatcher
+                .get_position_assets(position_id: liquidator_order_info.order.receive_position)
+        } else {
+            liquidator_balance_before
+        };
+        let liquidator_receive_spot_balance_before = get_synthetic_balance(
+            assets: liquidator_receive_balance_before.assets, asset_id: liquidated_asset_id,
+        );
+
+        let fee_position_balance_before = dispatcher
+            .get_position_assets(position_id: FEE_POSITION)
+            .collateral_balance;
+        let insurance_fee_position_balance_before = dispatcher
+            .get_position_assets(position_id: INSURANCE_FUND_POSITION)
+            .collateral_balance;
+
+        let operator_nonce = self.get_nonce();
+        self.operator.set_as_caller(self.perpetuals_contract);
+
+        ICoreDispatcher { contract_address: self.perpetuals_contract }
+            .liquidate_spot_asset(
+                :operator_nonce,
+                liquidated_position_id: liquidated_user.position_id,
+                liquidator_order: liquidator_order_info.order,
+                liquidator_signature: liquidator_order_info.signature,
+                :actual_amount_spot_collateral,
+                :actual_amount_base_collateral,
+                :actual_liquidator_fee,
+                :liquidated_fee_amount,
+            );
+
+        // Validate balances after liquidation
+        self
+            .validate_collateral_balance(
+                position_id: liquidated_user.position_id,
+                expected_balance: liquidated_collateral_balance_before
+                    - liquidated_fee_amount.into()
+                    + actual_amount_base_collateral.into(),
+            );
+
+        self
+            .validate_asset_balance(
+                position_id: liquidated_user.position_id,
+                asset_id: liquidated_asset_id,
+                expected_balance: liquidated_spot_balance_before
+                    + actual_amount_spot_collateral.into(),
+            );
+
+        self
+            .validate_collateral_balance(
+                position_id: liquidator_order_info.order.source_position,
+                expected_balance: liquidator_collateral_balance_before
+                    - actual_liquidator_fee.into()
+                    - actual_amount_base_collateral.into(),
+            );
+
+        // Validate asset balance based on whether source and receive positions are different
+        if !is_receive_position_different {
+            // Same position: receives assets and pays collateral
+            self
+                .validate_asset_balance(
+                    position_id: liquidator_order_info.order.source_position,
+                    asset_id: liquidated_asset_id,
+                    expected_balance: liquidator_spot_balance_before
+                        - actual_amount_spot_collateral.into(),
+                );
+        } else {
+            // Different positions: source keeps its assets unchanged, receive gets new assets
+            self
+                .validate_asset_balance(
+                    position_id: liquidator_order_info.order.source_position,
+                    asset_id: liquidated_asset_id,
+                    expected_balance: liquidator_spot_balance_before,
+                );
+            // Receive position gets the liquidated assets
+            self
+                .validate_asset_balance(
+                    position_id: liquidator_order_info.order.receive_position,
+                    asset_id: liquidated_asset_id,
+                    expected_balance: liquidator_receive_spot_balance_before
+                        - actual_amount_spot_collateral.into(),
+                );
+        }
+
+        self
+            .validate_collateral_balance(
+                position_id: FEE_POSITION,
+                expected_balance: fee_position_balance_before + actual_liquidator_fee.into(),
+            );
+
+        self
+            .validate_collateral_balance(
+                position_id: INSURANCE_FUND_POSITION,
+                expected_balance: insurance_fee_position_balance_before
+                    + liquidated_fee_amount.into(),
+            );
+
+        // Verify liquidation event was emitted
+        assert_liquidate_event_with_expected(
+            spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
+            liquidated_position_id: liquidated_user.position_id,
+            liquidator_order_position_id: liquidator_order_info.order.source_position,
+            liquidator_order_base_asset_id: liquidated_asset_id,
+            liquidator_order_base_amount: liquidator_order_info.order.base_amount,
+            collateral_id: self.collateral_id,
+            liquidator_order_quote_amount: liquidator_order_info.order.quote_amount,
+            liquidator_order_fee_amount: liquidator_order_info.order.fee_amount,
+            actual_amount_base_liquidated: actual_amount_spot_collateral,
+            actual_amount_quote_liquidated: actual_amount_base_collateral,
+            actual_liquidator_fee: actual_liquidator_fee,
+            insurance_fund_fee_amount: liquidated_fee_amount,
+            liquidator_order_hash: liquidator_order_info.hash,
         );
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds test coverage and helpers for spot-collateral liquidation flows.
> 
> - Extends `perps_tests_facade.cairo` with `LimitOrderInfo`, `create_limit_order`, and `liquidate_spot_asset`, including balance/event validations and support for different `source_position` vs `receive_position`.
> - Adds unit tests in `unit_flow_tests.cairo` covering: liquidation after price drop; multi-step liquidation; exact full-position liquidation; liquidation to empty position; rejection for non-spot and vault-share assets; validation on very small amounts (quote/fee ratio); rejection when position is deleveragable; and liquidation with distinct source/receive positions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e54a8480674e3517663815c4c6972a6daff63daf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/197)
<!-- Reviewable:end -->
