### PR TITLE
chore : bump versions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -10,11 +10,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3
         with:
-          starknet-foundry-version: "0.49.0"
+          starknet-foundry-version: "0.55.0"
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.2"
+          scarb-version: "2.15.1"
 
       - name: Build Contracts
         run: scarb build
@@ -44,7 +44,7 @@ jobs:
 
       - uses: software-mansion/setup-scarb@v1
         with:
-          scarb-version: "2.12.2"
+          scarb-version: "2.15.1"
 
       - name: Build Contracts
         run: scarb --release build

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.12.2
-starknet-foundry 0.49.0
+scarb 2.15.1
+starknet-foundry 0.55.0
 starknet-devnet 0.6.1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,4 +179,4 @@ Executes signed user intents, processes deposits, performs liquidations, updates
 
 ---
 
-**Cairo:** 2.x (Edition 2024_07) | **Starknet:** 2.12.2 | **Last Updated:** 2025-10-22
+**Cairo:** 2.x (Edition 2024_07) | **Starknet:** 2.15.1 | **Last Updated:** 2026-01-15

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#eed7b88804c0f73741e081779f1cbe1ace465522"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=eed7b88804c0f73741e081779f1cbe1ace465522#eed7b88804c0f73741e081779f1cbe1ace465522"
 dependencies = [
  "openzeppelin",
 ]
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "starkware_utils_testing"
 version = "1.0.0"
-source = "git+https://github.com/starkware-libs/starkware-starknet-utils?branch=oz-3.0.0-alpha.2#eed7b88804c0f73741e081779f1cbe1ace465522"
+source = "git+https://github.com/starkware-libs/starkware-starknet-utils?rev=eed7b88804c0f73741e081779f1cbe1ace465522#eed7b88804c0f73741e081779f1cbe1ace465522"
 dependencies = [
  "openzeppelin",
  "snforge_std",

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,12 +2,12 @@
 members = ["workspace/apps/perpetuals/contracts", "workspace/vault/", "workspace/fulfillment"]
 
 [workspace.dependencies]
-starknet = "2.12.2"
-assert_macros = "2.12.2"
+starknet = "2.15.1"
+assert_macros = "2.15.1"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts", rev = "0e51722f231c0913915945d3df89e43cbb5cfc38" }
 snforge_std = "0.49.0"
-starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
-starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", branch = "oz-3.0.0-alpha.2" }
+starkware_utils = { git = "https://github.com/starkware-libs/starkware-starknet-utils", rev = "eed7b88804c0f73741e081779f1cbe1ace465522" }
+starkware_utils_testing = { git = "https://github.com/starkware-libs/starkware-starknet-utils", rev = "eed7b88804c0f73741e081779f1cbe1ace465522" }
 
 [scripts]
 test = "snforge test --run-native"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/200)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Toolchain/CI upgrades**
> 
> - Update CI workflow to use `starknet-foundry 0.55.0` and `scarb 2.15.1` for builds/tests
> - Bump local tool versions in `.tool-versions` to `scarb 2.15.1` and `starknet-foundry 0.55.0`
> 
> **Dependency updates**
> 
> - Move workspace deps `starknet`/`assert_macros` to `2.15.1` in `Scarb.toml`
> - Pin `starkware_utils` and `starkware_utils_testing` from branch to a specific `rev` in `Scarb.toml` (reflected in `Scarb.lock`)
> 
> **Docs**
> 
> - Refresh `AGENTS.md` environment footer to Cairo 2.x / Starknet `2.15.1` with updated date
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc68b6105851188924530b6172e8471a11141c05. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->