### PR TITLE
generalize liquidation order validation to use ValidateableOrderTrait

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -13,8 +13,8 @@ pub mod AssetsComponent {
         ALREADY_INITIALIZED, ASSET_NOT_EXISTS, COLLATERAL_NOT_REGISTERED, FUNDING_EXPIRED,
         FUNDING_TICKS_NOT_SORTED, INACTIVE_ASSET, INVALID_FUNDING_TICK_LEN, INVALID_MEDIAN,
         INVALID_PRICE_TIMESTAMP, INVALID_TIMESTAMP, INVALID_ZERO_ASSET_ID, INVALID_ZERO_QUANTUM,
-        INVALID_ZERO_TOKEN_ADDRESS, NOT_COLLATERAL, NOT_SYNTHETIC, QUORUM_NOT_REACHED,
-        SIGNED_PRICES_UNSORTED, SYNTHETIC_EXPIRED_PRICE, SYNTHETIC_NOT_ACTIVE,
+        INVALID_ZERO_TOKEN_ADDRESS, NOT_COLLATERAL, NOT_SYNTHETIC, NO_SUCH_ASSET,
+        QUORUM_NOT_REACHED, SIGNED_PRICES_UNSORTED, SYNTHETIC_EXPIRED_PRICE, SYNTHETIC_NOT_ACTIVE,
         ZERO_MAX_FUNDING_INTERVAL, ZERO_MAX_FUNDING_RATE, ZERO_MAX_ORACLE_PRICE,
         ZERO_MAX_PRICE_INTERVAL, oracle_public_key_not_registered,
     };
@@ -242,6 +242,14 @@ pub mod AssetsComponent {
                 tiers.append(risk_factor_tiers.at(i).read());
             }
             tiers.span()
+        }
+
+        fn get_asset_type(self: @ComponentState<TContractState>, asset_id: AssetId) -> AssetType {
+            let entry = self.asset_config.entry(asset_id).as_ptr();
+            if (!SyntheticTrait::is_some_config(entry)) {
+                panic_with_felt252(NO_SUCH_ASSET)
+            }
+            SyntheticTrait::at_asset_type(entry)
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -1,6 +1,6 @@
 use openzeppelin::interfaces::erc20::IERC20Dispatcher;
 use perpetuals::core::types::asset::AssetId;
-use perpetuals::core::types::asset::synthetic::{AssetConfig, TimelyData};
+use perpetuals::core::types::asset::synthetic::{AssetConfig, AssetType, TimelyData};
 use perpetuals::core::types::funding::FundingTick;
 use perpetuals::core::types::price::SignedPrice;
 use perpetuals::core::types::risk_factor::RiskFactor;
@@ -39,6 +39,7 @@ pub trait IAssets<TContractState> {
     fn get_asset_config(self: @TContractState, asset_id: AssetId) -> AssetConfig;
     fn get_timely_data(self: @TContractState, asset_id: AssetId) -> TimelyData;
     fn get_risk_factor_tiers(self: @TContractState, asset_id: AssetId) -> Span<RiskFactor>;
+    fn get_asset_type(self: @TContractState, asset_id: AssetId) -> AssetType;
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -658,6 +658,20 @@ pub mod Positions {
             assert(amount.abs() <= position_base_balance.abs(), INVALID_BASE_CHANGE);
         }
 
+        fn _validate_spot_collateral_shrink_non_negative(
+            self: @ComponentState<TContractState>,
+            position: StoragePath<Position>,
+            asset_id: AssetId,
+            amount: i64,
+        ) {
+            let position_spot_balance: i64 = self
+                .get_synthetic_balance(:position, synthetic_id: asset_id)
+                .into();
+            assert(position_spot_balance >= 0, 'POSITION_SPOT_BALANCE_NEGATIVE');
+            assert(amount < 0, INVALID_AMOUNT_SIGN);
+            assert(amount.abs() <= position_spot_balance.abs(), INVALID_BASE_CHANGE);
+        }
+
         fn _validate_imposed_reduction_trade(
             ref self: ComponentState<TContractState>,
             position_id_a: PositionId,

--- a/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/order.cairo
@@ -173,6 +173,23 @@ pub struct Order {
     pub salt: felt252,
 }
 
+pub impl OrderIntoLimitOrderImpl of Into<Order, LimitOrder> {
+    fn into(self: Order) -> LimitOrder {
+        LimitOrder {
+            source_position: self.position_id,
+            receive_position: self.position_id,
+            base_asset_id: self.base_asset_id,
+            base_amount: self.base_amount,
+            quote_asset_id: self.quote_asset_id,
+            quote_amount: self.quote_amount,
+            fee_asset_id: self.fee_asset_id,
+            fee_amount: self.fee_amount,
+            expiration: self.expiration,
+            salt: self.salt,
+        }
+    }
+}
+
 impl OrderValidationTraitImpl of ValidateableOrderTrait<Order> {
     fn position_id(self: @Order) -> PositionId {
         *self.position_id


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Generalizes liquidation order validation to be trait-based instead of `LimitOrder`-specific.
> 
> - Refactors `_validate_liquidate` to a generic function over `ValidateableOrderTrait<T>`, replacing field access with trait getters (`position_id()`, `base_asset_id()`, amounts/fee accessors)
> - Updates `liquidate()` to pass orders directly (removes `.into()` for validation) and adjusts calls to `validate_trade` and asset lookups to use trait methods
> - Execution path (`_execute_liquidate`) and emitted events remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35adad1b7630462047b7eaa51eafcedfb2f90b6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/202)
<!-- Reviewable:end -->
