### PR TITLE
liquidate vault shares transforms position to be delevreged

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -948,11 +948,14 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr() {
         .liquidate_shares(
             vault: vault_config,
             liquidated_user: redeeming_user,
-            shares_to_burn_vault: 400,
-            value_of_shares_vault: 400,
-            actual_shares_user: 400,
-            actual_collateral_user: 400,
+            shares_to_burn_vault: 1000,
+            value_of_shares_vault: 1000,
+            actual_shares_user: 1000,
+            actual_collateral_user: 900,
         );
+
+    state.facade.validate_total_value(redeeming_user.position_id, -100);
+    state.facade.validate_total_risk(redeeming_user.position_id, 300);
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines liquidation behavior validation in protocol vault tests.
> 
> - Updates `liquidate_shares` scenario to burn `1000` shares valued at `1000`, delivering `900` collateral to the user
> - Adds post-liquidation checks asserting `TV = -100` and `TR = 300` for the liquidated position
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 146ca3de1ff08e3387caf9cb572496be4bbf18d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/204)
<!-- Reviewable:end -->
