### PR TITLE
update namespace runner name

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cairo_tests:
-    runs-on: namespace-profile-2xlarge-ubuntu-24-04-amd64
+    runs-on: namespace-profile-starkware-libs-starknet-perpetual-xlarge-hm-ubuntu-24-04-amd64
     steps:
       - uses: actions/checkout@v4
       - uses: foundry-rs/setup-snfoundry@v3
@@ -29,7 +29,7 @@ jobs:
       - name: Check formatting
         run: scarb fmt -w --check
   python_tests:
-    runs-on: namespace-profile-2xlarge-ubuntu-24-04-amd64
+    runs-on: namespace-profile-starkware-libs-starknet-perpetual-xlarge-hm-ubuntu-24-04-amd64
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI runner update**
> 
> - Switches `runs-on` in `.github/workflows/on-pull-request.yaml` to `namespace-profile-starkware-libs-starknet-perpetual-xlarge-hm-ubuntu-24-04-amd64` for both `cairo_tests` and `python_tests`, replacing the older namespace profile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dab5a787b65e293014f8c36f313bf4bb44f2ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/206)
<!-- Reviewable:end -->
