### PR TITLE
test(perpetuals): add tests for update risk factor requests

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -503,6 +503,24 @@ pub fn assert_add_synthetic_event_with_expected(
     );
 }
 
+pub fn assert_risk_factor_increase_request_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    asset_id: AssetId,
+    risk_factor_tiers: Span<u16>,
+    risk_factor_first_tier_boundary: u128,
+    risk_factor_tier_size: u128,
+) {
+    let expected_event = assets_events::RiskFactorIncreaseRequest {
+        asset_id, risk_factor_tiers, risk_factor_first_tier_boundary, risk_factor_tier_size,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("RiskFactorIncreaseRequest"),
+        expected_event_name: "RiskFactorIncreaseRequest",
+    );
+}
+
 pub fn assert_change_asset_event_with_expected(
     spied_event: @(ContractAddress, Event),
     asset_id: AssetId,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds coverage for the risk factor increase request/execute flow and validation across asset types.
> 
> - New `assert_risk_factor_increase_request_event_with_expected` in `event_test_utils.cairo`
> - Unit tests for requesting and applying RF increases on synthetic, spot, and vault assets, including event emission and config updates
> - Tests for overwrite semantics (only latest request served) and mismatch failure (`RF_REQUEST_MISMATCH`)
> - Negative tests enforcing single-tier constraint on non-synthetic assets (`INVALID_NON_SYNTHETIC_RF_TIERS`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8477016820e9a5abd7458ed1fa9c8fbf9ef9138. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/207)
<!-- Reviewable:end -->
