### PR TITLE
fix(perps): remove unused nonce

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -18,7 +18,6 @@ pub struct Deleverage {
 pub trait IDeleverageManager<TContractState> {
     fn deleverage(
         ref self: TContractState,
-        operator_nonce: u64,
         deleveraged_position_id: PositionId,
         deleverager_position_id: PositionId,
         base_asset_id: AssetId,
@@ -148,7 +147,6 @@ pub(crate) mod DeleverageManager {
         /// - Perform fundamental validation for both positions after the execution.
         fn deleverage(
             ref self: ContractState,
-            operator_nonce: u64,
             deleveraged_position_id: PositionId,
             deleverager_position_id: PositionId,
             base_asset_id: AssetId,

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -29,7 +29,6 @@ pub struct Liquidate {
 pub trait ILiquidationManager<TContractState> {
     fn liquidate(
         ref self: TContractState,
-        operator_nonce: u64,
         liquidator_signature: Signature,
         liquidated_position_id: PositionId,
         liquidator_order: Order,
@@ -191,7 +190,6 @@ pub(crate) mod LiquidationManager {
         /// - Update liquidator order fulfillment.
         fn liquidate(
             ref self: ContractState,
-            operator_nonce: u64,
             liquidator_signature: Span<felt252>,
             liquidated_position_id: PositionId,
             liquidator_order: Order,

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -104,7 +104,6 @@ pub mod Vaults {
 
         fn activate_vault(
             ref self: ComponentState<TContractState>,
-            operator_nonce: u64,
             order: ConvertPositionToVault,
             signature: Signature,
         ) {

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -8,21 +8,13 @@ use starkware_utils::signature::stark::Signature;
 #[starknet::interface]
 pub trait IVaultExternal<TContractState> {
     fn activate_vault(
-        ref self: TContractState,
-        operator_nonce: u64,
-        order: ConvertPositionToVault,
-        signature: Signature,
+        ref self: TContractState, order: ConvertPositionToVault, signature: Signature,
     );
     fn invest_in_vault(
-        ref self: TContractState,
-        operator_nonce: u64,
-        signature: Signature,
-        order: LimitOrder,
-        correlation_id: felt252,
+        ref self: TContractState, signature: Signature, order: LimitOrder, correlation_id: felt252,
     );
     fn redeem_from_vault(
         ref self: TContractState,
-        operator_nonce: u64,
         signature: Signature,
         order: LimitOrder,
         vault_approval: LimitOrder,
@@ -33,7 +25,6 @@ pub trait IVaultExternal<TContractState> {
 
     fn liquidate_vault_shares(
         ref self: TContractState,
-        operator_nonce: u64,
         liquidated_position_id: PositionId,
         vault_approval: LimitOrder,
         vault_signature: Signature,
@@ -182,19 +173,13 @@ pub(crate) mod VaultsManager {
     #[abi(embed_v0)]
     impl VaultsImpl of IVaultExternal<ContractState> {
         fn activate_vault(
-            ref self: ContractState,
-            operator_nonce: u64,
-            order: ConvertPositionToVault,
-            signature: Signature,
+            ref self: ContractState, order: ConvertPositionToVault, signature: Signature,
         ) {
-            self
-                .vaults
-                .activate_vault(operator_nonce: operator_nonce, order: order, signature: signature);
+            self.vaults.activate_vault(:order, :signature);
         }
 
         fn invest_in_vault(
             ref self: ContractState,
-            operator_nonce: u64,
             signature: Signature,
             order: LimitOrder,
             correlation_id: felt252,
@@ -346,7 +331,6 @@ pub(crate) mod VaultsManager {
         }
         fn redeem_from_vault(
             ref self: ContractState,
-            operator_nonce: u64,
             signature: Span<felt252>,
             order: LimitOrder,
             vault_approval: LimitOrder,
@@ -368,7 +352,6 @@ pub(crate) mod VaultsManager {
 
         fn liquidate_vault_shares(
             ref self: ContractState,
-            operator_nonce: u64,
             liquidated_position_id: PositionId,
             vault_approval: LimitOrder,
             vault_signature: Span<felt252>,

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -516,7 +516,6 @@ pub mod Core {
                 .external_components
                 ._get_liquidation_manager_dispatcher()
                 .liquidate(
-                    :operator_nonce,
                     :liquidator_signature,
                     :liquidated_position_id,
                     :liquidator_order,
@@ -561,7 +560,6 @@ pub mod Core {
                 .external_components
                 ._get_deleverage_manager_dispatcher()
                 .deleverage(
-                    :operator_nonce,
                     :deleveraged_position_id,
                     :deleverager_position_id,
                     :base_asset_id,
@@ -672,7 +670,6 @@ pub mod Core {
                 .external_components
                 ._get_vault_manager_dispatcher()
                 .redeem_from_vault(
-                    :operator_nonce,
                     :signature,
                     :order,
                     :vault_approval,
@@ -699,7 +696,6 @@ pub mod Core {
                 .external_components
                 ._get_vault_manager_dispatcher()
                 .liquidate_vault_shares(
-                    :operator_nonce,
                     :liquidated_position_id,
                     :vault_approval,
                     :vault_signature,
@@ -720,7 +716,7 @@ pub mod Core {
             self
                 .external_components
                 ._get_vault_manager_dispatcher()
-                .activate_vault(operator_nonce: operator_nonce, :order, :signature)
+                .activate_vault(:order, :signature)
         }
         fn invest_in_vault(
             ref self: ContractState,
@@ -735,9 +731,7 @@ pub mod Core {
             self
                 .external_components
                 ._get_vault_manager_dispatcher()
-                .invest_in_vault(
-                    operator_nonce: operator_nonce, :signature, :order, :correlation_id,
-                )
+                .invest_in_vault(:signature, :order, :correlation_id)
         }
 
         // Forced actions.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Centralizes nonce validation in `core.cairo` and removes the redundant `operator_nonce` parameter from external component interfaces and dispatches.
> 
> - Drops `operator_nonce` from `deleverage`, `liquidate`, `activate_vault`, `invest_in_vault`, `redeem_from_vault`, and `liquidate_vault_shares` in managers/contracts (`deleverage_manager.cairo`, `liquidation_manager.cairo`, `vaults.cairo`, `vaults_contract.cairo`)
> - Updates `core.cairo` to still call `operator_nonce.use_checked_nonce(...)` but no longer forwards it to external components
> - No business logic changes beyond API simplification and call-site adjustments
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 623b278cfcfe506fe2085dadc8fd2a90754eb6aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/210)
<!-- Reviewable:end -->
