### PR TITLE
feat(multi-collateral): add spot deleverage flow

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -593,8 +593,8 @@ pub mod AssetsComponent {
         }
 
 
-        fn validate_asset_active(self: @ComponentState<TContractState>, synthetic_id: AssetId) {
-            let entry = self.asset_config.entry(synthetic_id).as_ptr();
+        fn validate_asset_active(self: @ComponentState<TContractState>, asset_id: AssetId) {
+            let entry = self.asset_config.entry(asset_id).as_ptr();
             assert(SyntheticTrait::is_some_config(entry), ASSET_NOT_EXISTS);
             assert(SyntheticTrait::at_asset_status(entry) == AssetStatus::ACTIVE, INACTIVE_ASSET);
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -24,10 +24,20 @@ pub trait IDeleverageManager<TContractState> {
         deleveraged_base_amount: i64,
         deleveraged_quote_amount: i64,
     );
+    fn deleverage_spot_asset(
+        ref self: TContractState,
+        deleveraged_position_id: PositionId,
+        deleverager_position_id: PositionId,
+        asset_id: AssetId,
+        deleveraged_amount: i64,
+        deleveraged_base_collateral_amount: i64,
+    );
 }
 
 #[starknet::contract]
 pub(crate) mod DeleverageManager {
+    use core::panic_with_felt252;
+    use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
@@ -41,8 +51,9 @@ pub(crate) mod DeleverageManager {
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
     use perpetuals::core::types::position::PositionId;
-    use starknet::storage::StoragePath;
+    use starknet::storage::{StorageAsPointer, StoragePath, StoragePathEntry};
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
@@ -50,12 +61,17 @@ pub(crate) mod DeleverageManager {
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
+    use crate::core::components::assets::errors::NO_SUCH_ASSET;
     use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_DELEVERAGES;
     use crate::core::components::external_components::named_component::ITypedComponent;
+    use crate::core::components::positions::interface::IPositions;
+    use crate::core::errors::{NO_DELEVERAGE_VAULT_SHARES, position_not_deleveragable};
     use crate::core::types::position::{Position, PositionDiff};
-    use crate::core::value_risk_calculator::deleveraged_position_validations;
+    use crate::core::value_risk_calculator::{
+        calculate_position_tvtr_before, calculate_position_tvtr_change,
+        deleveraged_position_validations,
+    };
     use super::{AssetId, Deleverage, IDeleverageManager};
-
 
     #[event]
     #[derive(Drop, starknet::Event)]
@@ -161,7 +177,7 @@ pub(crate) mod DeleverageManager {
                 .get_position_snapshot(position_id: deleverager_position_id);
 
             /// Validation:
-            self.assets.validate_asset_active(synthetic_id: base_asset_id);
+            self.assets.validate_asset_active(asset_id: base_asset_id);
             self
                 .positions
                 ._validate_imposed_reduction_trade(
@@ -181,9 +197,50 @@ pub(crate) mod DeleverageManager {
                     :deleverager_position_id,
                     :deleveraged_position,
                     :deleverager_position,
-                    :base_asset_id,
-                    :deleveraged_base_amount,
-                    :deleveraged_quote_amount,
+                    asset_id: base_asset_id,
+                    deleveraged_asset_amount: deleveraged_base_amount,
+                    deleveraged_collateral_amount: deleveraged_quote_amount,
+                );
+        }
+        fn deleverage_spot_asset(
+            ref self: ContractState,
+            deleveraged_position_id: PositionId,
+            deleverager_position_id: PositionId,
+            asset_id: AssetId,
+            deleveraged_amount: i64,
+            deleveraged_base_collateral_amount: i64,
+        ) {
+            let deleveraged_position = self
+                .positions
+                .get_position_snapshot(position_id: deleveraged_position_id);
+            let deleverager_position = self
+                .positions
+                .get_position_snapshot(position_id: deleverager_position_id);
+
+            /// Validation:
+            self.assets.validate_asset_active(:asset_id);
+            self
+                .positions
+                ._validate_imposed_reduction_trade(
+                    position_id_a: deleveraged_position_id,
+                    position_id_b: deleverager_position_id,
+                    position_a: deleveraged_position,
+                    position_b: deleverager_position,
+                    base_asset_id: asset_id,
+                    base_amount_a: deleveraged_amount,
+                    quote_amount_a: deleveraged_base_collateral_amount,
+                );
+
+            /// Execution:
+            self
+                ._execute_deleverage(
+                    :deleveraged_position_id,
+                    :deleverager_position_id,
+                    :deleveraged_position,
+                    :deleverager_position,
+                    :asset_id,
+                    deleveraged_asset_amount: deleveraged_amount,
+                    deleveraged_collateral_amount: deleveraged_base_collateral_amount,
                 );
         }
     }
@@ -211,9 +268,39 @@ pub(crate) mod DeleverageManager {
                     provisional_delta: Option::Some(provisional_delta),
                 );
 
-            deleveraged_position_validations(
-                :position_id, :unchanged_assets, :position_diff_enriched,
-            );
+            let (asset_id, _) = position_diff.asset_diff.expect(NO_SUCH_ASSET);
+            let entry = self.assets.asset_config.entry(asset_id).as_ptr();
+            match SyntheticTrait::get_asset_type(entry).expect(NO_SUCH_ASSET) {
+                AssetType::SYNTHETIC => {
+                    deleveraged_position_validations(
+                        :position_id, :unchanged_assets, :position_diff_enriched,
+                    );
+                },
+                AssetType::SPOT_COLLATERAL => {
+                    if (!self.positions.is_deleveragable(:position_id)) {
+                        let tvtr_before = calculate_position_tvtr_before(
+                            :unchanged_assets, :position_diff_enriched,
+                        );
+                        let tvtr = calculate_position_tvtr_change(
+                            :tvtr_before,
+                            synthetic_enriched_position_diff: position_diff_enriched.into(),
+                        );
+                        let err = position_not_deleveragable(:position_id, :tvtr);
+                        panic_with_byte_array(err: @err);
+                    }
+                    self
+                        .positions
+                        .validate_healthy_or_healthier_position(
+                            :position_id,
+                            :position,
+                            :position_diff,
+                            tvtr_before: Default::default(),
+                        );
+                },
+                AssetType::VAULT_SHARE_COLLATERAL => {
+                    panic_with_felt252(NO_DELEVERAGE_VAULT_SHARES);
+                },
+            }
         }
 
         fn _execute_deleverage(
@@ -222,24 +309,31 @@ pub(crate) mod DeleverageManager {
             deleverager_position_id: PositionId,
             deleveraged_position: StoragePath<Position>,
             deleverager_position: StoragePath<Position>,
-            base_asset_id: AssetId,
-            deleveraged_base_amount: i64,
-            deleveraged_quote_amount: i64,
+            asset_id: AssetId,
+            deleveraged_asset_amount: i64,
+            deleveraged_collateral_amount: i64,
         ) {
             let deleveraged_position_diff = PositionDiff {
-                collateral_diff: deleveraged_quote_amount.into(),
-                asset_diff: Option::Some((base_asset_id, deleveraged_base_amount.into())),
+                collateral_diff: deleveraged_collateral_amount.into(),
+                asset_diff: Option::Some((asset_id, deleveraged_asset_amount.into())),
             };
             // Passing the negative of actual amounts to deleverager as it is linked to
             // deleveraged.
             let deleverager_position_diff = PositionDiff {
-                collateral_diff: -deleveraged_quote_amount.into(),
-                asset_diff: Option::Some((base_asset_id, -deleveraged_base_amount.into())),
+                collateral_diff: -deleveraged_collateral_amount.into(),
+                asset_diff: Option::Some((asset_id, -deleveraged_asset_amount.into())),
             };
 
             /// Validations - Fundamentals:
             // The deleveraged position should be deleveragable before
             // and healthy or healthier after and the deleverage must be fair.
+
+            // TODO: Add logic for spot asset is fair deleverage. Technical issue- we currently
+            // check is fair deleverage in value_risk_calculator which is not a contract and does
+            // not have any of the components of the perps contract (we would need the assets
+            // component at the very least to get the asset type but could be more depending on the
+            // validation logic).
+
             self
                 ._validate_deleveraged_position(
                     position_id: deleveraged_position_id,
@@ -272,10 +366,10 @@ pub(crate) mod DeleverageManager {
                     Deleverage {
                         deleveraged_position_id,
                         deleverager_position_id,
-                        base_asset_id,
-                        deleveraged_base_amount,
+                        base_asset_id: asset_id,
+                        deleveraged_base_amount: deleveraged_asset_amount,
                         quote_asset_id: self.assets.get_collateral_id(),
-                        deleveraged_quote_amount,
+                        deleveraged_quote_amount: deleveraged_collateral_amount,
                     },
                 )
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -53,6 +53,7 @@ pub mod Positions {
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::errors::{
         INVALID_AMOUNT_SIGN, INVALID_BASE_CHANGE, INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT,
+        NO_DELEVERAGE_VAULT_SHARES,
     };
     use crate::core::types::asset::synthetic::{AssetBalanceDiffEnriched, AssetType};
     use crate::core::types::balance::BalanceDiff;
@@ -722,7 +723,7 @@ pub mod Positions {
                         );
                 },
                 AssetType::VAULT_SHARE_COLLATERAL => {
-                    panic_with_felt252('NO_DELEVERAGE_VAULT_SHARES');
+                    panic_with_felt252(NO_DELEVERAGE_VAULT_SHARES);
                 },
             }
         }

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -568,6 +568,47 @@ pub mod Core {
                 )
         }
 
+        /// Executes a spot asset deleverage of a user position with a deleverager position.
+        ///
+        /// Validations:
+        /// - The contract must not be paused.
+        /// - The `operator_nonce` must be valid.
+        /// - The prices of all assets in the system are valid.
+        /// - Verifies the signs of amounts:
+        ///   - Ensures the opposite sign of amounts in spot and base collateral.
+        ///   - Ensures the sign of amounts in each position is consistent.
+        /// - Verifies that the spot asset is active.
+        /// - validates the deleveraged position is deleveragable.
+        ///
+        /// Execution:
+        /// - Update the position, based on `delevereged_spot_asset`.
+        /// - Adjust collateral balances based on `delevereged_base_collateral_amount`.
+        /// - Perform fundamental validation for both positions after the execution.
+        fn deleverage_spot_asset(
+            ref self: ContractState,
+            operator_nonce: u64,
+            deleveraged_position_id: PositionId,
+            deleverager_position_id: PositionId,
+            asset_id: AssetId,
+            deleveraged_amount: i64,
+            deleveraged_base_collateral_amount: i64,
+        ) {
+            /// Validations:
+            self.pausable.assert_not_paused();
+            self.assets.validate_price_interval_integrity(Time::now());
+            self.operator_nonce.use_checked_nonce(:operator_nonce);
+            self
+                .external_components
+                ._get_deleverage_manager_dispatcher()
+                .deleverage_spot_asset(
+                    :deleveraged_position_id,
+                    :deleverager_position_id,
+                    :asset_id,
+                    :deleveraged_amount,
+                    :deleveraged_base_collateral_amount,
+                )
+        }
+
         /// Executes a trade between position with inactive synthetic assets.
         ///
         /// Validations:

--- a/workspace/apps/perpetuals/contracts/src/core/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/errors.cairo
@@ -29,6 +29,7 @@ pub const NON_MONOTONIC_TIME: felt252 = 'NON_MONOTONIC_TIME';
 pub const STALE_TIME: felt252 = 'STALE_TIME';
 pub const INVALID_INTEREST_RATE: felt252 = 'INVALID_INTEREST_RATE';
 pub const ZERO_MAX_INTEREST_RATE: felt252 = 'ZERO_MAX_INTEREST_RATE';
+pub const NO_DELEVERAGE_VAULT_SHARES: felt252 = 'NO_DELEVERAGE_VAULT_SHARES';
 
 pub fn fulfillment_exceeded_err(position_id: PositionId) -> ByteArray {
     format!("FULFILLMENT_EXCEEDED position_id: {:?}", position_id)

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -96,6 +96,15 @@ pub trait ICore<TContractState> {
         deleveraged_base_amount: i64,
         deleveraged_quote_amount: i64,
     );
+    fn deleverage_spot_asset(
+        ref self: TContractState,
+        operator_nonce: u64,
+        deleveraged_position_id: PositionId,
+        deleverager_position_id: PositionId,
+        asset_id: AssetId,
+        deleveraged_amount: i64,
+        deleveraged_base_collateral_amount: i64,
+    );
     fn reduce_asset_position(
         ref self: TContractState,
         operator_nonce: u64,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core deleverage logic and adds a new operator action that moves collateral balances between positions; correctness depends on asset-type branching and currently documents a TODO for spot “fair deleverage” validation.
> 
> **Overview**
> Adds a new operator-only flow `deleverage_spot_asset` to transfer spot-collateral balances and base collateral between a deleveraged position and a deleverager position, wired through `core.cairo`, `interface.cairo`, and `DeleverageManager`.
> 
> Extends deleverage validation logic to branch on `AssetType` (synthetic vs spot collateral vs vault shares), introduces a shared `NO_DELEVERAGE_VAULT_SHARES` error constant, and updates asset “active” validation naming; docs (`spec.md`) are updated to describe the new spot deleverage API and note *missing* “fair deleverage” logic for spot assets (TODO).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aafeb27bb24727c5eb4979cb83d8af9438e97672. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/212)
<!-- Reviewable:end -->
