### PR TITLE
fix(perps): do not allow negative spot balance on withdraw

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -411,7 +411,7 @@ pub(crate) mod LiquidationManager {
                 AssetType::SPOT_COLLATERAL => {
                     self
                         .positions
-                        ._validate_spot_collateral_shrink_non_negative(
+                        ._validate_asset_shrink_non_negative(
                             :position, asset_id: asset_diff_id, amount: asset_diff_balance.into(),
                         );
                 },

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -660,7 +660,7 @@ pub mod Positions {
             assert(amount.abs() <= position_base_balance.abs(), INVALID_BASE_CHANGE);
         }
 
-        fn _validate_spot_collateral_shrink_non_negative(
+        fn _validate_asset_shrink_non_negative(
             self: @ComponentState<TContractState>,
             position: StoragePath<Position>,
             asset_id: AssetId,
@@ -717,7 +717,7 @@ pub mod Positions {
                     // Validate that deleveraged spot balance is not negative
                     // and will not become negative after the deleverage.
                     self
-                        ._validate_spot_collateral_shrink_non_negative(
+                        ._validate_asset_shrink_non_negative(
                             position: position_a, asset_id: base_asset_id, amount: base_amount_a,
                         );
                 },

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -122,8 +122,8 @@ pub(crate) mod WithdrawalManager {
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
     use perpetuals::core::errors::{
-        FORCED_WAIT_REQUIRED, INVALID_WITHDRAW_COLLATERAL, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED,
-        TRANSFER_FAILED,
+        AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_WITHDRAW_COLLATERAL, INVALID_ZERO_AMOUNT,
+        SIGNED_TX_EXPIRED, TRANSFER_FAILED,
     };
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::asset::synthetic::SyntheticTrait;
@@ -475,6 +475,12 @@ pub(crate) mod WithdrawalManager {
                 assert(
                     SyntheticTrait::at_asset_status(entry) == AssetStatus::ACTIVE, INACTIVE_ASSET,
                 );
+                let signed_amount: i64 = -amount.try_into().expect(AMOUNT_OVERFLOW);
+                self
+                    .positions
+                    ._validate_asset_shrink_non_negative(
+                        :position, asset_id: collateral_id, amount: signed_amount,
+                    );
                 (
                     PositionDiff {
                         collateral_diff: Zero::zero(),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/213)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core funds-flow validation (withdraw/liquidation/deleverage) and could change rejection behavior for some edge cases, but is narrowly scoped to additional balance checks and includes a regression test.
> 
> **Overview**
> Prevents withdrawing spot collateral amounts that would drive a position’s spot-asset balance below zero by adding an explicit `_validate_asset_shrink_non_negative` check in `WithdrawalManager._withdraw` (including safe `u64`→`i64` negation with `AMOUNT_OVERFLOW`).
> 
> Renames the spot-only helper to a more general `_validate_asset_shrink_non_negative` and updates callers in liquidation/deleverage flows to use it; adds a unit flow test asserting an over-withdraw of spot collateral fails with `INVALID_BASE_CHANGE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 329f0937f375b34253066c06a2bf732725098afb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->