### PR TITLE
refactor(perps): reduce reads in validate asset active

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -594,11 +594,9 @@ pub mod AssetsComponent {
 
 
         fn validate_asset_active(self: @ComponentState<TContractState>, synthetic_id: AssetId) {
-            if let Option::Some(config) = self.asset_config.read(synthetic_id) {
-                assert(config.status == AssetStatus::ACTIVE, SYNTHETIC_NOT_ACTIVE);
-            } else {
-                panic_with_felt252(ASSET_NOT_EXISTS);
-            }
+            let entry = self.asset_config.entry(synthetic_id).as_ptr();
+            assert(SyntheticTrait::is_some_config(entry), ASSET_NOT_EXISTS);
+            assert(SyntheticTrait::at_asset_status(entry) == AssetStatus::ACTIVE, INACTIVE_ASSET);
         }
 
         /// Validates assets integrity prerequisites:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/214)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Logic is unchanged but revert reasons/error selectors change, which can break callers/tests that rely on specific error codes.
> 
> **Overview**
> **Refactors `validate_asset_active` to reduce storage reads** by using an `asset_config` entry pointer and `SyntheticTrait` accessors instead of reading the full `Option<AssetConfig>`.
> 
> This also changes the revert behavior/messages: missing assets now assert `ASSET_NOT_EXISTS`, and inactive assets assert `INACTIVE_ASSET` (replacing the prior `SYNTHETIC_NOT_ACTIVE`/manual panic path).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d941f99e162ce269e5166b3af800318a2b7c0b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->