### PR TITLE
fix(perps): do not allow transfer that results in negative spot/XVS balance

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/errors.cairo
@@ -28,6 +28,8 @@ pub const LENGTH_MISMATCH: felt252 = 'LENGTH_MISMATCH';
 pub const INVALID_INTEREST_RATE: felt252 = 'INVALID_INTEREST_RATE';
 pub const ZERO_MAX_INTEREST_RATE: felt252 = 'ZERO_MAX_INTEREST_RATE';
 pub const NO_DELEVERAGE_VAULT_SHARES: felt252 = 'NO_DELEVERAGE_VAULT_SHARES';
+pub const NOT_TRANSFERABLE_ASSET: felt252 = 'NOT_TRANSFERABLE_ASSET';
+pub const VAULT_CANNOT_HOLD_SHARES: felt252 = 'VAULT_CANNOT_HOLD_SHARES';
 
 pub fn fulfillment_exceeded_err(position_id: PositionId) -> ByteArray {
     format!("FULFILLMENT_EXCEEDED position_id: {:?}", position_id)

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/transfer_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/transfer_tests.cairo
@@ -103,9 +103,7 @@ fn test_successful_transfer_of_vault_share() {
 
 
 #[test]
-#[should_panic(
-    expected: "POSITION_NOT_HEALTHY_NOR_HEALTHIER position_id: PositionId { value: 22 } TV before 24000000, TR before 240000, TV after -24000000, TR after 240000",
-)]
+#[should_panic(expected: 'INVALID_BASE_CHANGE')]
 fn test_unsuccessful_transfer_of_vault_share_not_enough_balance() {
     let cfg: PerpetualsInitConfig = Default::default();
     let mut state = setup_state_with_pending_vault_share(
@@ -175,3 +173,4 @@ fn test_unsuccessful_transfer_of_vault_share_not_enough_balance() {
             salt: transfer_args.salt,
         );
 }
+

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -4313,6 +4313,18 @@ fn test_invalid_transfer_request_amount_is_zero() {
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
         );
+
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.operator);
+    state
+        .transfer(
+            operator_nonce: state.get_operator_nonce(),
+            asset_id: cfg.collateral_cfg.collateral_id,
+            recipient: transfer_args.recipient,
+            position_id: transfer_args.position_id,
+            amount: transfer_args.amount,
+            expiration: transfer_args.expiration,
+            salt: transfer_args.salt,
+        );
 }
 
 // `validate_synthetic_price` tests.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/215)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core transfer execution/validation logic; while the change is narrow and well-covered by new tests, it can affect user flows and revert reasons for transfers across multiple asset types.
> 
> **Overview**
> Prevents transfers of non-base collateral assets (spot collateral and vault-share collateral) that would make the sender’s asset balance negative by adding an explicit `_validate_asset_shrink_non_negative` check before health validation.
> 
> Moves/centralizes asset-type and active-status validation into `_execute_transfer` (rejecting synthetics with **new** `NOT_TRANSFERABLE_ASSET`), adds a clearer error for sending vault shares to vault positions (`VAULT_CANNOT_HOLD_SHARES`), and shifts the zero-amount check to `transfer` execution.
> 
> Updates tests to cover synthetic-transfer rejection and negative spot-collateral transfer failure, and adjusts an existing vault-share test to expect `INVALID_BASE_CHANGE` instead of a health error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66c8cfb0d2949f8da6c970a50ec42134beb33137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->