### PR TITLE
feat(multi-collateral): use system time in apply interest

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -51,6 +51,7 @@ pub(crate) mod DeleverageManager {
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
     use perpetuals::core::types::position::PositionId;
     use starknet::storage::{StorageAsPointer, StoragePath, StoragePathEntry};
@@ -86,6 +87,8 @@ pub(crate) mod DeleverageManager {
         #[flat]
         AssetsEvent: AssetsComponent::Event,
         #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
+        #[flat]
         PositionsEvent: PositionsComponent::Event,
         #[flat]
         DepositEvent: DepositComponent::Event,
@@ -115,6 +118,8 @@ pub(crate) mod DeleverageManager {
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,
         #[substorage(v0)]
+        pub system_time: SystemTimeComponent::Storage,
+        #[substorage(v0)]
         pub fulfillment_tracking: FulfillmentComponent::Storage,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
@@ -127,6 +132,7 @@ pub(crate) mod DeleverageManager {
     component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
     component!(path: AssetsComponent, storage: assets, event: AssetsEvent);
     component!(path: PositionsComponent, storage: positions, event: PositionsEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
     component!(path: RolesComponent, storage: roles, event: RolesEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -68,6 +68,7 @@ pub(crate) mod LiquidationManager {
         FEE_POSITION, INSURANCE_FUND_POSITION, InternalTrait as PositionsInternal,
     };
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::synthetic::SyntheticTrait;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
     use starknet::storage::{StorageAsPointer, StoragePath, StoragePathEntry};
@@ -108,6 +109,8 @@ pub(crate) mod LiquidationManager {
         #[flat]
         PositionsEvent: PositionsComponent::Event,
         #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
+        #[flat]
         RequestApprovalsEvent: RequestApprovalsComponent::Event,
         #[flat]
         SRC5Event: SRC5Component::Event,
@@ -133,6 +136,8 @@ pub(crate) mod LiquidationManager {
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,
         #[substorage(v0)]
+        pub system_time: SystemTimeComponent::Storage,
+        #[substorage(v0)]
         pub fulfillment_tracking: FulfillmentComponent::Storage,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
@@ -145,6 +150,7 @@ pub(crate) mod LiquidationManager {
     component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
     component!(path: AssetsComponent, storage: assets, event: AssetsEvent);
     component!(path: PositionsComponent, storage: positions, event: PositionsEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
     component!(path: RolesComponent, storage: roles, event: RolesEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);
     component!(path: AccessControlComponent, storage: accesscontrol, event: AccessControlEvent);

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -52,6 +52,7 @@ pub(crate) mod VaultsManager {
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
     use perpetuals::core::types::price::PriceMulTrait;
@@ -97,6 +98,8 @@ pub(crate) mod VaultsManager {
         #[flat]
         PositionsEvent: PositionsComponent::Event,
         #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
+        #[flat]
         DepositEvent: DepositComponent::Event,
         #[flat]
         RequestApprovalsEvent: RequestApprovalsComponent::Event,
@@ -130,6 +133,8 @@ pub(crate) mod VaultsManager {
         #[substorage(v0)]
         pub positions: PositionsComponent::Storage,
         #[substorage(v0)]
+        pub system_time: SystemTimeComponent::Storage,
+        #[substorage(v0)]
         pub fulfillment_tracking: FulfillmentComponent::Storage,
         #[substorage(v0)]
         src5: SRC5Component::Storage,
@@ -146,6 +151,7 @@ pub(crate) mod VaultsManager {
     component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
     component!(path: AssetsComponent, storage: assets, event: AssetsEvent);
     component!(path: PositionsComponent, storage: positions, event: PositionsEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
     component!(path: DepositComponent, storage: deposits, event: DepositEvent);
     component!(path: RolesComponent, storage: roles, event: RolesEvent);
     component!(path: SRC5Component, storage: src5, event: SRC5Event);

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1026,7 +1026,7 @@ pub mod Core {
             self.operator_nonce.use_checked_nonce(:operator_nonce);
 
             // Read once and pass as arguments to avoid redundant storage reads
-            let current_time = Time::now();
+            let current_time = self.get_system_time();
             let max_interest_rate_per_sec = self.max_interest_rate_per_sec.read();
             let interest_rate_scale: u64 = 2_u64.pow(32);
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/infra.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/infra.cairo
@@ -210,7 +210,7 @@ pub impl FlowTestImpl of FlowTestExtendedTrait {
     }
 
     fn hourly_funding_tick(ref self: FlowTestExtended, funding_indexes: Span<(felt252, i64)>) {
-        advance_time(HOUR);
+        self.flow_test_base.facade.advance_time(HOUR);
         let mut funding_indexes_dict = Default::default();
         for (asset, index) in funding_indexes {
             funding_indexes_dict.insert(*asset, NullableTrait::new(*index));

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -116,7 +116,7 @@ fn test_deleverage_after_funding_tick() {
         .facade
         .validate_total_risk(position_id: deleveraged_user.position_id, expected_total_risk: 2);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 7 * FUNDING_SCALE };
     state
         .facade
@@ -386,7 +386,7 @@ fn test_deleverage_by_recieving_asset() {
         .facade
         .validate_total_risk(position_id: deleveraged_user.position_id, expected_total_risk: 2);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: -6 * FUNDING_SCALE };
     state
         .facade
@@ -565,7 +565,7 @@ fn test_liquidate_after_funding_tick() {
         .facade
         .validate_total_risk(position_id: liquidated_user.position_id, expected_total_risk: 3);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 4 * FUNDING_SCALE };
     state
         .facade
@@ -1244,7 +1244,7 @@ fn test_reduce_synthetic() {
     state.facade.validate_total_value(position_id: user_1.position_id, expected_total_value: 5);
     state.facade.validate_total_risk(position_id: user_1.position_id, expected_total_risk: 3);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 3 * FUNDING_SCALE };
     state
         .facade
@@ -1359,7 +1359,7 @@ fn test_status_change_healthy_liquidatable_deleveragable() {
         .validate_total_value(position_id: primary_user.position_id, expected_total_value: 5);
     state.facade.validate_total_risk(position_id: primary_user.position_id, expected_total_risk: 2);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 2 * FUNDING_SCALE };
     state
         .facade
@@ -1383,7 +1383,7 @@ fn test_status_change_healthy_liquidatable_deleveragable() {
         'user is not liquidatable',
     );
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     new_funding_index = FundingIndex { value: 4 * FUNDING_SCALE };
     state
         .facade
@@ -1485,7 +1485,7 @@ fn test_status_change_healthy_liquidatable_deleveragable() {
         'user is not deleveragable',
     );
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     new_funding_index = FundingIndex { value: FUNDING_SCALE };
     state
         .facade
@@ -1608,7 +1608,7 @@ fn test_status_change_by_deposit() {
         .validate_total_value(position_id: primary_user.position_id, expected_total_value: 5);
     state.facade.validate_total_risk(position_id: primary_user.position_id, expected_total_risk: 2);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 4 * FUNDING_SCALE };
     state
         .facade
@@ -1775,7 +1775,7 @@ fn test_status_change_by_transfer() {
         .facade
         .validate_total_value(position_id: primary_user.position_id, expected_total_value: 5);
     state.facade.validate_total_risk(position_id: primary_user.position_id, expected_total_risk: 2);
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 4 * FUNDING_SCALE };
     state
         .facade
@@ -1931,7 +1931,7 @@ fn test_status_change_by_trade() {
         .facade
         .validate_total_value(position_id: primary_user.position_id, expected_total_value: 6);
     state.facade.validate_total_risk(position_id: primary_user.position_id, expected_total_risk: 6);
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 2 * FUNDING_SCALE };
     state
         .facade
@@ -2171,7 +2171,7 @@ fn test_late_funding() {
 
     state.facade.add_active_synthetic(synthetic_info: @synthetic_info, initial_price: 100);
 
-    advance_time(100000);
+    state.facade.advance_time(100000);
     let mut new_funding_index = FundingIndex { value: FUNDING_SCALE };
     state
         .facade
@@ -2340,7 +2340,7 @@ fn test_funding_index_rounding() {
     state.facade.validate_collateral_balance(user_2.position_id, 1000_i64.into());
 
     // funding tick of half
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: FUNDING_SCALE / 2 };
     state
         .facade
@@ -2355,7 +2355,7 @@ fn test_funding_index_rounding() {
     state.facade.validate_collateral_balance(user_2.position_id, 1000_i64.into());
 
     // funding tick of minus half
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: -FUNDING_SCALE / 2 };
     state
         .facade
@@ -2448,7 +2448,7 @@ fn test_unfair_deleverage() {
         .facade
         .validate_total_risk(position_id: deleveraged_user.position_id, expected_total_risk: 2);
 
-    advance_time(10000);
+    state.facade.advance_time(10000);
     let mut new_funding_index = FundingIndex { value: 7 * FUNDING_SCALE };
     state
         .facade
@@ -3511,7 +3511,7 @@ fn test_apply_interest_to_position_with_zero_balance() {
     state.facade.apply_interests(:position_ids, :interest_amounts);
 
     // Advance time by 1 hour
-    advance_time(seconds: HOUR);
+    state.facade.advance_time(seconds: HOUR);
 
     let position_ids = array![user_1.position_id, user_2.position_id].span();
     let interest_amounts = array![100, 100].span();
@@ -3540,7 +3540,7 @@ fn test_apply_interest_to_multiple_positions() {
     state.facade.process_deposit(deposit_info: deposit_info_b);
 
     // Advance time by 1 hour
-    advance_time(seconds: HOUR);
+    state.facade.advance_time(seconds: HOUR);
 
     // Calculate valid interest amounts for both positions
     let balance_a: u128 = 10_000;
@@ -3578,7 +3578,7 @@ fn test_apply_interest_exceeds_max_rate() {
     state.facade.process_deposit(deposit_info: deposit_info);
 
     // Advance time by 1 hour
-    advance_time(seconds: HOUR);
+    state.facade.advance_time(seconds: HOUR);
 
     // Calculate max allowed interest
     let balance: u128 = 10_000;
@@ -3620,7 +3620,7 @@ fn test_apply_negative_interest() {
     state.facade.process_deposit(deposit_info: deposit_info);
 
     // Advance time by 1 hour
-    advance_time(seconds: HOUR);
+    state.facade.advance_time(seconds: HOUR);
 
     // Calculate valid interest amount (negative)
     let balance: u128 = 10_000;
@@ -3652,7 +3652,7 @@ fn test_apply_interest_sequential_updates() {
     state.facade.process_deposit(deposit_info: deposit_info);
 
     // Advance time by 1 hour
-    advance_time(seconds: HOUR);
+    state.facade.advance_time(seconds: HOUR);
 
     // Calculate and apply first interest
     let balance: u128 = 10_000;
@@ -3669,7 +3669,7 @@ fn test_apply_interest_sequential_updates() {
     state.facade.validate_collateral_balance(user.position_id, balance_after_first.into());
 
     // Advance time by another hour
-    advance_time(seconds: HOUR);
+    state.facade.advance_time(seconds: HOUR);
 
     // Calculate and apply second interest (based on new balance)
     let new_balance: u128 = balance_after_first.try_into().unwrap();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the timestamp source used for interest/position bookkeeping, so mis-synchronization between block time and stored system time could affect interest validation and state transitions; updates are operator-gated and monotonic but touch core financial logic.
> 
> **Overview**
> Interest accrual and position initialization now use the contract’s `SystemTimeComponent` instead of reading `Time::now()` directly (notably `Core.apply_interests` and `Positions.new_position`).
> 
> To support this, external manager contracts (`deleverage_manager`, `liquidation_manager`, `vaults_contract`) embed `SystemTimeComponent` storage/events, and flow tests add a facade `advance_time` helper that advances the cheat block timestamp *and* calls `update_system_time`, replacing the prior standalone `advance_time` utility and initializing system time at deploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f73ebc0d26066af3d17a683ad948b8b5d06fb0bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/216)
<!-- Reviewable:end -->
