### PR TITLE
fix(perpetuals): block deposit of inactive asset

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -57,13 +57,14 @@ pub(crate) mod DepositManager {
     use openzeppelin::interfaces::erc20::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
+    use perpetuals::core::components::assets::errors::INACTIVE_ASSET;
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::Deposit as DepositComponent;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
-    use perpetuals::core::types::asset::AssetId;
+    use perpetuals::core::types::asset::{AssetId, AssetStatus};
     use perpetuals::core::types::position::PositionId;
     use starknet::storage::{StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess};
     use starknet::{ContractAddress, get_contract_address};
@@ -240,6 +241,7 @@ pub(crate) mod DepositManager {
             } else {
                 let asset_config = self.assets.get_asset_config(asset_id);
                 assert(asset_config.asset_type != AssetType::SYNTHETIC, 'NOT_SPOT_ASSET');
+                assert(asset_config.status == AssetStatus::ACTIVE, INACTIVE_ASSET);
                 let token_contract = IERC20Dispatcher {
                     contract_address: asset_config.token_contract.expect('NO_ERC20_CONFIGURED'),
                 };
@@ -326,6 +328,7 @@ pub(crate) mod DepositManager {
                     );
                 }
                 assert(asset_config.asset_type != AssetType::SYNTHETIC, 'NOT_SPOT_ASSET');
+                assert(asset_config.status == AssetStatus::ACTIVE, INACTIVE_ASSET);
                 let token_contract = IERC20Dispatcher {
                     contract_address: asset_config.token_contract.expect('NO_ERC20_CONFIGURED'),
                 };

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -711,7 +711,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     }
 
     fn register_vault_share_spot_asset(
-        ref self: PerpsTestsFacade, position_vault: User,
+        ref self: PerpsTestsFacade, position_vault: User, initial_price: u128,
     ) -> VaultState {
         self.operator.set_as_caller(self.perpetuals_contract);
 
@@ -775,6 +775,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                     asset_info.asset_name,
                 );
         }
+        // Activate the vault share asset.
+        self.price_tick(asset_info: @asset_info, price: initial_price);
 
         let operator_nonce = self.get_nonce();
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
@@ -70,7 +70,9 @@ fn test_deposit_into_protocol_vault_recieve_to_same_position() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state
         .facade
@@ -181,7 +183,9 @@ fn test_deposit_into_protocol_vault_recieve_to_different_position() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state
         .facade
@@ -232,7 +236,9 @@ fn test_deposit_cannot_be_called_except_by_perps_contract() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     let dispatcher: IERC4626Dispatcher = vault_config.deployed_vault.erc4626;
     dispatcher.deposit(assets: 1000, receiver: receiving_user.account.address);

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -19,7 +19,9 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -143,7 +145,9 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position_with_9pct_premium() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -270,7 +274,9 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position_is_rejected_with_11pc
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -316,7 +322,9 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -385,7 +393,9 @@ fn test_redeem_from_protocol_vault_unfair__user_redeem() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -435,7 +445,9 @@ fn test_redeem_from_protocol_vault_unfair__vault_redeem() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -486,7 +498,9 @@ fn test_redeem_from_protocol_vault_over_fulfilled_user() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -538,7 +552,9 @@ fn test_redeem_from_protocol_vault_over_fulfilled_vault() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -590,7 +606,9 @@ fn test_redeem_from_protocol_vault_allows_redeem_when_improving_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -718,7 +736,9 @@ fn test_redeem_from_protocol_vault_fails_redeem_when_worsening_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -844,7 +864,9 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -965,7 +987,9 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr_starting_with_negat
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -1089,7 +1113,9 @@ fn test_liquidate_vault_shares_fails_when_not_improving_tv_tr_starting_with_nega
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -1214,7 +1240,9 @@ fn test_liquidate_vault_shares_fails_when_worsening_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -1335,7 +1363,9 @@ fn test_withdraw_cannot_be_called_except_by_perps_contract() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     let dispatcher: IERC4626Dispatcher = vault_config.deployed_vault.erc4626;
     dispatcher
@@ -1356,7 +1386,9 @@ fn test_redeem_cannot_be_called_except_by_perps_contract() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     let dispatcher: IERC4626Dispatcher = vault_config.deployed_vault.erc4626;
     dispatcher
@@ -1378,7 +1410,9 @@ fn test_redeem_vault_shares_negative() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 400_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state.facade.price_tick(@vault_config.asset_info, 1);
     state.facade.process_deposit(state.facade.deposit(user.account, user.position_id, 10000_u64));

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -3277,7 +3277,9 @@ fn test_liquidate_spot_for_vault_share_asset() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     // Create users.

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_deposit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_deposit_flow_tests.cairo
@@ -16,7 +16,9 @@ fn test_protocol_vault_deposit_vault_shares() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
     let init_shares = vault_config
         .deployed_vault
         .erc20
@@ -55,7 +57,9 @@ fn test_protocol_vault_cancel_deposit_vault_shares() {
     let receiving_user = state.new_user_with_position();
     let deposit_info = state.facade.deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(deposit_info);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     let deposit_info = state
         .facade

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_tv_tr_impact_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_tv_tr_impact_tests.cairo
@@ -12,7 +12,9 @@ fn test_shares_should_contribute_zero_until_activated() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state
         .facade
@@ -53,7 +55,9 @@ fn position_should_be_usable_with_inactive_vault_shares() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state
         .facade
@@ -105,7 +109,9 @@ fn test_shares_should_contribute_to_tv_tr_after_activation() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state
+        .facade
+        .register_vault_share_spot_asset(vault_user, initial_price: 1000);
 
     state
         .facade

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -5676,6 +5676,54 @@ fn test_unsuccessful_vault_token_deposit_synthetic_asset() {
             salt: user.salt_counter,
         );
 }
+
+#[test]
+#[should_panic(expected: 'INACTIVE_ASSET')]
+fn test_unsuccessful_deposit_inactive_spot_asset() {
+    // Setup:
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
+    let user = Default::default();
+
+    let spot_asset_id = SYNTHETIC_ASSET_ID_2();
+    let risk_factor_first_tier_boundary = MAX_U128;
+    let risk_factor_tier_size = 1;
+    let risk_factor_tiers = array![10].span();
+    let quorum = 1_u8;
+    let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
+    let quantum = 12_u64;
+    let erc20_contract_address = token_state.address;
+
+    // Add spot asset:
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
+    state
+        .add_spot_asset(
+            asset_id: spot_asset_id,
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            :risk_factor_tiers,
+            :risk_factor_first_tier_boundary,
+            :risk_factor_tier_size,
+            :quorum,
+        );
+
+    // Initialize position:
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
+    init_position(cfg: @cfg, ref :state, :user);
+
+    // Test: Try to deposit inactive spot asset (should fail):
+    cheat_caller_address_once(contract_address: test_address(), caller_address: user.address);
+    state
+        .deposit_asset(
+            asset_id: spot_asset_id,
+            position_id: user.position_id,
+            quantized_amount: DEPOSIT_AMOUNT,
+            salt: user.salt_counter,
+        );
+}
+
 #[test]
 fn test_successful_vault_token_cancel_deposit() {
     // Setup state, token and user:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core deposit validation logic and can block previously-accepted deposit flows if asset activation is misconfigured; test updates reduce regression risk but runtime behavior changes for spot/vault-share deposits.
> 
> **Overview**
> Prevents depositing spot assets (including vault-share collateral assets) unless their `AssetStatus` is `ACTIVE`, enforcing this check in both `deposit` and `process_deposit` flows in `DepositManager` (reverting with `INACTIVE_ASSET`).
> 
> Updates vault-share flow tests to explicitly *activate* the vault-share asset (via an initial price tick) before using it, and adds a new unit test asserting deposits of an inactive spot asset revert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0a73623f88b536ff419082c6d9140714b178248. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/218)
<!-- Reviewable:end -->
