### PR TITLE
refactor(multi-collateral): add validate interest

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1031,7 +1031,7 @@ pub mod Core {
                 let interest_amount = *interest_amounts[i];
                 self
                     .positions
-                    .apply_interest_to_position(
+                    .apply_interest(
                         position_id: *position_id,
                         :interest_amount,
                         :current_time,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches collateral/interest accounting and changes timestamp update semantics, which can affect subsequent interest bounds and accrual timing even though core math is unchanged.
> 
> **Overview**
> Refactors position interest application by renaming `apply_interest_to_position` to `apply_interest` and extracting the interest-rate bounds checks into a new `validate_interest` helper.
> 
> Behavior is adjusted for edge cases: first-time interest application (zero `last_interest_applied_time`) now explicitly requires `interest_amount == 0` and initializes the timestamp, and zero-interest updates no longer advance `last_interest_applied_time` (timestamp only advances on non-zero interest).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6534d0afb7b42712f5006db7be8616ef9970a757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/220)
<!-- Reviewable:end -->
