### PR TITLE
fix(perps): allow transfet of inactive asset

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -62,7 +62,7 @@ pub(crate) mod TransferManager {
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
-    use perpetuals::core::components::assets::errors::{INACTIVE_ASSET, NO_SUCH_ASSET};
+    use perpetuals::core::components::assets::errors::NO_SUCH_ASSET;
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
@@ -90,7 +90,6 @@ pub(crate) mod TransferManager {
         AMOUNT_OVERFLOW, INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT, NOT_TRANSFERABLE_ASSET,
         SIGNED_TX_EXPIRED, VAULT_CANNOT_HOLD_SHARES,
     };
-    use crate::core::types::asset::AssetStatus;
     use crate::core::types::position::PositionDiff;
     use crate::core::types::transfer::TransferArgs;
     use super::{ITransferManager, Signature, Timestamp, Transfer, TransferRequest};
@@ -305,10 +304,6 @@ pub(crate) mod TransferManager {
             } else {
                 let entry = (@self).assets.asset_config.entry(collateral_id).as_ptr();
                 let asset_type = SyntheticTrait::get_asset_type(entry).expect(NO_SUCH_ASSET);
-
-                assert(
-                    SyntheticTrait::at_asset_status(entry) == AssetStatus::ACTIVE, INACTIVE_ASSET,
-                );
 
                 assert(
                     asset_type == AssetType::SPOT_COLLATERAL


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/222)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain transfer validation semantics; while scoped to transferability checks, it could enable movements of assets previously blocked by status and should be reviewed for downstream accounting/health assumptions.
> 
> **Overview**
> Relaxes `TransferManager` collateral transfers by removing the check that the transferred asset must be *active*, allowing transfers of inactive `SPOT_COLLATERAL`/`VAULT_SHARE_COLLATERAL` as long as the asset exists and is of a transferable type.
> 
> Cleans up related imports by dropping `INACTIVE_ASSET` and `AssetStatus` usage in `transfer_manager.cairo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f05a2d9eccdb69dc8250b7779ca0be3373db152c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->