### PR TITLE
Make forced withdraw actions disabled by default.

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -19,9 +19,9 @@ pub mod Core {
     };
     use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::errors::{
-        AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_ZERO_TIMEOUT, LENGTH_MISMATCH,
-        ORDER_IS_NOT_EXPIRED, TRADE_ASSET_NOT_SYNTHETIC, TRANSFER_FAILED, ZERO_MAX_INTEREST_RATE,
-        ESCAPE_HATCH_DISABLED
+        AMOUNT_OVERFLOW, ESCAPE_HATCH_DISABLED, FORCED_WAIT_REQUIRED, INVALID_ZERO_TIMEOUT,
+        LENGTH_MISMATCH, ORDER_IS_NOT_EXPIRED, TRADE_ASSET_NOT_SYNTHETIC, TRANSFER_FAILED,
+        ZERO_MAX_INTEREST_RATE,
     };
     use perpetuals::core::events;
     use perpetuals::core::interface::{ICore, Settlement};

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1245,7 +1245,7 @@ pub mod Core {
         }
 
         fn enable_escape_hatch(ref self: ContractState) { 
-            assert(self.roles.is_governance_admin(get_caller_address()), 'NOT-GOVERNANCE-ADMIN');
+            self.roles.only_app_governor();
             self.forced_actions_enabled.write(true);
         }
     }

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -173,9 +173,9 @@ pub mod Core {
         // Example: max_interest_rate_per_sec = 10 means the rate is 10 / 2^32 ≈ 0.000000232 per
         // second, which is approximately 7.4% per year.
         max_interest_rate_per_sec: u32,
-        // Whether the new escape hatch logic is enabled. 
+        // Whether the new escape hatch logic is enabled.
         // Off by default to be enabled one time in the future
-        forced_actions_enabled: bool
+        forced_actions_enabled: bool,
     }
 
     #[event]
@@ -1244,7 +1244,7 @@ pub mod Core {
                 );
         }
 
-        fn enable_escape_hatch(ref self: ContractState) { 
+        fn enable_escape_hatch(ref self: ContractState) {
             self.roles.only_app_governor();
             self.forced_actions_enabled.write(true);
         }

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -21,6 +21,7 @@ pub mod Core {
     use perpetuals::core::errors::{
         AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_ZERO_TIMEOUT, LENGTH_MISMATCH,
         ORDER_IS_NOT_EXPIRED, TRADE_ASSET_NOT_SYNTHETIC, TRANSFER_FAILED, ZERO_MAX_INTEREST_RATE,
+        ESCAPE_HATCH_DISABLED
     };
     use perpetuals::core::events;
     use perpetuals::core::interface::{ICore, Settlement};
@@ -810,7 +811,7 @@ pub mod Core {
             expiration: Timestamp,
             salt: felt252,
         ) {
-            assert(self._is_escape_hatch_enabled(), 'ESCAPE-HATCH-DISABLED');
+            assert(self._is_escape_hatch_enabled(), ESCAPE_HATCH_DISABLED);
             assert(!self._is_vault(vault_position: position_id), 'VAULT_CANNOT_INITIATE_WITHDRAW');
             self
                 .external_components
@@ -874,7 +875,7 @@ pub mod Core {
             order_a: Order,
             order_b: Order,
         ) {
-            assert(self._is_escape_hatch_enabled(), 'ESCAPE-HATCH-DISABLED');
+            assert(self._is_escape_hatch_enabled(), ESCAPE_HATCH_DISABLED);
             let position_a = self.positions.get_position_snapshot(position_id: order_a.position_id);
             let position_b = self.positions.get_position_snapshot(position_id: order_b.position_id);
 
@@ -1036,6 +1037,8 @@ pub mod Core {
             order: LimitOrder,
             vault_approval: LimitOrder,
         ) {
+            assert(self._is_escape_hatch_enabled(), ESCAPE_HATCH_DISABLED);
+
             let redeeming_position = self
                 .positions
                 .get_position_snapshot(position_id: order.source_position);

--- a/workspace/apps/perpetuals/contracts/src/core/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/errors.cairo
@@ -29,6 +29,7 @@ pub const ZERO_MAX_INTEREST_RATE: felt252 = 'ZERO_MAX_INTEREST_RATE';
 pub const NO_DELEVERAGE_VAULT_SHARES: felt252 = 'NO_DELEVERAGE_VAULT_SHARES';
 pub const NOT_TRANSFERABLE_ASSET: felt252 = 'NOT_TRANSFERABLE_ASSET';
 pub const VAULT_CANNOT_HOLD_SHARES: felt252 = 'VAULT_CANNOT_HOLD_SHARES';
+pub const ESCAPE_HATCH_DISABLED: felt252 = 'ESCAPE_HATCH_DISABLED';
 
 pub fn fulfillment_exceeded_err(position_id: PositionId) -> ByteArray {
     format!("FULFILLMENT_EXCEEDED position_id: {:?}", position_id)

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -205,4 +205,6 @@ pub trait ICore<TContractState> {
         actual_liquidator_fee: u64,
         liquidated_fee_amount: u64,
     );
+
+    fn enable_escape_hatch(ref self: TContractState);
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -330,3 +330,11 @@ fn test_activate_new_component_only_upgrade_governor() {
             component_type: 'TRANSFERS', component_address: 'SOME_HASH'.try_into().unwrap(),
         );
 }
+
+#[test]
+#[should_panic(expected: "ONLY_APP_GOVERNOR")]
+fn test_escape_hatch_only_app_governor() {
+    let (_, contract_address) = setup();
+    let dispatcher = ICoreDispatcher { contract_address };
+    dispatcher.enable_escape_hatch();
+}

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -2413,6 +2413,11 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         self.operator.set_as_caller(self.perpetuals_contract);
         dispatcher.update_system_time(:operator_nonce, :new_timestamp);
     }
+
+    fn enable_escape_hatch(ref self: PerpsTestsFacade) {
+        self.set_app_governor_as_caller();
+        ICoreDispatcher { contract_address: self.perpetuals_contract }.enable_escape_hatch();
+    }
 }
 
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -1448,6 +1448,7 @@ fn test_redeem_vault_shares_negative() {
 #[test]
 fn test_forced_redeem_from_vault_request() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.enable_escape_hatch();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
@@ -1571,6 +1572,7 @@ fn test_forced_redeem_from_vault_request() {
 #[test]
 fn test_forced_redeem_from_vault_after_timelock() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.enable_escape_hatch();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
@@ -1708,6 +1710,7 @@ fn test_forced_redeem_from_vault_after_timelock() {
 #[test]
 fn test_forced_redeem_from_vault_by_operator_before_timelock() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.enable_escape_hatch();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
@@ -1800,6 +1803,7 @@ fn test_forced_redeem_from_vault_by_operator_before_timelock() {
 #[should_panic(expected: 'FORCED_WAIT_REQUIRED')]
 fn test_forced_redeem_from_vault_user_before_timelock_fails() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.enable_escape_hatch();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
@@ -1866,6 +1870,7 @@ fn test_forced_redeem_from_vault_user_before_timelock_fails() {
 #[should_panic(expected: 'REQUEST_ALREADY_PROCESSED')]
 fn test_forced_redeem_from_vault_user_after_operator_already_redeemed_fails() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.enable_escape_hatch();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state
@@ -1938,6 +1943,7 @@ fn test_forced_redeem_from_vault_user_after_operator_already_redeemed_fails() {
 #[should_panic(expected: 'REQUEST_ALREADY_PROCESSED')]
 fn test_forced_redeem_from_vault_operator_after_user_already_redeemed_fails() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.enable_escape_hatch();
     let vault_user = state.new_user_with_position();
     let redeeming_user = state.new_user_with_position();
     let vault_init_deposit = state

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -2930,7 +2930,7 @@ fn test_successful_forced_withdraw_request() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     dispatcher.enable_escape_hatch();
 
     // Create a position.
@@ -3027,7 +3027,7 @@ fn test_successful_forced_withdraw_operator_executes() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     dispatcher.enable_escape_hatch();
 
     // Create a position.
@@ -3180,7 +3180,7 @@ fn test_successful_forced_withdraw_user_executes() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     dispatcher.enable_escape_hatch();
 
     // Create a position.
@@ -3348,7 +3348,7 @@ fn test_forced_withdraw_before_timeout() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     dispatcher.enable_escape_hatch();
 
     // Create a position.
@@ -3451,7 +3451,7 @@ fn test_forced_withdraw_after_operator_processed_withdraw() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     dispatcher.enable_escape_hatch();
 
     // Create a position.
@@ -3575,7 +3575,7 @@ fn test_withdraw_after_user_forced_withdraw_executed() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     dispatcher.enable_escape_hatch();
 
     // Create a position.
@@ -3704,7 +3704,7 @@ fn test_forced_withdraw_request_zero_amount() {
     init_position(cfg: @cfg, ref :state, :user);
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     // Setup parameters:
@@ -5979,7 +5979,7 @@ fn test_successful_forced_trade_request() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();
@@ -6072,7 +6072,7 @@ fn test_successful_forced_trade_after_timelock() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();
@@ -6213,7 +6213,7 @@ fn test_forced_trade_user_after_operator_executed() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();
@@ -6294,7 +6294,7 @@ fn test_successful_forced_trade_by_operator_before_timelock() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();
@@ -6368,7 +6368,7 @@ fn test_forced_trade_operator_after_user_executed() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();
@@ -6450,7 +6450,7 @@ fn test_forced_trade_before_timelock_non_operator() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();
@@ -6518,7 +6518,7 @@ fn test_forced_trade_request_insufficient_premium() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
-    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
     state.enable_escape_hatch();
 
     let user_a = Default::default();

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -2930,6 +2930,9 @@ fn test_successful_forced_withdraw_request() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
+    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    dispatcher.enable_escape_hatch();
+
     // Create a position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     position_dispatcher
@@ -3023,6 +3026,9 @@ fn test_successful_forced_withdraw_operator_executes() {
 
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
+
+    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    dispatcher.enable_escape_hatch();
 
     // Create a position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
@@ -3173,6 +3179,9 @@ fn test_successful_forced_withdraw_user_executes() {
 
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
+
+    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    dispatcher.enable_escape_hatch();
 
     // Create a position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
@@ -3339,6 +3348,9 @@ fn test_forced_withdraw_before_timeout() {
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
 
+    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    dispatcher.enable_escape_hatch();
+
     // Create a position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
     position_dispatcher
@@ -3438,6 +3450,9 @@ fn test_forced_withdraw_after_operator_processed_withdraw() {
 
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
+
+    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    dispatcher.enable_escape_hatch();
 
     // Create a position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
@@ -3559,6 +3574,9 @@ fn test_withdraw_after_user_forced_withdraw_executed() {
 
     let user: User = Default::default();
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
+
+    cheat_caller_address_once(:contract_address, caller_address: cfg.governance_admin);
+    dispatcher.enable_escape_hatch();
 
     // Create a position.
     cheat_caller_address_once(:contract_address, caller_address: cfg.operator);
@@ -3685,6 +3703,9 @@ fn test_forced_withdraw_request_zero_amount() {
     let user = Default::default();
     init_position(cfg: @cfg, ref :state, :user);
     let recipient = UserTrait::new(position_id: POSITION_ID_200, key_pair: KEY_PAIR_2());
+
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
 
     // Setup parameters:
     let expiration = Time::now().add(delta: Time::days(1));
@@ -5958,6 +5979,9 @@ fn test_successful_forced_trade_request() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
+
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);
 
@@ -6047,6 +6071,9 @@ fn test_successful_forced_trade_after_timelock() {
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
 
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);
@@ -6186,6 +6213,9 @@ fn test_forced_trade_user_after_operator_executed() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
+
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);
     add_synthetic_to_position(
@@ -6264,6 +6294,9 @@ fn test_successful_forced_trade_by_operator_before_timelock() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
+
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);
     add_synthetic_to_position(
@@ -6334,6 +6367,9 @@ fn test_forced_trade_operator_after_user_executed() {
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
 
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);
@@ -6414,6 +6450,9 @@ fn test_forced_trade_before_timelock_non_operator() {
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
+
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);
 
@@ -6478,6 +6517,9 @@ fn test_forced_trade_request_insufficient_premium() {
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
+
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.governance_admin);
+    state.enable_escape_hatch();
 
     let user_a = Default::default();
     init_position(cfg: @cfg, ref :state, user: user_a);


### PR DESCRIPTION
This PR disabled the forced actions from being callable until they are enabled by calling enable_force_hatch by the governance admin (?) 

Enabling should be a one time procedure. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the availability of critical forced-action paths by introducing a new governance-controlled gate; misconfiguration or improper enabling could block emergency user exits or unexpectedly re-enable them.
> 
> **Overview**
> Forced-action *request* entrypoints (e.g. `forced_withdraw_request`, `forced_trade_request`, `forced_redeem_from_vault_request`) are now **disabled by default** and will revert with new `ESCAPE_HATCH_DISABLED` unless an on-chain `forced_actions_enabled` flag is set.
> 
> Adds a governor-only `enable_escape_hatch` method to flip this flag, exposes it on the `ICore` interface, and updates flow/unit tests to enable the escape hatch before exercising forced-action behavior plus a new negative test ensuring only the app governor can enable it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a48b831b0aa424ddabcc9da13defc7e64415fc7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/225)
<!-- Reviewable:end -->
