### PR TITLE
test(perps): add unit tests for withdraw

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/constants.cairo
@@ -72,6 +72,7 @@ pub const COLLATERAL_RESOLUTION_FACTOR: u64 = 1_000_000_000;
 pub const SYNTHETIC_QUORUM: u8 = 1;
 pub const SYNTHETIC_RESOLUTION_FACTOR: u64 = 1_000_000_000;
 pub const VAULT_DECIMALS: u8 = 6;
+pub const SPOT_DECIMALS: u8 = 6;
 pub const INITIAL_SUPPLY: u256 = 10_000_000_000_000_000;
 pub const WITHDRAW_AMOUNT: u64 = 1000;
 pub const DEPOSIT_AMOUNT: u64 = 10;
@@ -113,6 +114,9 @@ pub fn SYNTHETIC_ASSET_ID_3() -> AssetId {
 pub fn VAULT_SHARE_COLLATERAL_1_ID() -> AssetId {
     AssetIdTrait::new(value: selector!("VS_1"))
 }
+pub fn SPOT_COLLATERAL_ASSET_ID() -> AssetId {
+    AssetIdTrait::new(value: selector!("SPOT"))
+}
 pub fn VAULT_SHARE_COLLATERAL_1_NAME() -> ByteArray {
     "VS_1"
 }
@@ -127,6 +131,12 @@ pub fn VAULT_SHARE_COLLATERAL_2_NAME() -> ByteArray {
 }
 pub fn VAULT_SHARE_COLLATERAL_2_SYMBOL() -> ByteArray {
     "VS2"
+}
+pub fn SPOT_COLLATERAL_NAME() -> ByteArray {
+    "SPOT"
+}
+pub fn SPOT_COLLATERAL_SYMBOL() -> ByteArray {
+    "SPT"
 }
 
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/226)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that expand coverage and adjust test scaffolding; no production contract logic is modified.
> 
> **Overview**
> Adds spot-asset coverage to the Cairo test harness by introducing `SPOT_*` constants/metadata, extending `PerpetualsInitConfig` with a `spot_cfg`, and adding helpers for initializing positions with arbitrary spot-asset balances (plus renaming synthetic setup helpers for clarity).
> 
> Expands `unit_tests.cairo` with new withdraw-focused negative tests that assert failures when withdrawing a synthetic asset, withdrawing an inactive or non-existent spot asset, or withdrawing in a way that would make a position unhealthy; also updates existing tests to use the renamed synthetic setup helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 149122238fe917bb369bf3b9e850f76703a937f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->