### PR TITLE
test(perpetuals): add failed deposit scenarios

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -2218,6 +2218,48 @@ fn test_deposit_already_registered() {
 }
 
 #[test]
+#[should_panic(expected: 'ASSET_NOT_EXISTS')]
+fn test_deposit_non_existent_asset() {
+    // Setup:
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
+    let user = Default::default();
+    init_position(cfg: @cfg, ref :state, :user);
+
+    // Test:
+    cheat_caller_address_once(contract_address: test_address(), caller_address: user.address);
+    state
+        .deposit_asset(
+            asset_id: SYNTHETIC_ASSET_ID_2(), // Non-existent asset.
+            position_id: user.position_id,
+            quantized_amount: DEPOSIT_AMOUNT,
+            salt: user.salt_counter,
+        );
+}
+
+#[test]
+#[should_panic(expected: 'NOT_SPOT_ASSET')]
+fn test_deposit_synthetic_asset() {
+    // Setup:
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = setup_state_with_active_asset(cfg: @cfg, token_state: @token_state);
+    let user = Default::default();
+    init_position(cfg: @cfg, ref :state, :user);
+
+    // Test:
+    cheat_caller_address_once(contract_address: test_address(), caller_address: user.address);
+    state
+        .deposit_asset(
+            asset_id: cfg.synthetic_cfg.synthetic_id,
+            position_id: user.position_id,
+            quantized_amount: DEPOSIT_AMOUNT,
+            salt: user.salt_counter,
+        );
+}
+
+#[test]
 fn test_successful_process_deposit() {
     // Setup state, token and user:
     let cfg: PerpetualsInitConfig = Default::default();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes adding negative coverage for `deposit_asset`; no production logic is modified, so risk is limited to potential test brittleness if error strings change.
> 
> **Overview**
> Adds two unit tests around `deposit_asset` failure cases in `unit_tests.cairo`.
> 
> The new coverage asserts expected panics when attempting to deposit to a **non-existent asset** (`ASSET_NOT_EXISTS`) and when attempting to deposit using a **synthetic (non-spot) asset** (`NOT_SPOT_ASSET`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a27d0b13768665a826e0062bacba9dcc52ffd427. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/227)
<!-- Reviewable:end -->
