### PR TITLE
test(perpetuals): add failed deposit to vault position

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -711,7 +711,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     }
 
     fn register_vault_share_spot_asset(
-        ref self: PerpsTestsFacade, position_vault: User,
+        ref self: PerpsTestsFacade, position_vault: User, asset_name: felt252,
     ) -> VaultState {
         self.operator.set_as_caller(self.perpetuals_contract);
 
@@ -726,7 +726,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         let risk_factor_1 = array![100].span();
 
         let asset_info = AssetInfoTrait::new_with_resolution(
-            asset_name: 'VS_1',
+            :asset_name,
             risk_factor_data: RiskFactorTiers {
                 tiers: risk_factor_1,
                 first_tier_boundary: risk_factor_first_tier_boundary,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
@@ -70,7 +70,7 @@ fn test_deposit_into_protocol_vault_recieve_to_same_position() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state
         .facade
@@ -181,7 +181,7 @@ fn test_deposit_into_protocol_vault_recieve_to_different_position() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state
         .facade
@@ -232,7 +232,7 @@ fn test_deposit_cannot_be_called_except_by_perps_contract() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     let dispatcher: IERC4626Dispatcher = vault_config.deployed_vault.erc4626;
     dispatcher.deposit(assets: 1000, receiver: receiving_user.account.address);

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -27,7 +27,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -151,7 +151,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position_with_9pct_premium() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -278,7 +278,7 @@ fn test_redeem_from_protocol_vault_redeem_to_same_position_is_rejected_with_11pc
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -324,7 +324,7 @@ fn test_redeem_from_protocol_vault_impacts_price_as_expected() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -393,7 +393,7 @@ fn test_redeem_from_protocol_vault_unfair__user_redeem() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -443,7 +443,7 @@ fn test_redeem_from_protocol_vault_unfair__vault_redeem() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -494,7 +494,7 @@ fn test_redeem_from_protocol_vault_over_fulfilled_user() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -546,7 +546,7 @@ fn test_redeem_from_protocol_vault_over_fulfilled_vault() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -598,7 +598,7 @@ fn test_redeem_from_protocol_vault_allows_redeem_when_improving_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -741,7 +741,7 @@ fn test_redeem_from_protocol_vault_fails_redeem_when_worsening_tv_tr_of_unhealth
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -867,7 +867,7 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -988,7 +988,7 @@ fn test_liquidate_vault_shares_succeeds_when_improving_tv_tr_starting_with_negat
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -1112,7 +1112,7 @@ fn test_liquidate_vault_shares_fails_when_not_improving_tv_tr_starting_with_nega
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -1237,7 +1237,7 @@ fn test_liquidate_vault_shares_fails_when_worsening_tv_tr() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
 
@@ -1358,7 +1358,7 @@ fn test_withdraw_cannot_be_called_except_by_perps_contract() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     let dispatcher: IERC4626Dispatcher = vault_config.deployed_vault.erc4626;
     dispatcher
@@ -1379,7 +1379,7 @@ fn test_redeem_cannot_be_called_except_by_perps_contract() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     let dispatcher: IERC4626Dispatcher = vault_config.deployed_vault.erc4626;
     dispatcher
@@ -1401,7 +1401,7 @@ fn test_redeem_vault_shares_negative() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 400_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state.facade.price_tick(@vault_config.asset_info, 1);
     state.facade.process_deposit(state.facade.deposit(user.account, user.position_id, 10000_u64));
@@ -1454,7 +1454,7 @@ fn test_forced_redeem_from_vault_request() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -1577,7 +1577,7 @@ fn test_forced_redeem_from_vault_after_timelock() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -1714,7 +1714,7 @@ fn test_forced_redeem_from_vault_by_operator_before_timelock() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -1806,7 +1806,7 @@ fn test_forced_redeem_from_vault_user_before_timelock_fails() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -1872,7 +1872,7 @@ fn test_forced_redeem_from_vault_user_after_operator_already_redeemed_fails() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state
@@ -1944,7 +1944,7 @@ fn test_forced_redeem_from_vault_operator_after_user_already_redeemed_fails() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     state

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -3186,7 +3186,7 @@ fn test_liquidate_spot_for_vault_share_asset() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     state.facade.price_tick(@vault_config.asset_info, 1);
 
     // Create users.

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_tv_tr_impact_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_tv_tr_impact_tests.cairo
@@ -12,7 +12,7 @@ fn test_shares_should_contribute_zero_until_activated() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state
         .facade
@@ -53,7 +53,7 @@ fn position_should_be_usable_with_inactive_vault_shares() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
 
     state
         .facade
@@ -105,7 +105,7 @@ fn test_shares_should_contribute_to_tv_tr_after_activation() {
         .facade
         .deposit(vault_user.account, vault_user.position_id, 5000_u64);
     state.facade.process_deposit(vault_init_deposit);
-    let vault_config = state.facade.register_vault_share_spot_asset(vault_user);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
     //vault shares have 10% risk factor
 
     state


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/228)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (helper signature + updated callsites) with no production contract logic modifications; risk is limited to potential test breakage due to the new parameter requirement.
> 
> **Overview**
> Updates the flow-test `register_vault_share_spot_asset` helper to accept an `asset_name`, instead of hardcoding `'VS_1'`, and adjusts all vault deposit/redeem/liquidation flow tests to pass the explicit name.
> 
> Adds a new flow test asserting that attempting to deposit vault-share tokens from one protocol vault into another vault’s position is rejected (panics with `DEPOSIT_VAULT_SHARES_INTO_VAULT`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdf140f3889d066ed9f779377f65ce3e2c711327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->