### PR TITLE
chore(perpertuals): minor changes

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -308,9 +308,7 @@ pub(crate) mod LiquidationManager {
             let collateral_id = self.assets.get_collateral_id();
             let entry = (@self).assets.asset_config.entry(liquidator_order.base_asset_id).as_ptr();
             let liquidated_asset_type = SyntheticTrait::get_asset_type(entry).expect(NO_SUCH_ASSET);
-            if liquidated_asset_type != AssetType::SPOT_COLLATERAL {
-                panic_with_felt252('INVALID_ASSET_TYPE');
-            }
+            assert(liquidated_asset_type == AssetType::SPOT_COLLATERAL, 'INVALID_ASSET_TYPE');
 
             let liquidator_position_id = liquidator_order.source_position;
             let liquidator_position = self.positions.get_position_snapshot(liquidator_position_id);
@@ -319,10 +317,10 @@ pub(crate) mod LiquidationManager {
                 liquidator_order.receive_position != INSURANCE_FUND_POSITION,
                 CANT_LIQUIDATE_IF_POSITION,
             );
+            assert(liquidator_order.receive_position != FEE_POSITION, CANT_TRADE_WITH_FEE_POSITION);
             assert(
                 liquidator_order.receive_position != liquidated_position_id, INVALID_SAME_POSITIONS,
             );
-            assert(liquidator_order.receive_position != FEE_POSITION, CANT_TRADE_WITH_FEE_POSITION);
 
             let liquidated_order = LimitOrder {
                 source_position: liquidated_position_id,

--- a/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/price.cairo
@@ -72,7 +72,7 @@ impl PriceMulU32 of PriceMulTrait<u32> {
 impl PriceMulBalance of PriceMulTrait<Balance> {
     type Target = i128;
     fn mul(self: @Price, rhs: Balance) -> Self::Target {
-        let price: i128 = (*self.value).try_into().unwrap();
+        let price: i128 = (*self.value).into();
         let balance: i128 = rhs.into();
         let intermediate: i128 = price * balance;
         return intermediate / PRICE_SCALE.into();

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/system_time_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/system_time_tests.cairo
@@ -9,12 +9,22 @@ use starkware_utils::time::time::Time;
 #[should_panic(expected: 'STALE_TIME')]
 fn test_system_time_cannot_drift_too_much() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
-    state.facade.advance_time(1);
 
     let future_timestamp = Time::now().add(Time::seconds(360));
     let dispatcher = ISystemTimeDispatcher { contract_address: state.facade.perpetuals_contract };
     state.facade.operator.set_as_caller(state.facade.perpetuals_contract);
-    dispatcher.update_system_time(2, future_timestamp);
+    dispatcher.update_system_time(operator_nonce: 1, new_timestamp: future_timestamp);
+}
+
+#[test]
+#[should_panic(expected: 'NON_MONOTONIC_TIME')]
+fn test_system_time_set_past_time() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+
+    let past_timestamp = Time::now().sub_delta(Time::seconds(1));
+    let dispatcher = ISystemTimeDispatcher { contract_address: state.facade.perpetuals_contract };
+    state.facade.operator.set_as_caller(state.facade.perpetuals_contract);
+    dispatcher.update_system_time(operator_nonce: 1, new_timestamp: past_timestamp);
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are small and mostly validation/test tweaks; low risk, but touches liquidation assertions which could alter revert reasons/order in edge cases.
> 
> **Overview**
> Tightens `liquidate_spot_asset` validation by converting the spot-collateral type check to an `assert` and reordering/adding position guards so the `FEE_POSITION` cannot be used as the receive position.
> 
> Simplifies `Price * Balance` multiplication by removing an unnecessary `try_into().unwrap()` cast, and updates system time flow tests to use named args for `update_system_time` while adding coverage for setting a past timestamp (`NON_MONOTONIC_TIME`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22d83358bbbe2b20d2d38e4db309c29deaf7c2aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/231)
<!-- Reviewable:end -->
