### PR TITLE
chore(multi-collateral): add apply interest event

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -214,6 +214,7 @@ pub mod Core {
         ForcedTrade: events::ForcedTrade,
         ForcedRedeemFromVaultRequest: vault_events::ForcedRedeemFromVaultRequest,
         ForcedRedeemFromVault: vault_events::ForcedRedeemFromVault,
+        InterestApplied: events::InterestApplied,
         #[flat]
         FulfillmentEvent: Fulfillement::Event,
         #[flat]
@@ -1213,6 +1214,13 @@ pub mod Core {
                         :current_time,
                         :max_interest_rate_per_sec,
                         :interest_rate_scale,
+                    );
+
+                self
+                    .emit(
+                        events::InterestApplied {
+                            position_id: *position_id, interest_amount: interest_amount,
+                        },
                     );
                 i += 1;
             }

--- a/workspace/apps/perpetuals/contracts/src/core/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/events.cairo
@@ -154,3 +154,10 @@ pub struct ForcedTrade {
     #[key]
     pub order_b_hash: felt252,
 }
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct InterestApplied {
+    #[key]
+    pub position_id: PositionId,
+    pub interest_amount: i64,
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches on-chain interest-application state (`last_interest_applied_time`) and introduces new event emissions, which can affect downstream indexers and edge-case interest accounting if timestamp update semantics changed.
> 
> **Overview**
> Adds a new `InterestApplied` Starknet event (position id + interest amount) and emits it from `Core.apply_interests` for each position updated.
> 
> Refactors interest validation by renaming `validate_interest` to `validate_interest_in_range` and moving `last_interest_applied_time` updates into validation (set on first call with zero interest, and after successful non-zero validation) instead of being written during the balance update path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6224e4314295643e7f5ca909705e35bf03233a4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/232)
<!-- Reviewable:end -->
