### PR TITLE
Added vault protection config.

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2176,7 +2176,7 @@ Only APP\_GOVERNOR can execute.
   Force-resets the vault protection mechanism by snapshotting the current total value and recalculating the maximum allowed TV loss so that the limit for a day can be extended.                                                                                  
                                                                                                                                                                                                                     
   ```rust
-  fn force_reset_nightly_protection_limit(
+  fn force_reset_daily_protection_limit(
       ref self: ContractState,
       vault_position: PositionId,
   )

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2173,13 +2173,12 @@ Only APP\_GOVERNOR can execute.
 
   ###### Force Reset Protection Limit                                                                                                                                                                                 
                                                                                                                                                                                                                       
-  Force-resets the vault protection mechanism by snapshotting the current total value and recalculating the maximum allowed TV loss.                                                                                  
+  Force-resets the vault protection mechanism by snapshotting the current total value and recalculating the maximum allowed TV loss so that the limit for a day can be extended.                                                                                  
                                                                                                                                                                                                                     
   ```rust
-  fn force_reset_protection_limit(
+  fn force_reset_nightly_protection_limit(
       ref self: ContractState,
       vault_position: PositionId,
-      percentage: u32,
   )
   ```
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2211,7 +2211,7 @@ Only APP\_GOVERNOR can execute.
 
   ###### Update Vault Protection Limit
 
-  Updates the per-vault protection limit percentage override. A value of 0 resets to the default (5%).
+  Updates the per-vault protection limit percentage override. Default is 5%, 0 is not allowed as it prevents any withdraws.
 
   ```rust
   fn update_vault_protection_limit(

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2238,7 +2238,7 @@ Only APP\_GOVERNOR can execute.
 
   **Emits:**
 
-  [PerVaultProtectionLimitUpdated](#pervaultprotectionlimitupdated)
+  [VaultProtectionLimitUpdated](#VaultProtectionLimitUpdated)
 
   **Errors:**
 
@@ -2261,11 +2261,11 @@ Only APP\_GOVERNOR can execute.
   }
   ```
 
-  ###### PerVaultProtectionLimitUpdated
+  ###### VaultProtectionLimitUpdated
 
   ```rust
   #[derive(Debug, Drop, PartialEq, starknet::Event)]
-  pub struct PerVaultProtectionLimitUpdated {
+  pub struct VaultProtectionLimitUpdated {
       #[key]
       pub vault_position_id: PositionId,
       pub old_limit: u32,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2171,6 +2171,109 @@ Only APP\_GOVERNOR can execute.
 - INVALID_ZERO_QUORUM
 - INVALID_SAME_QUORUM
 
+  ###### Force Reset Protection Limit                                                                                                                                                                                 
+                                                                                                                                                                                                                      
+  Force-resets the vault protection mechanism by snapshotting the current total value and recalculating the maximum allowed TV loss.                                                                                  
+                                                                                                                                                                                                                    
+  ```rust
+  fn force_reset_protection_limit(
+      ref self: ContractState,
+      vault_position: PositionId,
+      percentage: u32,
+  )
+  ```
+
+  **Access Control:**
+
+  Only APP\_GOVERNOR can execute.
+
+  **Validations:**
+
+  1. App Governor is the caller.
+  2. `vault_position` is a registered vault position.
+
+  **Logic:**
+
+  1. Run validations.
+  2. Get current `VaultConfig` for the vault position.
+  3. Calculate current total value via `get_position_tv_tr`.
+  4. Calculate `max_tv_loss` from `tv_at_check` and `percentage`.
+  5. Update `VaultConfig` with new `tv_at_check`, `max_tv_loss`, and `last_tv_check_timestamp = now`.
+  6. Write updated config to both `registered_vaults_by_position` and `registered_vaults_by_asset`.
+
+  **Emits:**
+
+  [VaultProtectionReset](#vaultprotectionreset)
+
+  **Errors:**
+
+  - ONLY\_APP\_GOVERNOR
+  - UNKNOWN\_VAULT
+
+  ###### Update Vault Protection Limit
+
+  Updates the per-vault protection limit percentage override. A value of 0 resets to the default (5%).
+
+  ```rust
+  fn update_vault_protection_limit(
+      ref self: ContractState,
+      vault_position: PositionId,
+      limit: u32,
+  )
+  ```
+
+  **Access Control:**
+
+  Only APP\_GOVERNOR can execute.
+
+  **Validations:**
+
+  1. App Governor is the caller.
+  2. `vault_position` is a registered vault position.
+
+  **Logic:**
+
+  1. Run validations.
+  2. Write `limit` to `vault_protection_limit_overrides[vault_position]`.
+
+  **Emits:**
+
+  [PerVaultProtectionLimitUpdated](#pervaultprotectionlimitupdated)
+
+  **Errors:**
+
+  - ONLY\_APP\_GOVERNOR
+  - UNKNOWN\_VAULT
+
+  And the events:
+
+  ###### VaultProtectionReset
+
+  ```rust
+  #[derive(Debug, Drop, PartialEq, starknet::Event)]
+  pub struct VaultProtectionReset {
+      #[key]
+      pub vault_position_id: PositionId,
+      pub old_tv_at_check: i128,
+      pub old_max_tv_loss: i128,
+      pub new_tv_at_check: i128,
+      pub new_max_tv_loss: i128,
+  }
+  ```
+
+  ###### PerVaultProtectionLimitUpdated
+
+  ```rust
+  #[derive(Debug, Drop, PartialEq, starknet::Event)]
+  pub struct PerVaultProtectionLimitUpdated {
+      #[key]
+      pub vault_position_id: PositionId,
+      pub old_limit: u32,
+      pub new_limit: u32,
+  }
+  ```
+
+
 ###### ActivateVault
 
 Activate vault is called by the operator to activate a vault position

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -114,8 +114,6 @@ pub(crate) mod DepositManager {
         RolesEvent: RolesComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
-        #[flat]
-        SystemTimeEvent: SystemTimeComponent::Event,
         Deposit: events::Deposit,
         DepositCanceled: events::DepositCanceled,
         DepositProcessed: events::DepositProcessed,
@@ -148,8 +146,6 @@ pub(crate) mod DepositManager {
         pub request_approvals: RequestApprovalsComponent::Storage,
         #[substorage(v0)]
         pub vaults: VaultsComponent::Storage,
-        #[substorage(v0)]
-        system_time: SystemTimeComponent::Storage,
     }
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
@@ -166,7 +162,6 @@ pub(crate) mod DepositManager {
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
     component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
-    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
 
     #[abi(embed_v0)]
     impl TypedComponent of ITypedComponent<ContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -95,6 +95,8 @@ pub(crate) mod DepositManager {
         #[flat]
         PausableEvent: PausableComponent::Event,
         #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
+        #[flat]
         OperatorNonceEvent: OperatorNonceComponent::Event,
         #[flat]
         AssetsEvent: AssetsComponent::Event,
@@ -130,6 +132,8 @@ pub(crate) mod DepositManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        system_time: SystemTimeComponent::Storage,
+        #[substorage(v0)]
         #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
@@ -150,6 +154,7 @@ pub(crate) mod DepositManager {
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
     component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
     component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
     component!(path: AssetsComponent, storage: assets, event: AssetsEvent);
     component!(path: PositionsComponent, storage: positions, event: PositionsEvent);

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -129,8 +129,6 @@ pub(crate) mod TransferManager {
         RolesEvent: RolesComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
-        #[flat]
-        SystemTimeEvent: SystemTimeComponent::Event,
     }
 
     #[storage]
@@ -158,8 +156,6 @@ pub(crate) mod TransferManager {
         pub request_approvals: RequestApprovalsComponent::Storage,
         #[substorage(v0)]
         pub vaults: VaultsComponent::Storage,
-        #[substorage(v0)]
-        system_time: SystemTimeComponent::Storage,
     }
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
@@ -175,7 +171,6 @@ pub(crate) mod TransferManager {
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
     component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
-    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
 
     #[abi(embed_v0)]
     impl TypedComponent of ITypedComponent<ContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -112,6 +112,8 @@ pub(crate) mod TransferManager {
         #[flat]
         PausableEvent: PausableComponent::Event,
         #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
+        #[flat]
         OperatorNonceEvent: OperatorNonceComponent::Event,
         #[flat]
         AssetsEvent: AssetsComponent::Event,
@@ -142,6 +144,8 @@ pub(crate) mod TransferManager {
         #[substorage(v0)]
         pub roles: RolesComponent::Storage,
         #[substorage(v0)]
+        system_time: SystemTimeComponent::Storage,
+        #[substorage(v0)]
         #[allow(starknet::colliding_storage_paths)]
         pub assets: AssetsComponent::Storage,
         #[substorage(v0)]
@@ -160,6 +164,7 @@ pub(crate) mod TransferManager {
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
     component!(path: PausableComponent, storage: pausable, event: PausableEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
     component!(path: OperatorNonceComponent, storage: operator_nonce, event: OperatorNonceEvent);
     component!(path: AssetsComponent, storage: assets, event: AssetsEvent);
     component!(path: PositionsComponent, storage: positions, event: PositionsEvent);

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -134,7 +134,7 @@ pub struct VaultProtectionReset {
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
-pub struct PerVaultProtectionLimitUpdated {
+pub struct VaultProtectionLimitUpdated {
     #[key]
     pub vault_position_id: PositionId,
     pub old_limit: u32,

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -122,3 +122,21 @@ pub struct RedeemVaultShares {
     pub interest_amount_redeeming_position: i64,
     pub interest_amount_receiver: i64,
 }
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct VaultProtectionReset {
+    #[key]
+    pub vault_position_id: PositionId,
+    pub old_tv_at_check: i128,
+    pub old_max_tv_loss: u128,
+    pub new_tv_at_check: i128,
+    pub new_max_tv_loss: u128,
+}
+
+#[derive(Debug, Drop, PartialEq, starknet::Event)]
+pub struct PerVaultProtectionLimitUpdated {
+    #[key]
+    pub vault_position_id: PositionId,
+    pub old_limit: u32,
+    pub new_limit: u32,
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
@@ -1,8 +1,58 @@
 use perpetuals::core::types::asset::AssetId;
+use starkware_utils::time::time::Seconds;
+use starknet::storage::StoragePointer0Offset;
+use starknet::storage_access::storage_address_from_base_and_offset;
+use starknet::syscalls::storage_read_syscall;
+use starknet::SyscallResultTrait;
 
 #[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct VaultConfig {
     pub version: u8,
     pub asset_id: AssetId,
     pub position_id: u32,
+    pub last_tv_check: Seconds,
+    pub tv_at_check: i128,
+    pub max_tv_loss: u128,
+}
+
+#[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde)]
+pub struct VaultProtectionParams {
+    pub tv_at_check: i128,
+    pub max_tv_loss: u128,
+}
+
+#[generate_trait]
+pub impl VaultConfigImpl of VaultConfigTrait {
+    
+    #[inline]
+    fn read(
+        entry: StoragePointer0Offset<VaultConfig>, offset: u8,
+    ) -> felt252 {
+        storage_read_syscall(
+            0,
+            storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset),
+        )
+            .unwrap_syscall()
+    }
+
+    #[inline]
+    fn read_version(entry: StoragePointer0Offset<VaultConfig>) -> felt252 {
+        Self::read(entry, 0)
+    }
+
+   /// Returns true if the Option is Some, false if None.
+    /// At the storage 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_some(entry: StoragePointer0Offset<VaultConfig>) -> bool {
+        let version = Self::read_version(entry);
+        version != 0
+    }
+
+    /// Returns true if the Option is None, false if Some.
+    /// At the storage 0 indicates None, 1 indicates Some.
+    #[inline]
+    fn is_none(entry: StoragePointer0Offset<VaultConfig>) -> bool {
+        let version = Self::read_version(entry);
+        version == 0
+    }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
@@ -38,7 +38,7 @@ pub impl VaultConfigOffsetIntoU8 of Into<VaultConfigOffset, u8> {
     fn into(self: VaultConfigOffset) -> u8 {
         match self {
             VaultConfigOffset::VERSION => 0_u8,
-            VaultConfigOffset::ASSET_ID => 1_8,
+            VaultConfigOffset::ASSET_ID => 1_u8,
             VaultConfigOffset::POSITION_ID => 2_u8,
             VaultConfigOffset::LAST_TV_CHECK_TIMESTAMP => 3_u8,
             VaultConfigOffset::TV_AT_CHECK => 4_u8,

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
@@ -1,19 +1,19 @@
 use perpetuals::core::types::asset::AssetId;
-use starkware_utils::time::time::Seconds;
-use starkware_utils::math::utils::mul_wide_and_floor_div;
-use starkware_utils::math::abs::Abs;
+use starknet::SyscallResultTrait;
 use starknet::storage::StoragePointer0Offset;
 use starknet::storage_access::storage_address_from_base_and_offset;
 use starknet::syscalls::storage_read_syscall;
-use starknet::SyscallResultTrait;
+use starkware_utils::math::abs::Abs;
+use starkware_utils::math::utils::mul_wide_and_floor_div;
+use starkware_utils::time::time::Timestamp;
 
 
-#[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde, starknet::Store)]
+#[derive(Copy, Debug, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct VaultConfig {
     pub version: u8,
     pub asset_id: AssetId,
     pub position_id: u32,
-    pub last_tv_check_timestamp: Seconds,
+    pub last_tv_check_timestamp: Timestamp,
     pub tv_at_check: i128,
     pub max_tv_loss: u128,
 }
@@ -49,11 +49,8 @@ pub impl VaultConfigOffsetIntoU8 of Into<VaultConfigOffset, u8> {
 
 #[generate_trait]
 pub impl VaultConfigImpl of VaultConfigTrait {
-    
     #[inline]
-    fn read(
-        entry: StoragePointer0Offset<VaultConfig>, offset: VaultConfigOffset,
-    ) -> felt252 {
+    fn read(entry: StoragePointer0Offset<VaultConfig>, offset: VaultConfigOffset) -> felt252 {
         storage_read_syscall(
             0,
             storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset.into()),
@@ -66,7 +63,7 @@ pub impl VaultConfigImpl of VaultConfigTrait {
         Self::read(entry, VaultConfigOffset::VERSION)
     }
 
-   /// Returns true if the Option is Some, false if None.
+    /// Returns true if the Option is Some, false if None.
     /// At the storage 0 indicates None, 1 indicates Some.
     #[inline]
     fn is_some(entry: StoragePointer0Offset<VaultConfig>) -> bool {

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
@@ -1,9 +1,12 @@
 use perpetuals::core::types::asset::AssetId;
 use starkware_utils::time::time::Seconds;
+use starkware_utils::math::utils::mul_wide_and_floor_div;
+use starkware_utils::math::abs::Abs;
 use starknet::storage::StoragePointer0Offset;
 use starknet::storage_access::storage_address_from_base_and_offset;
 use starknet::syscalls::storage_read_syscall;
 use starknet::SyscallResultTrait;
+
 
 #[derive(Copy, Debug, Default, Drop, Hash, PartialEq, Serde, starknet::Store)]
 pub struct VaultConfig {
@@ -54,5 +57,10 @@ pub impl VaultConfigImpl of VaultConfigTrait {
     fn is_none(entry: StoragePointer0Offset<VaultConfig>) -> bool {
         let version = Self::read_version(entry);
         version == 0
+    }
+
+    #[inline]
+    fn get_max_tv_loss(tv_at_check: i128, limit: u32) -> u128 {
+        return mul_wide_and_floor_div(tv_at_check.abs(), limit.into() * 10, 1000).unwrap();
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/types.cairo
@@ -13,7 +13,7 @@ pub struct VaultConfig {
     pub version: u8,
     pub asset_id: AssetId,
     pub position_id: u32,
-    pub last_tv_check: Seconds,
+    pub last_tv_check_timestamp: Seconds,
     pub tv_at_check: i128,
     pub max_tv_loss: u128,
 }
@@ -24,23 +24,46 @@ pub struct VaultProtectionParams {
     pub max_tv_loss: u128,
 }
 
+#[derive(Copy, Drop, Debug, PartialEq, Serde)]
+pub enum VaultConfigOffset {
+    VERSION,
+    ASSET_ID,
+    POSITION_ID,
+    LAST_TV_CHECK_TIMESTAMP,
+    TV_AT_CHECK,
+    MAX_TV_LOSS,
+}
+
+pub impl VaultConfigOffsetIntoU8 of Into<VaultConfigOffset, u8> {
+    fn into(self: VaultConfigOffset) -> u8 {
+        match self {
+            VaultConfigOffset::VERSION => 0_u8,
+            VaultConfigOffset::ASSET_ID => 1_8,
+            VaultConfigOffset::POSITION_ID => 2_u8,
+            VaultConfigOffset::LAST_TV_CHECK_TIMESTAMP => 3_u8,
+            VaultConfigOffset::TV_AT_CHECK => 4_u8,
+            VaultConfigOffset::MAX_TV_LOSS => 5_u8,
+        }
+    }
+}
+
 #[generate_trait]
 pub impl VaultConfigImpl of VaultConfigTrait {
     
     #[inline]
     fn read(
-        entry: StoragePointer0Offset<VaultConfig>, offset: u8,
+        entry: StoragePointer0Offset<VaultConfig>, offset: VaultConfigOffset,
     ) -> felt252 {
         storage_read_syscall(
             0,
-            storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset),
+            storage_address_from_base_and_offset(entry.__storage_pointer_address__, offset.into()),
         )
             .unwrap_syscall()
     }
 
     #[inline]
     fn read_version(entry: StoragePointer0Offset<VaultConfig>) -> felt252 {
-        Self::read(entry, 0)
+        Self::read(entry, VaultConfigOffset::VERSION)
     }
 
    /// Returns true if the Option is Some, false if None.

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -1,9 +1,11 @@
 use crate::core::types::asset::AssetId;
 use crate::core::types::position::PositionId;
 use starkware_utils::constants::DAY;
+use starkware_utils::time::time::TimeDelta;
+
 
 const STORAGE_VERSION: u8 = 1;
-const CHECK_FREQUENCY: u64 = DAY;
+const CHECK_FREQUENCY: TimeDelta = TimeDelta{ seconds: DAY};
 const DEFAULT_LIMIT_PERCENT: u32 = 5;
 
 
@@ -12,7 +14,7 @@ pub trait IVaults<TContractState> {
     fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
     fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
     fn force_reset_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
-    fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, limit: u32);
+    fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
 }
 
 #[starknet::component]
@@ -44,7 +46,7 @@ pub mod Vaults {
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use starkware_utils::time::time::{validate_expiration, Time};
+    use starkware_utils::time::time::{validate_expiration, Time, Timestamp};
     use vault::interface::{IProtocolVaultDispatcher, IProtocolVaultDispatcherTrait};
     use crate::core::components::positions::interface::IPositions;
     use perpetuals::core::components::system_time::SystemTimeComponent;
@@ -60,7 +62,7 @@ pub mod Vaults {
     pub enum Event {
         VaultOpened: events::VaultOpened,
         VaultProtectionReset: events::VaultProtectionReset,
-        PerVaultProtectionLimitUpdated: events::PerVaultProtectionLimitUpdated,
+        VaultProtectionLimitUpdated: events::VaultProtectionLimitUpdated,
     }
 
     #[storage]
@@ -134,26 +136,23 @@ pub mod Vaults {
         }
 
         fn update_vault_protection_limit(
-            ref self: ComponentState<TContractState>, vault_position: PositionId, limit: u32,
+            ref self: ComponentState<TContractState>, vault_position: PositionId, percentage: u32,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
             assert(self.is_vault_position(vault_position), 'UNKNOWN_VAULT');
-            let old_limit = self.vault_protection_limit_overrides.read(vault_position);
-            self.vault_protection_limit_overrides.write(vault_position, limit);
+            assert(percentage != 0, 'ZERO-LIMIT');
+            let old_percentage = self.vault_protection_limit_overrides.read(vault_position);
+            self.vault_protection_limit_overrides.write(vault_position, percentage);
             self
                 .emit(
-                    events::PerVaultProtectionLimitUpdated {
+                    events::VaultProtectionLimitUpdated {
                         vault_position_id: vault_position,
-                        old_limit: if old_limit == 0 {
+                        old_limit: if old_percentage == 0 {
                             DEFAULT_LIMIT_PERCENT
                         } else {
-                            old_limit
+                            old_percentage
                         },
-                        new_limit: if limit == 0 {
-                            DEFAULT_LIMIT_PERCENT
-                        } else {
-                            limit 
-                        },
+                        new_limit: percentage,
                     },
                 );
         }
@@ -199,11 +198,11 @@ pub mod Vaults {
             }
 
             let current_config = self.registered_vaults_by_position.read(vault_position);
-            let current_time: u64 = Time::now().into();
-            let last_check_time = current_config.last_tv_check_timestamp;
-            if (current_time - last_check_time >= CHECK_FREQUENCY) {    
+            let current_time = Time::now();
+            let last_check_time = Timestamp{ seconds: current_config.last_tv_check_timestamp };
+            if (current_time.sub(last_check_time) >= CHECK_FREQUENCY) {    
                 let positions = get_dep_component!(@self, Positions);
-                let position_tv_tr = IPositions::get_position_tv_tr(positions, position_id: vault_position);
+                let position_tv_tr = positions.get_position_tv_tr(position_id: vault_position);
                 let tv_at_check = position_tv_tr.total_value;
 
                 let limit_from_storage = self.vault_protection_limit_overrides.read(vault_position);
@@ -218,7 +217,7 @@ pub mod Vaults {
                     version: current_config.version,
                     asset_id: current_config.asset_id,
                     position_id: current_config.position_id,
-                    last_tv_check_timestamp: current_time,
+                    last_tv_check_timestamp: current_time.into(),
                     tv_at_check: tv_at_check,
                     max_tv_loss: max_tv_loss,
                 };

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -13,7 +13,7 @@ const DEFAULT_LIMIT_PERCENT: u32 = 5;
 pub trait IVaults<TContractState> {
     fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
     fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
-    fn force_reset_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
+    fn force_reset_nightly_protection_limit(ref self: TContractState, vault_position: PositionId);
     fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
 }
 
@@ -98,16 +98,16 @@ pub mod Vaults {
             return self.registered_vaults_by_asset.read(asset_id).version != 0;
         }
 
-        fn force_reset_protection_limit(
+        fn force_reset_nightly_protection_limit(
             ref self: ComponentState<TContractState>,
             vault_position: PositionId,
-            percentage: u32,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
 
             let current_config = self.get_vault_config_for_position(:vault_position);
             let positions = get_dep_component!(@self, Positions);
             let position_tv_tr = positions.get_position_tv_tr(vault_position);
+            let percentage = self.vault_protection_limit_overrides.read(vault_position);
             let tv_at_check = position_tv_tr.total_value;
             let max_tv_loss = VaultConfigTrait::get_max_tv_loss(tv_at_check, percentage);
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -13,7 +13,7 @@ const DEFAULT_LIMIT_PERCENT: u32 = 5;
 pub trait IVaults<TContractState> {
     fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
     fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
-    fn force_reset_nightly_protection_limit(ref self: TContractState, vault_position: PositionId);
+    fn force_reset_daily_protection_limit(ref self: TContractState, vault_position: PositionId);
     fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
 }
 
@@ -98,7 +98,7 @@ pub mod Vaults {
             return self.registered_vaults_by_asset.read(asset_id).version != 0;
         }
 
-        fn force_reset_nightly_protection_limit(
+        fn force_reset_daily_protection_limit(
             ref self: ComponentState<TContractState>,
             vault_position: PositionId,
         ) {

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -209,7 +209,7 @@ pub mod Vaults {
 
                 let limit_from_storage = self.vault_protection_limit_overrides.read(vault_position);
                 let limit = if limit_from_storage == 0 {
-                    5
+                    DEFAULT_LIMIT_PERCENT
                 } else {
                     limit_from_storage
                 };

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -1,11 +1,11 @@
-use crate::core::types::asset::AssetId;
-use crate::core::types::position::PositionId;
 use starkware_utils::constants::DAY;
 use starkware_utils::time::time::TimeDelta;
+use crate::core::types::asset::AssetId;
+use crate::core::types::position::PositionId;
 
 
 const STORAGE_VERSION: u8 = 1;
-const CHECK_FREQUENCY: TimeDelta = TimeDelta{ seconds: DAY};
+const CHECK_FREQUENCY: TimeDelta = TimeDelta { seconds: DAY };
 const DEFAULT_LIMIT_PERCENT: u32 = 5;
 
 
@@ -14,7 +14,9 @@ pub trait IVaults<TContractState> {
     fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
     fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
     fn force_reset_daily_protection_limit(ref self: TContractState, vault_position: PositionId);
-    fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
+    fn update_vault_protection_limit(
+        ref self: TContractState, vault_position: PositionId, percentage: u32,
+    );
 }
 
 #[starknet::component]
@@ -25,13 +27,13 @@ pub mod Vaults {
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
     use openzeppelin::introspection::src5::SRC5Component;
-    
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::Deposit::InternalImpl as DepositInternal;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::components::vaults::types::{VaultConfig, VaultConfigTrait};
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::asset::synthetic::AssetType;
@@ -46,16 +48,15 @@ pub mod Vaults {
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use starkware_utils::time::time::{validate_expiration, Time, Timestamp};
+    use starkware_utils::time::time::{Time, Timestamp, validate_expiration};
     use vault::interface::{IProtocolVaultDispatcher, IProtocolVaultDispatcherTrait};
     use crate::core::components::positions::interface::IPositions;
-    use perpetuals::core::components::system_time::SystemTimeComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::components::vaults::events;
     use crate::core::components::vaults::types::VaultProtectionParams;
     use crate::core::types::vault::ConvertPositionToVault;
     use crate::core::utils::validate_signature;
-    use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, DEFAULT_LIMIT_PERCENT};
+    use super::{CHECK_FREQUENCY, DEFAULT_LIMIT_PERCENT, IVaults, STORAGE_VERSION};
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
@@ -75,7 +76,7 @@ pub mod Vaults {
     #[embeddable_as(VaultsImpl)]
     impl VaultsComponent<
         TContractState,
-        +HasComponent<TContractState>, 
+        +HasComponent<TContractState>,
         +Drop<TContractState>,
         +AccessControlComponent::HasComponent<TContractState>,
         +SRC5Component::HasComponent<TContractState>,
@@ -99,15 +100,16 @@ pub mod Vaults {
         }
 
         fn force_reset_daily_protection_limit(
-            ref self: ComponentState<TContractState>,
-            vault_position: PositionId,
+            ref self: ComponentState<TContractState>, vault_position: PositionId,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
 
             let current_config = self.get_vault_config_for_position(:vault_position);
             let positions = get_dep_component!(@self, Positions);
             let position_tv_tr = positions.get_position_tv_tr(vault_position);
-            let percentage_from_storage = self.vault_protection_limit_overrides.read(vault_position);
+            let percentage_from_storage = self
+                .vault_protection_limit_overrides
+                .read(vault_position);
             let percentage = if percentage_from_storage.is_zero() {
                 DEFAULT_LIMIT_PERCENT
             } else {
@@ -120,7 +122,7 @@ pub mod Vaults {
                 version: current_config.version,
                 asset_id: current_config.asset_id,
                 position_id: current_config.position_id,
-                last_tv_check_timestamp: Time::now().into(),
+                last_tv_check_timestamp: Time::now(),
                 tv_at_check: tv_at_check,
                 max_tv_loss: max_tv_loss,
             };
@@ -195,6 +197,12 @@ pub mod Vaults {
             vault_config
         }
 
+
+        /// Gets the config for a vault position that determines how much can be withdrawn per day
+        /// expressed as tv tr.
+        /// It's based on the percentage set at 'vault_protection_limit_overrides'
+        /// Based on CHECK_FREQUENCY we update the limits daily to reset the daily allowance for
+        /// withdraw.
         fn get_vault_protection_config(
             ref self: ComponentState<TContractState>, vault_position: PositionId,
         ) -> Option<VaultProtectionParams> {
@@ -204,8 +212,8 @@ pub mod Vaults {
 
             let current_config = self.registered_vaults_by_position.read(vault_position);
             let current_time = Time::now();
-            let last_check_time = Timestamp{ seconds: current_config.last_tv_check_timestamp };
-            if (current_time.sub(last_check_time) >= CHECK_FREQUENCY) {    
+            let last_check_time = current_config.last_tv_check_timestamp;
+            if (current_time.sub(last_check_time) >= CHECK_FREQUENCY) {
                 let positions = get_dep_component!(@self, Positions);
                 let position_tv_tr = positions.get_position_tv_tr(position_id: vault_position);
                 let tv_at_check = position_tv_tr.total_value;
@@ -222,21 +230,22 @@ pub mod Vaults {
                     version: current_config.version,
                     asset_id: current_config.asset_id,
                     position_id: current_config.position_id,
-                    last_tv_check_timestamp: current_time.into(),
+                    last_tv_check_timestamp: current_time,
                     tv_at_check: tv_at_check,
                     max_tv_loss: max_tv_loss,
                 };
                 self.registered_vaults_by_position.write(vault_position, updated_config);
                 self.registered_vaults_by_asset.write(current_config.asset_id, updated_config);
-                self.emit(
-                    events::VaultProtectionReset {
-                        vault_position_id: vault_position,
-                        old_tv_at_check: current_config.tv_at_check,
-                        old_max_tv_loss: current_config.max_tv_loss,
-                        new_tv_at_check: updated_config.tv_at_check,
-                        new_max_tv_loss: updated_config.max_tv_loss,
-                    },
-                );
+                self
+                    .emit(
+                        events::VaultProtectionReset {
+                            vault_position_id: vault_position,
+                            old_tv_at_check: current_config.tv_at_check,
+                            old_max_tv_loss: current_config.max_tv_loss,
+                            new_tv_at_check: updated_config.tv_at_check,
+                            new_max_tv_loss: updated_config.max_tv_loss,
+                        },
+                    );
                 return Some(
                     VaultProtectionParams {
                         tv_at_check: updated_config.tv_at_check,
@@ -329,7 +338,7 @@ pub mod Vaults {
                         version: STORAGE_VERSION,
                         asset_id: vault_asset_id,
                         position_id: vault_position.value,
-                        last_tv_check_timestamp: 0,
+                        last_tv_check_timestamp: Timestamp { seconds: 0 },
                         tv_at_check: 0,
                         max_tv_loss: 0,
                     },
@@ -343,7 +352,7 @@ pub mod Vaults {
                         version: STORAGE_VERSION,
                         asset_id: vault_asset_id,
                         position_id: vault_position.value,
-                        last_tv_check_timestamp: 0,
+                        last_tv_check_timestamp: Timestamp { seconds: 0 },
                         tv_at_check: 0,
                         max_tv_loss: 0,
                     },

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -107,7 +107,12 @@ pub mod Vaults {
             let current_config = self.get_vault_config_for_position(:vault_position);
             let positions = get_dep_component!(@self, Positions);
             let position_tv_tr = positions.get_position_tv_tr(vault_position);
-            let percentage = self.vault_protection_limit_overrides.read(vault_position);
+            let percentage_from_storage = self.vault_protection_limit_overrides.read(vault_position);
+            let percentage = if percentage_from_storage == 0 {
+                DEFAULT_LIMIT_PERCENT
+            } else {
+                percentage_from_storage
+            };
             let tv_at_check = position_tv_tr.total_value;
             let max_tv_loss = VaultConfigTrait::get_max_tv_loss(tv_at_check, percentage);
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -1,17 +1,23 @@
 use crate::core::types::asset::AssetId;
 use crate::core::types::position::PositionId;
+use super::types::VaultProtectionParams;
+use starkware_utils::constants::DAY;
 
 const STORAGE_VERSION: u8 = 1;
+const CHECK_FREQUENCY: u64 = DAY;
 
 
 #[starknet::interface]
 pub trait IVaults<TContractState> {
     fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
     fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
+    fn force_reset_protection_limit(ref self: TContractState, vault_position: PositionId, percentage_basis_points: u32);
+    fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, limit: u32);
 }
 
 #[starknet::component]
 pub mod Vaults {
+    use RolesComponent::InternalTrait as RolesInternalTrait;
     use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
@@ -23,52 +29,137 @@ pub mod Vaults {
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
-    use perpetuals::core::components::vaults::types::VaultConfig;
+    use perpetuals::core::components::vaults::types::{VaultConfig, VaultConfigTrait};
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::asset::synthetic::AssetType;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
-    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
+    use starknet::storage::{
+        Map, StorageAsPointer, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
+    };
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
+    use starkware_utils::math::abs::Abs;
+    use starkware_utils::math::utils::mul_wide_and_floor_div;
     use starkware_utils::signature::stark::Signature;
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
-    use starkware_utils::time::time::validate_expiration;
+    use starkware_utils::time::time::{validate_expiration, Time};
     use vault::interface::{IProtocolVaultDispatcher, IProtocolVaultDispatcherTrait};
+    use crate::core::components::positions::interface::IPositions;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::components::system_time::SystemTimeComponent;
     use crate::core::components::vaults::events;
     use crate::core::types::vault::ConvertPositionToVault;
     use crate::core::utils::validate_signature;
-    use super::{IVaults, STORAGE_VERSION};
-
+    use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, VaultProtectionParams};
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
     pub enum Event {
         VaultOpened: events::VaultOpened,
+        VaultProtectionReset: events::VaultProtectionReset,
+        PerVaultProtectionLimitUpdated: events::PerVaultProtectionLimitUpdated,
     }
 
     #[storage]
     pub struct Storage {
         registered_vaults_by_asset: Map<AssetId, VaultConfig>,
         registered_vaults_by_position: Map<PositionId, VaultConfig>,
+        vault_protection_limit_overrides: Map<PositionId, u32>,
     }
 
     #[embeddable_as(VaultsImpl)]
     impl VaultsComponent<
-        TContractState, +HasComponent<TContractState>, +Drop<TContractState>,
+        TContractState,
+        +HasComponent<TContractState>, 
+        +Drop<TContractState>,
+        +AccessControlComponent::HasComponent<TContractState>,
+        +SRC5Component::HasComponent<TContractState>,
+        impl Assets: AssetsComponent::HasComponent<TContractState>,
+        impl OperatorNonce: OperatorNonceComponent::HasComponent<TContractState>,
+        impl Pausable: PausableComponent::HasComponent<TContractState>,
+        impl Positions: PositionsComponent::HasComponent<TContractState>,
+        impl Roles: RolesComponent::HasComponent<TContractState>,
+        impl RequestApprovals: RequestApprovalsComponent::HasComponent<TContractState>,
+        impl SystemTime: SystemTimeComponent::HasComponent<TContractState>,
     > of IVaults<ComponentState<TContractState>> {
         fn is_vault_position(
             ref self: ComponentState<TContractState>, vault_position: PositionId,
         ) -> bool {
-            return self.registered_vaults_by_position.read(vault_position).version != 0;
+            let entry = (@self).registered_vaults_by_position.entry(vault_position).as_ptr();
+            return VaultConfigTrait::is_some(entry);
         }
 
         fn is_vault_asset(ref self: ComponentState<TContractState>, asset_id: AssetId) -> bool {
             return self.registered_vaults_by_asset.read(asset_id).version != 0;
+        }
+
+        fn force_reset_protection_limit(
+            ref self: ComponentState<TContractState>,
+            vault_position: PositionId,
+            percentage_basis_points: u32,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+
+            let current_config = self.get_vault_config_for_position(:vault_position);
+            let positions = get_dep_component!(@self, Positions);
+            let position_tv_tr = positions.get_position_tv_tr(vault_position);
+            let tv_at_check = position_tv_tr.total_value;
+            let max_tv_loss = mul_wide_and_floor_div(
+                tv_at_check.abs(), percentage_basis_points.into() * 10, 1000,
+            )
+                .unwrap();
+
+            let updated_config = VaultConfig {
+                version: current_config.version,
+                asset_id: current_config.asset_id,
+                position_id: current_config.position_id,
+                last_tv_check: Time::now().into(),
+                tv_at_check: tv_at_check,
+                max_tv_loss: max_tv_loss,
+            };
+
+            self.registered_vaults_by_position.write(vault_position, updated_config);
+            self.registered_vaults_by_asset.write(current_config.asset_id, updated_config);
+
+            self
+                .emit(
+                    events::VaultProtectionReset {
+                        vault_position_id: vault_position,
+                        old_tv_at_check: current_config.tv_at_check,
+                        old_max_tv_loss: current_config.max_tv_loss,
+                        new_tv_at_check: updated_config.tv_at_check,
+                        new_max_tv_loss: updated_config.max_tv_loss,
+                    },
+                );
+        }
+
+        fn update_vault_protection_limit(
+            ref self: ComponentState<TContractState>, vault_position: PositionId, limit: u32,
+        ) {
+            get_dep_component!(@self, Roles).only_app_governor();
+            assert(self.is_vault_position(vault_position), 'UNKNOWN_VAULT');
+            let old_limit = self.vault_protection_limit_overrides.read(vault_position);
+            self.vault_protection_limit_overrides.write(vault_position, limit);
+            self
+                .emit(
+                    events::PerVaultProtectionLimitUpdated {
+                        vault_position_id: vault_position,
+                        old_limit: if old_limit == 0 {
+                            5
+                        } else {
+                            old_limit
+                        },
+                        new_limit: if limit == 0 {
+                            5
+                        } else {
+                            limit 
+                        },
+                    },
+                );
         }
     }
 
@@ -87,6 +178,7 @@ pub mod Vaults {
         impl Positions: PositionsComponent::HasComponent<TContractState>,
         impl Roles: RolesComponent::HasComponent<TContractState>,
         impl RequestApprovals: RequestApprovalsComponent::HasComponent<TContractState>,
+        impl SystemTime: SystemTimeComponent::HasComponent<TContractState>,
     > of InternalTrait<TContractState> {
         fn get_vault_config_for_position(
             ref self: ComponentState<TContractState>, vault_position: PositionId,
@@ -102,6 +194,65 @@ pub mod Vaults {
             let vault_config = self.registered_vaults_by_asset.read(vault_asset_id);
             assert(vault_config.version != 0, 'UNKNOWN_VAULT');
             vault_config
+        }
+
+        fn get_vault_protection_config(
+            ref self: ComponentState<TContractState>, vault_position: PositionId,
+        ) -> Option<VaultProtectionParams> {
+            if (!self.is_vault_position(vault_position)) {
+                return Option::None;
+            }
+
+            let current_config = self.registered_vaults_by_position.read(vault_position);
+            let current_time: u64 = Time::now().into();
+            let last_check_time = current_config.last_tv_check;
+            if (current_time - last_check_time >= CHECK_FREQUENCY) {    
+                let positions = get_dep_component!(@self, Positions);
+                let position_tv_tr = IPositions::get_position_tv_tr(positions, position_id: vault_position);
+                let tv_at_check = position_tv_tr.total_value;
+
+                let limit_from_storage = self.vault_protection_limit_overrides.read(vault_position);
+                let limit = if limit_from_storage == 0 {
+                    5
+                } else {
+                    limit_from_storage
+                };
+
+                let max_tv_loss = mul_wide_and_floor_div(tv_at_check.abs(), limit.into() * 10, 1000)
+                    .unwrap();
+                let updated_config = VaultConfig {
+                    version: current_config.version,
+                    asset_id: current_config.asset_id,
+                    position_id: current_config.position_id,
+                    last_tv_check: current_time,
+                    tv_at_check: tv_at_check,
+                    max_tv_loss: max_tv_loss,
+                };
+                self.registered_vaults_by_position.write(vault_position, updated_config);
+                self.registered_vaults_by_asset.write(current_config.asset_id, updated_config);
+                self.emit(
+                    events::VaultProtectionReset {
+                        vault_position_id: vault_position,
+                        old_tv_at_check: current_config.tv_at_check,
+                        old_max_tv_loss: current_config.max_tv_loss,
+                        new_tv_at_check: updated_config.tv_at_check,
+                        new_max_tv_loss: updated_config.max_tv_loss,
+                    },
+                );
+                return Some(
+                    VaultProtectionParams {
+                        tv_at_check: updated_config.tv_at_check,
+                        max_tv_loss: updated_config.max_tv_loss,
+                    },
+                );
+            } else {
+                return Some(
+                    VaultProtectionParams {
+                        tv_at_check: current_config.tv_at_check,
+                        max_tv_loss: current_config.max_tv_loss,
+                    },
+                );
+            }
         }
 
         fn activate_vault(
@@ -180,6 +331,9 @@ pub mod Vaults {
                         version: STORAGE_VERSION,
                         asset_id: vault_asset_id,
                         position_id: vault_position.value,
+                        last_tv_check: 0,
+                        tv_at_check: 0,
+                        max_tv_loss: 0,
                     },
                 );
 
@@ -191,6 +345,9 @@ pub mod Vaults {
                         version: STORAGE_VERSION,
                         asset_id: vault_asset_id,
                         position_id: vault_position.value,
+                        last_tv_check: 0,
+                        tv_at_check: 0,
+                        max_tv_loss: 0,
                     },
                 );
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -108,7 +108,7 @@ pub mod Vaults {
             let positions = get_dep_component!(@self, Positions);
             let position_tv_tr = positions.get_position_tv_tr(vault_position);
             let percentage_from_storage = self.vault_protection_limit_overrides.read(vault_position);
-            let percentage = if percentage_from_storage == 0 {
+            let percentage = if percentage_from_storage.is_zero() {
                 DEFAULT_LIMIT_PERCENT
             } else {
                 percentage_from_storage
@@ -145,7 +145,7 @@ pub mod Vaults {
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
             assert(self.is_vault_position(vault_position), 'UNKNOWN_VAULT');
-            assert(percentage != 0, 'ZERO-LIMIT');
+            assert(percentage.is_non_zero(), 'ZERO-LIMIT');
             let old_percentage = self.vault_protection_limit_overrides.read(vault_position);
             self.vault_protection_limit_overrides.write(vault_position, percentage);
             self
@@ -211,7 +211,7 @@ pub mod Vaults {
                 let tv_at_check = position_tv_tr.total_value;
 
                 let limit_from_storage = self.vault_protection_limit_overrides.read(vault_position);
-                let limit = if limit_from_storage == 0 {
+                let limit = if limit_from_storage.is_zero() {
                     DEFAULT_LIMIT_PERCENT
                 } else {
                     limit_from_storage

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -1,6 +1,5 @@
 use crate::core::types::asset::AssetId;
 use crate::core::types::position::PositionId;
-use super::types::VaultProtectionParams;
 use starkware_utils::constants::DAY;
 
 const STORAGE_VERSION: u8 = 1;
@@ -24,6 +23,7 @@ pub mod Vaults {
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
     use openzeppelin::introspection::src5::SRC5Component;
+    
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::Deposit::InternalImpl as DepositInternal;
@@ -40,8 +40,6 @@ pub mod Vaults {
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
     use starkware_utils::components::roles::RolesComponent;
-    use starkware_utils::math::abs::Abs;
-    use starkware_utils::math::utils::mul_wide_and_floor_div;
     use starkware_utils::signature::stark::Signature;
     use starkware_utils::storage::iterable_map::{
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
@@ -52,9 +50,10 @@ pub mod Vaults {
     use perpetuals::core::components::system_time::SystemTimeComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::components::vaults::events;
+    use crate::core::components::vaults::types::VaultProtectionParams;
     use crate::core::types::vault::ConvertPositionToVault;
     use crate::core::utils::validate_signature;
-    use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, VaultProtectionParams, DEFAULT_LIMIT_PERCENT};
+    use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, DEFAULT_LIMIT_PERCENT};
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
@@ -114,7 +113,7 @@ pub mod Vaults {
                 version: current_config.version,
                 asset_id: current_config.asset_id,
                 position_id: current_config.position_id,
-                last_tv_check: Time::now().into(),
+                last_tv_check_timestamp: Time::now().into(),
                 tv_at_check: tv_at_check,
                 max_tv_loss: max_tv_loss,
             };
@@ -201,7 +200,7 @@ pub mod Vaults {
 
             let current_config = self.registered_vaults_by_position.read(vault_position);
             let current_time: u64 = Time::now().into();
-            let last_check_time = current_config.last_tv_check;
+            let last_check_time = current_config.last_tv_check_timestamp;
             if (current_time - last_check_time >= CHECK_FREQUENCY) {    
                 let positions = get_dep_component!(@self, Positions);
                 let position_tv_tr = IPositions::get_position_tv_tr(positions, position_id: vault_position);
@@ -219,7 +218,7 @@ pub mod Vaults {
                     version: current_config.version,
                     asset_id: current_config.asset_id,
                     position_id: current_config.position_id,
-                    last_tv_check: current_time,
+                    last_tv_check_timestamp: current_time,
                     tv_at_check: tv_at_check,
                     max_tv_loss: max_tv_loss,
                 };
@@ -326,7 +325,7 @@ pub mod Vaults {
                         version: STORAGE_VERSION,
                         asset_id: vault_asset_id,
                         position_id: vault_position.value,
-                        last_tv_check: 0,
+                        last_tv_check_timestamp: 0,
                         tv_at_check: 0,
                         max_tv_loss: 0,
                     },
@@ -340,7 +339,7 @@ pub mod Vaults {
                         version: STORAGE_VERSION,
                         asset_id: vault_asset_id,
                         position_id: vault_position.value,
-                        last_tv_check: 0,
+                        last_tv_check_timestamp: 0,
                         tv_at_check: 0,
                         max_tv_loss: 0,
                     },

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -5,13 +5,14 @@ use starkware_utils::constants::DAY;
 
 const STORAGE_VERSION: u8 = 1;
 const CHECK_FREQUENCY: u64 = DAY;
+const DEFAULT_LIMIT_PERCENT: u32 = 5;
 
 
 #[starknet::interface]
 pub trait IVaults<TContractState> {
     fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
     fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
-    fn force_reset_protection_limit(ref self: TContractState, vault_position: PositionId, percentage_basis_points: u32);
+    fn force_reset_protection_limit(ref self: TContractState, vault_position: PositionId, percentage: u32);
     fn update_vault_protection_limit(ref self: TContractState, vault_position: PositionId, limit: u32);
 }
 
@@ -50,11 +51,10 @@ pub mod Vaults {
     use crate::core::components::positions::interface::IPositions;
     use perpetuals::core::components::system_time::SystemTimeComponent;
     use crate::core::components::snip::SNIP12MetadataImpl;
-    use crate::core::components::system_time::SystemTimeComponent;
     use crate::core::components::vaults::events;
     use crate::core::types::vault::ConvertPositionToVault;
     use crate::core::utils::validate_signature;
-    use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, VaultProtectionParams};
+    use super::{CHECK_FREQUENCY, IVaults, STORAGE_VERSION, VaultProtectionParams, DEFAULT_LIMIT_PERCENT};
 
     #[event]
     #[derive(Drop, PartialEq, starknet::Event)]
@@ -100,7 +100,7 @@ pub mod Vaults {
         fn force_reset_protection_limit(
             ref self: ComponentState<TContractState>,
             vault_position: PositionId,
-            percentage_basis_points: u32,
+            percentage: u32,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
 
@@ -108,10 +108,7 @@ pub mod Vaults {
             let positions = get_dep_component!(@self, Positions);
             let position_tv_tr = positions.get_position_tv_tr(vault_position);
             let tv_at_check = position_tv_tr.total_value;
-            let max_tv_loss = mul_wide_and_floor_div(
-                tv_at_check.abs(), percentage_basis_points.into() * 10, 1000,
-            )
-                .unwrap();
+            let max_tv_loss = VaultConfigTrait::get_max_tv_loss(tv_at_check, percentage);
 
             let updated_config = VaultConfig {
                 version: current_config.version,
@@ -149,12 +146,12 @@ pub mod Vaults {
                     events::PerVaultProtectionLimitUpdated {
                         vault_position_id: vault_position,
                         old_limit: if old_limit == 0 {
-                            5
+                            DEFAULT_LIMIT_PERCENT
                         } else {
                             old_limit
                         },
                         new_limit: if limit == 0 {
-                            5
+                            DEFAULT_LIMIT_PERCENT
                         } else {
                             limit 
                         },
@@ -171,7 +168,6 @@ pub mod Vaults {
         +Drop<TContractState>,
         +AccessControlComponent::HasComponent<TContractState>,
         +SRC5Component::HasComponent<TContractState>,
-        +SystemTimeComponent::HasComponent<TContractState>,
         impl Assets: AssetsComponent::HasComponent<TContractState>,
         impl OperatorNonce: OperatorNonceComponent::HasComponent<TContractState>,
         impl Pausable: PausableComponent::HasComponent<TContractState>,
@@ -218,8 +214,7 @@ pub mod Vaults {
                     limit_from_storage
                 };
 
-                let max_tv_loss = mul_wide_and_floor_div(tv_at_check.abs(), limit.into() * 10, 1000)
-                    .unwrap();
+                let max_tv_loss = VaultConfigTrait::get_max_tv_loss(tv_at_check, limit);
                 let updated_config = VaultConfig {
                     version: current_config.version,
                     asset_id: current_config.asset_id,

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -133,8 +133,7 @@ pub mod Core {
         ExternalComponentsComponent::ExternalComponentsImpl<ContractState>;
 
     #[abi(embed_v0)]
-    impl VaultImpl = 
-            VaultsComponent::VaultsImpl<ContractState>;
+    impl VaultImpl = VaultsComponent::VaultsImpl<ContractState>;
 
 
     #[storage]

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -132,6 +132,10 @@ pub mod Core {
     impl ExternalComponentsImpl =
         ExternalComponentsComponent::ExternalComponentsImpl<ContractState>;
 
+    #[abi(embed_v0)]
+    impl VaultImpl = 
+            VaultsComponent::VaultsImpl<ContractState>;
+
 
     #[storage]
     struct Storage {


### PR DESCRIPTION
This PR updates the vault component with a new vault protection configuration which defines the max operator withrawable amount in a 24 hour window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new state and time-based logic that affects vault withdrawal safety limits; incorrect calculations or timestamp handling could unintentionally loosen or tighten withdrawal constraints.
> 
> **Overview**
> Adds a **vault protection mechanism** that snapshots each vault’s total value and computes a max daily TV-loss (default 5%) to bound how much value can be withdrawn within a 24h window, including a daily auto-refresh path via `get_vault_protection_config`.
> 
> Extends `VaultConfig` storage to track `last_tv_check_timestamp`, `tv_at_check`, and `max_tv_loss`, adds per-vault percentage overrides, and introduces governor-only admin entrypoints `force_reset_daily_protection_limit` and `update_vault_protection_limit`, emitting new events `VaultProtectionReset` and `VaultProtectionLimitUpdated` (also documented in `docs/spec.md`).
> 
> Plumbs the vault external ABI into `core.cairo` and performs minor component ordering adjustments in deposit/transfer managers (moving `SystemTime` earlier in `Event`/`Storage`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 572640ea19732d3aa078c46b0c07c29566e37318. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/234)
<!-- Reviewable:end -->
