### PR TITLE
fix(perps): fix test names

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_deposit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/vault_share_deposit_flow_tests.cairo
@@ -138,7 +138,7 @@ fn test_protocol_vault_cancel_deposit_vault_shares() {
 
 #[test]
 #[should_panic(expected: 'DEPOSIT_VAULT_SHARES_INTO_VAULT')]
-fn test_protocol_vault_deposit_vault_shares_1() {
+fn test_protocol_vault_deposit_vault_shares_into_vault_position() {
     // Setup:
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let vault_user_1 = state.new_user_with_position();

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -6599,7 +6599,7 @@ fn test_withdraw_synthetic_asset() {
 
 #[test]
 #[should_panic(expected: 'INACTIVE_ASSET')]
-fn test_withdraw_inactive_asset_should_fail() {
+fn test_withdraw_inactive_asset() {
     // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
@@ -6724,7 +6724,7 @@ fn test_withdraw_to_create_unhealthy_position() {
 
 #[test]
 #[should_panic(expected: 'ASSET_NOT_EXISTS')]
-fn test_withdraw_non_existent_asset_should_fail() {
+fn test_withdraw_non_existent_asset() {
     // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
@@ -6732,11 +6732,7 @@ fn test_withdraw_non_existent_asset_should_fail() {
 
     // Create position
     let user: User = Default::default();
-    let spot_asset_id: AssetId = cfg.collateral_cfg.collateral_id;
-    let spot_asset_balance: Balance = 1_000_i64.into();
-    init_position_with_spot_asset_balance(
-        cfg: @cfg, ref :state, :user, :spot_asset_id, :spot_asset_balance,
-    );
+    init_position(cfg: @cfg, ref :state, :user);
 
     // Withdraw non-existent asset
     let expiration = Time::now().add(delta: Time::days(1));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/236)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (naming and minor setup adjustment) with no production logic modifications.
> 
> **Overview**
> Renames several Cairo tests to better match their asserted failure conditions (e.g., vault-share deposit into a vault position and withdraw failures for inactive/non-existent assets).
> 
> Simplifies `test_withdraw_non_existent_asset` setup by initializing an empty position via `init_position` instead of seeding a spot-asset balance, keeping the test focused on the `ASSET_NOT_EXISTS` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f31add33c180d9c4a07aaa3faf2b50febd9d384. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->