### PR TITLE
feat(multi-collateral): add health check to apply interest

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -543,7 +543,6 @@ pub mod Positions {
             interest_rate_scale: u64,
         ) {
             let position = self.get_position_mut(:position_id);
-
             self
                 .validate_interest_in_range(
                     :position,
@@ -554,9 +553,20 @@ pub mod Positions {
                     :interest_rate_scale,
                 );
 
-            // Apply interest
+            // Validate position health and apply interest.
             if interest_amount.is_non_zero() {
-                position.collateral_balance.add_and_write(interest_amount.into());
+                let position_diff = PositionDiff {
+                    collateral_diff: interest_amount.into(), asset_diff: Option::None,
+                };
+                self
+                    .validate_healthy_or_healthier_position(
+                        position_id: position_id,
+                        position: position.into(),
+                        position_diff: position_diff,
+                        tvtr_before: Default::default(),
+                    );
+
+                self.apply_diff(position_id: position_id, position_diff: position_diff);
             }
         }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core position accounting by gating interest accrual behind a health check, which could change when/if interest updates succeed and potentially impact liquidatable positions.
> 
> **Overview**
> `apply_interest` now applies interest via a `PositionDiff` and first calls `validate_healthy_or_healthier_position`, rather than directly mutating `collateral_balance`.
> 
> This makes interest application subject to the same post-change health constraints used by other balance-changing flows, potentially reverting interest updates that would worsen an unhealthy position.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38afeeb7bfd47baf449a5be9fa72e3a05df427ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/241)
<!-- Reviewable:end -->
