### PR TITLE
chore(multi-collateral): add funding check to deleverage spot

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -609,7 +609,7 @@ pub mod Core {
         ) {
             /// Validations:
             self.pausable.assert_not_paused();
-            self.assets.validate_price_interval_integrity(Time::now());
+            self.assets.validate_assets_integrity();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
             self
                 .external_components


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes validation logic on a core state-changing path; could block or allow deleverages differently depending on funding/price timing assumptions.
> 
> **Overview**
> Updates `Core.deleverage_spot_asset` to call `self.assets.validate_assets_integrity()` instead of only `validate_price_interval_integrity(Time::now())`, so spot deleveraging now enforces the full assets-integrity gate (including funding/price validity) before executing the external deleverage manager call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ed8e50f716ebbeaef57379d97e9054e39a9a915. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/242)
<!-- Reviewable:end -->
