### PR TITLE
feat(multi-collateral): add interest amount to process deposit

### DIFF
--- a/devnet_tests/perpetuals_test_utils.py
+++ b/devnet_tests/perpetuals_test_utils.py
@@ -458,6 +458,7 @@ class PerpetualsTestUtils:
         position_id: int,
         amount: int,
         salt: int,
+        interest_amount: int = 0,
     ):
         """Private method for processing deposits. Use the specific flow methods instead."""
         invocation = (
@@ -470,6 +471,7 @@ class PerpetualsTestUtils:
                 formatted_position_id(position_id),
                 amount,
                 salt,
+                interest_amount,
                 auto_estimate=True,
             )
         )

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit.cairo
@@ -200,6 +200,7 @@ pub(crate) mod Deposit {
             position_id: PositionId,
             quantized_amount: u64,
             salt: felt252,
+            interest_amount: i64,
         ) {
             /// Validations:
             get_dep_component!(@self, Pausable).assert_not_paused();
@@ -214,6 +215,7 @@ pub(crate) mod Deposit {
                     position_id: position_id,
                     quantized_amount: quantized_amount,
                     salt: salt,
+                    interest_amount: interest_amount,
                 );
         }
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -44,6 +44,7 @@ pub trait IDepositExternal<TContractState> {
         position_id: PositionId,
         quantized_amount: u64,
         salt: felt252,
+        interest_amount: i64,
     );
     fn get_deposit_status(self: @TContractState, deposit_hash: HashType) -> DepositStatus;
     fn get_cancel_delay(self: @TContractState) -> TimeDelta;
@@ -232,6 +233,7 @@ pub(crate) mod DepositManager {
             position_id: PositionId,
             quantized_amount: u64,
             salt: felt252,
+            interest_amount: i64,
         ) {
             let (token_contract, quantum, position_diff) = if (self
                 .assets
@@ -239,7 +241,8 @@ pub(crate) mod DepositManager {
                 let token_contract = self.assets.get_base_collateral_token_contract();
                 let quantum = self.assets.get_collateral_quantum();
                 let position_diff = PositionDiff {
-                    collateral_diff: quantized_amount.into(), asset_diff: Option::None,
+                    collateral_diff: quantized_amount.into() + interest_amount.into(),
+                    asset_diff: Option::None,
                 };
                 (token_contract, quantum, position_diff)
             } else {
@@ -249,7 +252,7 @@ pub(crate) mod DepositManager {
                     contract_address: asset_config.token_contract.expect('NO_ERC20_CONFIGURED'),
                 };
                 let position_diff = PositionDiff {
-                    collateral_diff: 0_i64.into(),
+                    collateral_diff: interest_amount.into(),
                     asset_diff: Option::Some((asset_id, quantized_amount.into())),
                 };
                 (token_contract, asset_config.quantum, position_diff)
@@ -275,6 +278,20 @@ pub(crate) mod DepositManager {
                 DepositStatus::PENDING(_) => {},
             }
             self.deposits.registered_deposits.write(deposit_hash, DepositStatus::PROCESSED);
+
+            let position = self.positions.get_position_mut(:position_id);
+            // Validate interest in range
+            self.positions.validate_interest_in_range(:position, :position_id, :interest_amount);
+            // Validate healthy or healthier position
+            self
+                .positions
+                .validate_healthy_or_healthier_position(
+                    :position_id,
+                    position: position.into(),
+                    :position_diff,
+                    tvtr_before: Default::default(),
+                );
+
             self.positions.apply_diff(:position_id, :position_diff);
             self
                 .emit(

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/interface.cairo
@@ -41,6 +41,7 @@ pub trait IDeposit<TContractState> {
         position_id: PositionId,
         quantized_amount: u64,
         salt: felt252,
+        interest_amount: i64,
     );
     fn get_deposit_status(self: @TContractState, deposit_hash: HashType) -> DepositStatus;
     fn get_cancel_delay(self: @TContractState) -> TimeDelta;

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -39,6 +39,7 @@ fn test_process_deposit_only_operator() {
             position_id: POSITION_ID_100,
             quantized_amount: DEPOSIT_AMOUNT,
             salt: 0,
+            interest_amount: 0,
         );
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -150,6 +150,7 @@ pub struct DepositInfo {
     quantized_amount: u64,
     salt: felt252,
     asset_id: AssetId,
+    interest_amount: i64,
 }
 
 #[derive(Copy, Drop)]
@@ -915,11 +916,15 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             :salt,
         );
 
-        DepositInfo { depositor, position_id, quantized_amount, salt, asset_id }
+        DepositInfo {
+            depositor, position_id, quantized_amount, salt, asset_id, interest_amount: 0_i64,
+        }
     }
 
     fn cancel_deposit(ref self: PerpsTestsFacade, deposit_info: DepositInfo) {
-        let DepositInfo { depositor, position_id, quantized_amount, salt, asset_id } = deposit_info;
+        let DepositInfo {
+            depositor, position_id, quantized_amount, salt, asset_id, interest_amount: _,
+        } = deposit_info;
         let token_state = self.find_contract_for_asset_id(:asset_id);
         let user_balance_before = token_state.balance_of(depositor.address);
         let contract_balance_before = token_state.balance_of(self.perpetuals_contract);
@@ -964,7 +969,9 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     }
 
     fn process_deposit(ref self: PerpsTestsFacade, deposit_info: DepositInfo) {
-        let DepositInfo { depositor, position_id, quantized_amount, salt, asset_id } = deposit_info;
+        let DepositInfo {
+            depositor, position_id, quantized_amount, salt, asset_id, interest_amount,
+        } = deposit_info;
         let collateral_balance_before = if (asset_id == self.collateral_id) {
             self.get_position_collateral_balance(position_id)
         } else {
@@ -983,6 +990,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 :position_id,
                 :quantized_amount,
                 :salt,
+                :interest_amount,
             );
 
         if (asset_id == self.collateral_id) {
@@ -2309,6 +2317,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             quantized_amount: deposit_event.quantized_amount,
             salt,
             asset_id: vault.asset_id,
+            interest_amount: 0_i64,
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
@@ -543,6 +543,7 @@ pub fn deposit_vault_share(
             position_id: user.position_id,
             quantized_amount: quantized_amount,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/protocol_vault_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/protocol_vault_tests.cairo
@@ -147,6 +147,7 @@ fn test_protocol_vault_initialisation_logic() {
             position_id: vault_user.position_id,
             quantized_amount: VAULT_DEPOSIT_AMOUNT,
             salt: vault_user.salt_counter,
+            interest_amount: 0,
         );
 
     // deposit into user position
@@ -172,6 +173,7 @@ fn test_protocol_vault_initialisation_logic() {
             position_id: depositing_user.position_id,
             quantized_amount: VAULT_DEPOSIT_AMOUNT,
             salt: depositing_user.salt_counter,
+            interest_amount: 0,
         );
 
     let deployed_vault = deploy_protocol_vault_with_dispatcher(

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -153,6 +153,7 @@ fn test_expiration_validation() {
             position_id: user.position_id,
             quantized_amount: amount,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Test:
@@ -385,6 +386,7 @@ fn test_signature_validation() {
             position_id: user_a.position_id,
             quantized_amount: amount,
             salt: user_a.salt_counter,
+            interest_amount: 0,
         );
 
     cheat_caller_address_once(:contract_address, caller_address: user_b.address);
@@ -402,6 +404,7 @@ fn test_signature_validation() {
             position_id: user_b.position_id,
             quantized_amount: amount,
             salt: user_b.salt_counter,
+            interest_amount: 0,
         );
 
     // Build orders.
@@ -2304,6 +2307,7 @@ fn test_successful_process_deposit() {
             position_id: user.position_id,
             quantized_amount: DEPOSIT_AMOUNT,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Catch the event.
@@ -2574,6 +2578,7 @@ fn test_cancel_already_done_deposit() {
             position_id: user.position_id,
             quantized_amount: DEPOSIT_AMOUNT,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     start_cheat_block_timestamp_global(
@@ -3069,6 +3074,7 @@ fn test_successful_forced_withdraw_operator_executes() {
             position_id: user.position_id,
             quantized_amount: deposit_amount,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Check user balance before forced withdraw request
@@ -3222,6 +3228,7 @@ fn test_successful_forced_withdraw_user_executes() {
             position_id: user.position_id,
             quantized_amount: deposit_amount,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Check user balance before forced withdraw request
@@ -3493,6 +3500,7 @@ fn test_forced_withdraw_after_operator_processed_withdraw() {
             position_id: user.position_id,
             quantized_amount: deposit_amount,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Fund user with premium cost
@@ -3617,6 +3625,7 @@ fn test_withdraw_after_user_forced_withdraw_executed() {
             position_id: user.position_id,
             quantized_amount: deposit_amount,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Fund user with premium cost
@@ -4499,6 +4508,7 @@ fn test_validate_asset_prices_pending_asset() {
             position_id: user.position_id,
             quantized_amount: DEPOSIT_AMOUNT,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
     // If no assertion error is thrown, the test passes
 }
@@ -4636,6 +4646,7 @@ fn test_validate_prices_no_update_needed() {
             position_id: user.position_id,
             quantized_amount: DEPOSIT_AMOUNT,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     assert!(state.assets.get_last_price_validation() == old_time);
@@ -5879,6 +5890,7 @@ fn test_successful_vault_share_process_deposit() {
             position_id: user.position_id,
             quantized_amount: DEPOSIT_AMOUNT,
             salt: user.salt_counter,
+            interest_amount: 0,
         );
 
     // Catch the event.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the deposit-processing entrypoint and position balance adjustments, which impacts core accounting and health checks for positions. Interface/ABI changes also require all callers to be updated and could break integrations if missed.
> 
> **Overview**
> `process_deposit` now accepts an `interest_amount` parameter end-to-end (deposit interface/component, `DepositManager`, and devnet test helpers), updating on-chain deposit processing to apply an additional signed collateral delta alongside the deposited asset amount.
> 
> `DepositManager.process_deposit` adds validations for the passed interest (range check and *healthy-or-healthier* position validation) before applying the resulting `PositionDiff`. All Cairo tests and the flow-test facade are updated to pass `interest_amount` (defaulting to `0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b1e90c6e834e3aea0a00bf494e9510a5ecd11bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/243)
<!-- Reviewable:end -->
