### PR TITLE
feat(perps): allow pending assets withdraw

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -474,9 +474,6 @@ pub(crate) mod WithdrawalManager {
                     SyntheticTrait::at_asset_type(entry) != AssetType::SYNTHETIC,
                     CANNOT_WITHDRAW_SYNTHETIC,
                 );
-                assert(
-                    SyntheticTrait::at_asset_status(entry) == AssetStatus::ACTIVE, INACTIVE_ASSET,
-                );
                 let signed_amount: i64 = -amount.try_into().expect(AMOUNT_OVERFLOW);
                 self
                     .positions

--- a/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
@@ -421,6 +421,10 @@ pub fn setup_state_with_pending_spot_asset(
             risk_factor_tier_size: MAX_U128,
             quorum: *cfg.spot_cfg.quorum,
         );
+    cfg
+        .spot_cfg
+        .token_state
+        .fund(recipient: test_address(), amount: CONTRACT_INIT_BALANCE.try_into().unwrap());
     state
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -6640,8 +6640,7 @@ fn test_withdraw_synthetic_asset() {
 }
 
 #[test]
-#[should_panic(expected: 'INACTIVE_ASSET')]
-fn test_withdraw_inactive_asset() {
+fn test_withdraw_pending_asset() {
     // Setup:
     let cfg: PerpetualsInitConfig = Default::default();
     let token_state = cfg.collateral_cfg.token_cfg.deploy();
@@ -6692,6 +6691,12 @@ fn test_withdraw_inactive_asset() {
             :expiration,
             salt: withdraw_args.salt,
         );
+    validate_asset_balance(
+        ref :state,
+        position_id: user.position_id,
+        asset_id: spot_asset_id,
+        expected_balance: 900_i64.into(),
+    );
 }
 
 #[test]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/244)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes withdrawal validation for non-base collateral assets, which can affect funds flow and risk checks if pending assets are misconfigured or unfunded.
> 
> **Overview**
> Permits withdrawing non-synthetic, non-base collateral spot assets even when their asset config is not `ACTIVE` by removing the `INACTIVE_ASSET` status check in `WithdrawalManager::_withdraw`.
> 
> Updates tests to reflect the new behavior by replacing the "inactive asset" panic expectation with a successful pending-asset withdrawal assertion, and adjusts test setup to fund the spot token contract so withdrawals can transfer out tokens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea2dda028aa33c6ef507f6e0d64d4f40f04848ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->