### PR TITLE
refactor(multi-collateral): refactor validate interest in range

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -63,6 +63,7 @@ pub(crate) mod DepositManager {
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::position::PositionId;
     use starknet::storage::{StorageMapReadAccess, StorageMapWriteAccess, StoragePointerReadAccess};
@@ -110,6 +111,8 @@ pub(crate) mod DepositManager {
         RolesEvent: RolesComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
+        #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
         Deposit: events::Deposit,
         DepositCanceled: events::DepositCanceled,
         DepositProcessed: events::DepositProcessed,
@@ -140,6 +143,8 @@ pub(crate) mod DepositManager {
         pub request_approvals: RequestApprovalsComponent::Storage,
         #[substorage(v0)]
         pub vaults: VaultsComponent::Storage,
+        #[substorage(v0)]
+        system_time: SystemTimeComponent::Storage,
     }
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
@@ -154,8 +159,8 @@ pub(crate) mod DepositManager {
     component!(
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
-
     component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
 
     #[abi(embed_v0)]
     impl TypedComponent of ITypedComponent<ContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -1,7 +1,7 @@
 #[starknet::component]
 pub mod Positions {
     use core::nullable::{FromNullableResult, match_nullable};
-    use core::num::traits::Zero;
+    use core::num::traits::{Pow, Zero};
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
@@ -57,6 +57,7 @@ pub mod Positions {
     use crate::core::errors::{
         AMOUNT_OVERFLOW, INVALID_AMOUNT_SIGN, INVALID_BASE_CHANGE, INVALID_INTEREST_RATE,
         INVALID_SAME_POSITIONS, INVALID_ZERO_AMOUNT, NO_DELEVERAGE_VAULT_SHARES,
+        ZERO_MAX_INTEREST_RATE,
     };
     use crate::core::types::asset::synthetic::{AssetBalanceDiffEnriched, AssetType};
     use crate::core::types::balance::BalanceDiff;
@@ -72,6 +73,10 @@ pub mod Positions {
     #[storage]
     pub struct Storage {
         pub positions: Map<PositionId, Position>,
+        // Maximum interest rate per second (32-bit fixed-point with 32-bit fractional part).
+        // Example: max_interest_rate_per_sec = 10 means the rate is 10 / 2^32 ≈ 0.000000232 per
+        // second, which is approximately 7.4% per year.
+        pub max_interest_rate_per_sec: u32,
     }
 
     #[event]
@@ -405,11 +410,13 @@ pub mod Positions {
         impl Pausable: PausableComponent::HasComponent<TContractState>,
         impl Roles: RolesComponent::HasComponent<TContractState>,
         impl RequestApprovals: RequestApprovalsComponent::HasComponent<TContractState>,
+        impl SystemTime: SystemTimeComponent::HasComponent<TContractState>,
     > of InternalTrait<TContractState> {
         fn initialize(
             ref self: ComponentState<TContractState>,
             fee_position_owner_public_key: PublicKey,
             insurance_fund_position_owner_public_key: PublicKey,
+            max_interest_rate_per_sec: u32,
         ) {
             // Checks that the component has not been initialized yet.
             let fee_position = self.positions.entry(FEE_POSITION);
@@ -418,6 +425,7 @@ pub mod Positions {
             // Checks that the input public keys are non-zero.
             assert(fee_position_owner_public_key.is_non_zero(), INVALID_ZERO_PUBLIC_KEY);
             assert(insurance_fund_position_owner_public_key.is_non_zero(), INVALID_ZERO_PUBLIC_KEY);
+            assert(max_interest_rate_per_sec.is_non_zero(), ZERO_MAX_INTEREST_RATE);
 
             // Create fee positions.
             fee_position.version.write(POSITION_VERSION);
@@ -428,6 +436,9 @@ pub mod Positions {
             insurance_fund_position
                 .owner_public_key
                 .write(insurance_fund_position_owner_public_key);
+
+            // Store max interest rate per second
+            self.max_interest_rate_per_sec.write(max_interest_rate_per_sec);
         }
 
         fn apply_diff(
@@ -544,7 +555,7 @@ pub mod Positions {
         ) {
             let position = self.get_position_mut(:position_id);
             self
-                .validate_interest_in_range(
+                .validate_interest_in_range_with_params(
                     :position,
                     :position_id,
                     :interest_amount,
@@ -570,7 +581,36 @@ pub mod Positions {
             }
         }
 
+        /// Validates that the interest amount is within the allowed range.
+        /// This version reads current_time, max_interest_rate_per_sec, and calculates
+        /// interest_rate_scale internally.
+        /// Use this when you want the function to read these values from storage/components.
         fn validate_interest_in_range(
+            ref self: ComponentState<TContractState>,
+            position: StoragePath<Mutable<Position>>,
+            position_id: PositionId,
+            interest_amount: i64,
+        ) {
+            let system_time_component = get_dep_component!(@self, SystemTime);
+            let current_time = system_time_component.get_system_time();
+            let max_interest_rate_per_sec = self.max_interest_rate_per_sec.read();
+            let interest_rate_scale: u64 = 2_u64.pow(32);
+            self
+                .validate_interest_in_range_with_params(
+                    :position,
+                    :position_id,
+                    :interest_amount,
+                    :current_time,
+                    :max_interest_rate_per_sec,
+                    :interest_rate_scale,
+                );
+        }
+
+        /// Validates that the interest amount is within the allowed range.
+        /// This version receives all parameters explicitly (current_time,
+        /// max_interest_rate_per_sec, interest_rate_scale).
+        /// Use this when you already have these values to avoid redundant storage reads.
+        fn validate_interest_in_range_with_params(
             ref self: ComponentState<TContractState>,
             position: StoragePath<Mutable<Position>>,
             position_id: PositionId,
@@ -857,6 +897,7 @@ pub mod Positions {
         +Drop<TContractState>,
         +AccessControlComponent::HasComponent<TContractState>,
         +SRC5Component::HasComponent<TContractState>,
+        +SystemTimeComponent::HasComponent<TContractState>,
         impl Assets: AssetsComponent::HasComponent<TContractState>,
         impl OperatorNonce: OperatorNonceComponent::HasComponent<TContractState>,
         impl Pausable: PausableComponent::HasComponent<TContractState>,

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -69,6 +69,7 @@ pub(crate) mod TransferManager {
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalImpl as OperatorNonceInternal;
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::AssetId;
     use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
     use perpetuals::core::types::position::{PositionId, PositionTrait};
@@ -122,6 +123,8 @@ pub(crate) mod TransferManager {
         RolesEvent: RolesComponent::Event,
         #[flat]
         VaultsEvent: VaultsComponent::Event,
+        #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
     }
 
     #[storage]
@@ -147,6 +150,8 @@ pub(crate) mod TransferManager {
         pub request_approvals: RequestApprovalsComponent::Storage,
         #[substorage(v0)]
         pub vaults: VaultsComponent::Storage,
+        #[substorage(v0)]
+        system_time: SystemTimeComponent::Storage,
     }
 
     component!(path: FulfillmentComponent, storage: fulfillment_tracking, event: FulfillmentEvent);
@@ -161,6 +166,7 @@ pub(crate) mod TransferManager {
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
     component!(path: VaultsComponent, storage: vaults, event: VaultsEvent);
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
 
     #[abi(embed_v0)]
     impl TypedComponent of ITypedComponent<ContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults.cairo
@@ -38,6 +38,7 @@ pub mod Vaults {
     use starkware_utils::time::time::validate_expiration;
     use vault::interface::{IProtocolVaultDispatcher, IProtocolVaultDispatcherTrait};
     use crate::core::components::snip::SNIP12MetadataImpl;
+    use crate::core::components::system_time::SystemTimeComponent;
     use crate::core::components::vaults::events;
     use crate::core::types::vault::ConvertPositionToVault;
     use crate::core::utils::validate_signature;
@@ -79,6 +80,7 @@ pub mod Vaults {
         +Drop<TContractState>,
         +AccessControlComponent::HasComponent<TContractState>,
         +SRC5Component::HasComponent<TContractState>,
+        +SystemTimeComponent::HasComponent<TContractState>,
         impl Assets: AssetsComponent::HasComponent<TContractState>,
         impl OperatorNonce: OperatorNonceComponent::HasComponent<TContractState>,
         impl Pausable: PausableComponent::HasComponent<TContractState>,

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -112,9 +112,7 @@ pub(crate) mod WithdrawalManager {
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
     use perpetuals::core::components::assets::AssetsComponent::InternalImpl as AssetsInternal;
-    use perpetuals::core::components::assets::errors::{
-        ASSET_NOT_EXISTS, CANNOT_WITHDRAW_SYNTHETIC, INACTIVE_ASSET,
-    };
+    use perpetuals::core::components::assets::errors::{ASSET_NOT_EXISTS, CANNOT_WITHDRAW_SYNTHETIC};
     use perpetuals::core::components::assets::interface::IAssets;
     use perpetuals::core::components::deposit::Deposit::InternalImpl as DepositInternal;
     use perpetuals::core::components::fulfillment::fulfillment::Fulfillement as FulfillmentComponent;
@@ -123,6 +121,7 @@ pub(crate) mod WithdrawalManager {
     use perpetuals::core::components::positions::Positions as PositionsComponent;
     use perpetuals::core::components::positions::Positions::InternalTrait as PositionsInternal;
     use perpetuals::core::components::snip::SNIP12MetadataImpl;
+    use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::errors::{
         AMOUNT_OVERFLOW, FORCED_WAIT_REQUIRED, INVALID_ZERO_AMOUNT, SIGNED_TX_EXPIRED,
         TRANSFER_FAILED,
@@ -150,7 +149,6 @@ pub(crate) mod WithdrawalManager {
     use starkware_utils::time::time::{Time, TimeDelta, validate_expiration};
     use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_WITHDRAWALS;
     use crate::core::components::external_components::named_component::ITypedComponent;
-    use crate::core::types::asset::AssetStatus;
     use crate::core::types::asset::synthetic::AssetType;
     use super::{
         ForcedWithdraw, ForcedWithdrawRequest, IWithdrawalManager, Signature, Timestamp, Withdraw,
@@ -184,6 +182,8 @@ pub(crate) mod WithdrawalManager {
         AccessControlEvent: AccessControlComponent::Event,
         #[flat]
         RolesEvent: RolesComponent::Event,
+        #[flat]
+        SystemTimeEvent: SystemTimeComponent::Event,
     }
 
     #[storage]
@@ -207,6 +207,8 @@ pub(crate) mod WithdrawalManager {
         src5: SRC5Component::Storage,
         #[substorage(v0)]
         pub request_approvals: RequestApprovalsComponent::Storage,
+        #[substorage(v0)]
+        system_time: SystemTimeComponent::Storage,
         // Timelock before forced actions can be executed.
         forced_action_timelock: TimeDelta,
         // Cost for executing forced actions.
@@ -224,6 +226,7 @@ pub(crate) mod WithdrawalManager {
     component!(
         path: RequestApprovalsComponent, storage: request_approvals, event: RequestApprovalsEvent,
     );
+    component!(path: SystemTimeComponent, storage: system_time, event: SystemTimeEvent);
 
     #[abi(embed_v0)]
     impl TypedComponent of ITypedComponent<ContractState> {

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -171,10 +171,6 @@ pub mod Core {
         forced_action_timelock: TimeDelta,
         // Cost for executing forced actions.
         premium_cost: u64,
-        // Maximum interest rate per second (32-bit fixed-point with 32-bit fractional part).
-        // Example: max_interest_rate_per_sec = 10 means the rate is 10 / 2^32 ≈ 0.000000232 per
-        // second, which is approximately 7.4% per year.
-        max_interest_rate_per_sec: u32,
         // Whether the new escape hatch logic is enabled.
         // Off by default to be enabled one time in the future
         forced_actions_enabled: bool,
@@ -266,13 +262,15 @@ pub mod Core {
         self.deposits.initialize(:cancel_delay);
         self
             .positions
-            .initialize(:fee_position_owner_public_key, :insurance_fund_position_owner_public_key);
+            .initialize(
+                :fee_position_owner_public_key,
+                :insurance_fund_position_owner_public_key,
+                :max_interest_rate_per_sec,
+            );
 
         assert(forced_action_timelock.is_non_zero(), INVALID_ZERO_TIMEOUT);
         self.forced_action_timelock.write(TimeDelta { seconds: forced_action_timelock });
         self.premium_cost.write(premium_cost);
-        assert(max_interest_rate_per_sec.is_non_zero(), ZERO_MAX_INTEREST_RATE);
-        self.max_interest_rate_per_sec.write(max_interest_rate_per_sec);
         self.system_time.initialize();
     }
 
@@ -1202,7 +1200,7 @@ pub mod Core {
 
             // Read once and pass as arguments to avoid redundant storage reads
             let current_time = self.get_system_time();
-            let max_interest_rate_per_sec = self.max_interest_rate_per_sec.read();
+            let max_interest_rate_per_sec = self.positions.max_interest_rate_per_sec.read();
             let interest_rate_scale: u64 = 2_u64.pow(32);
 
             let mut i: usize = 0;
@@ -1262,7 +1260,7 @@ pub mod Core {
             self.forced_actions_enabled.write(true);
         }
         fn get_max_interest_rate_per_sec(self: @ContractState) -> u32 {
-            self.max_interest_rate_per_sec.read()
+            self.positions.max_interest_rate_per_sec.read()
         }
 
         /// Sets the maximum interest rate per second.
@@ -1276,7 +1274,7 @@ pub mod Core {
         fn set_max_interest_rate_per_sec(ref self: ContractState, max_interest_rate_per_sec: u32) {
             self.roles.only_app_governor();
             assert(max_interest_rate_per_sec.is_non_zero(), ZERO_MAX_INTEREST_RATE);
-            self.max_interest_rate_per_sec.write(max_interest_rate_per_sec);
+            self.positions.max_interest_rate_per_sec.write(max_interest_rate_per_sec);
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core financial invariants around interest application and changes where the max rate is stored/read, which could affect runtime behavior and upgrades if any call paths still expect the old storage layout.
> 
> **Overview**
> Moves `max_interest_rate_per_sec` from `Core` storage into `Positions` storage (initialized in `Positions::initialize`) and updates `Core` getters/setters and `apply_interests` to read/write it via `self.positions`.
> 
> Refactors interest validation by splitting it into `validate_interest_in_range` (reads system time + max rate) and `validate_interest_in_range_with_params` (accepts pre-read params), and updates `apply_interest` to use the param-based path to avoid redundant reads.
> 
> Plumbs `SystemTimeComponent` into `DepositManager`, `TransferManager`, `WithdrawalManager`, and `Vaults` as a subcomponent/event dependency (no behavior changes shown beyond component wiring), plus minor import cleanup in withdrawals.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e664f9c45f5c5ce1f917b00991e363e638bda279. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/245)
<!-- Reviewable:end -->
