### PR TITLE
feat(multi-collateral): add interest amount to multi-trade

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -418,6 +418,11 @@ pub mod Core {
             self.operator_nonce.use_checked_nonce(:operator_nonce);
             self.assets.validate_assets_integrity();
 
+            // Read interest validation parameters once for all settlements
+            let current_time = self.get_system_time();
+            let max_interest_rate_per_sec = self.get_max_interest_rate_per_sec();
+            let interest_rate_scale: u64 = 2_u64.pow(32);
+
             let mut tvtr_cache: Felt252Dict<Nullable<PositionTVTR>> = Default::default();
 
             for _trade in trades {
@@ -437,6 +442,11 @@ pub mod Core {
                         actual_amount_quote_a: trade.actual_amount_quote_a,
                         actual_fee_a: trade.actual_fee_a,
                         actual_fee_b: trade.actual_fee_b,
+                        interest_amount_a: trade.interest_amount_a,
+                        interest_amount_b: trade.interest_amount_b,
+                        :current_time,
+                        :max_interest_rate_per_sec,
+                        :interest_rate_scale,
                         tvtr_a_before: cached_pos_a_tvtr,
                         tvtr_b_before: cached_pos_b_tvtr,
                         check_signature: true,
@@ -505,6 +515,9 @@ pub mod Core {
             self.assets.validate_assets_integrity();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
 
+            // Pass default values for interest validation parameters since interest_amount_a and
+            // interest_amount_b are zero. Interest validation is skipped when interest amounts are
+            // zero, so these parameters are not used.
             self
                 ._execute_trade(
                     :signature_a,
@@ -515,6 +528,11 @@ pub mod Core {
                     :actual_amount_quote_a,
                     :actual_fee_a,
                     :actual_fee_b,
+                    interest_amount_a: 0,
+                    interest_amount_b: 0,
+                    current_time: Timestamp { seconds: 0 },
+                    max_interest_rate_per_sec: 0,
+                    interest_rate_scale: 0,
                     tvtr_a_before: Default::default(),
                     tvtr_b_before: Default::default(),
                     check_signature: true,
@@ -992,6 +1010,10 @@ pub mod Core {
             }
 
             // Execute trade.
+
+            // Pass default values for interest validation parameters since interest_amount_a and
+            // interest_amount_b are zero. Interest validation is skipped when interest amounts are
+            // zero, so these parameters are not used.
             self
                 ._execute_trade(
                     signature_a: array![].span(),
@@ -1002,6 +1024,11 @@ pub mod Core {
                     actual_amount_quote_a: order_a.quote_amount,
                     actual_fee_a: Zero::zero(),
                     actual_fee_b: Zero::zero(),
+                    interest_amount_a: 0,
+                    interest_amount_b: 0,
+                    current_time: Timestamp { seconds: 0 },
+                    max_interest_rate_per_sec: 0,
+                    interest_rate_scale: 0,
                     tvtr_a_before: Default::default(),
                     tvtr_b_before: Default::default(),
                     check_signature: false,
@@ -1303,6 +1330,11 @@ pub mod Core {
             actual_amount_quote_a: i64,
             actual_fee_a: u64,
             actual_fee_b: u64,
+            interest_amount_a: i64,
+            interest_amount_b: i64,
+            current_time: Timestamp,
+            max_interest_rate_per_sec: u32,
+            interest_rate_scale: u64,
             tvtr_a_before: Nullable<PositionTVTR>,
             tvtr_b_before: Nullable<PositionTVTR>,
             check_signature: bool,
@@ -1324,6 +1356,32 @@ pub mod Core {
 
             let position_a = self.positions.get_position_snapshot(position_id_a);
             let position_b = self.positions.get_position_snapshot(position_id_b);
+
+            // Validate interest in range for both positions before applying diffs
+            let position_mut_a = self.positions.get_position_mut(position_id_a);
+            self
+                .positions
+                .validate_interest_in_range_with_params(
+                    position: position_mut_a,
+                    position_id: position_id_a,
+                    interest_amount: interest_amount_a,
+                    :current_time,
+                    :max_interest_rate_per_sec,
+                    :interest_rate_scale,
+                );
+
+            let position_mut_b = self.positions.get_position_mut(position_id_b);
+            self
+                .positions
+                .validate_interest_in_range_with_params(
+                    position: position_mut_b,
+                    position_id: position_id_b,
+                    interest_amount: interest_amount_b,
+                    :current_time,
+                    :max_interest_rate_per_sec,
+                    :interest_rate_scale,
+                );
+
             // Signatures validation:
             let (hash_a, hash_b) = match check_signature {
                 true => (
@@ -1367,13 +1425,17 @@ pub mod Core {
 
             /// Positions' Diffs:
             let position_diff_a = PositionDiff {
-                collateral_diff: actual_amount_quote_a.into() - actual_fee_a.into(),
+                collateral_diff: actual_amount_quote_a.into()
+                    - actual_fee_a.into()
+                    + interest_amount_a.into(),
                 asset_diff: Option::Some((order_a.base_asset_id, actual_amount_base_a.into())),
             };
 
             // Passing the negative of actual amounts to order_b as it is linked to order_a.
             let position_diff_b = PositionDiff {
-                collateral_diff: -actual_amount_quote_a.into() - actual_fee_b.into(),
+                collateral_diff: -actual_amount_quote_a.into()
+                    - actual_fee_b.into()
+                    + interest_amount_b.into(),
                 asset_diff: Option::Some((order_b.base_asset_id, -actual_amount_base_a.into())),
             };
 

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -16,6 +16,8 @@ pub struct Settlement {
     pub actual_amount_quote_a: i64,
     pub actual_fee_a: u64,
     pub actual_fee_b: u64,
+    pub interest_amount_a: i64,
+    pub interest_amount_b: i64,
 }
 
 #[starknet::interface]

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/multi_trade_regression_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/multi_trade_regression_tests.cairo
@@ -110,6 +110,8 @@ fn SETTLEMENT_1() -> Settlement {
         actual_amount_quote_a: -442389000_i64,
         actual_fee_a: 0x184d1.try_into().unwrap(),
         actual_fee_b: 0,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -151,6 +153,8 @@ fn SETTLEMENT_2() -> Settlement {
         actual_amount_quote_a: -93927900_i64,
         actual_fee_a: 0,
         actual_fee_b: 0x5bb9.try_into().unwrap(),
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -192,6 +196,8 @@ fn SETTLEMENT_3() -> Settlement {
         actual_amount_quote_a: -25082200_i64,
         actual_fee_a: 0,
         actual_fee_b: 0x187e.try_into().unwrap(),
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1464,6 +1464,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             actual_amount_quote_a: quote,
             actual_fee_a: fee_a,
             actual_fee_b: fee_b,
+            interest_amount_a: 0,
+            interest_amount_b: 0,
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/performance_tests/performance_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/performance_tests/performance_tests.cairo
@@ -79,6 +79,8 @@ fn settlement_1() -> Settlement {
         actual_amount_quote_a: -11053750_i64,
         actual_fee_a: 0xacb,
         actual_fee_b: 0x0,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -120,6 +122,8 @@ fn settlement_2() -> Settlement {
         actual_amount_quote_a: -147963000_i64,
         actual_fee_a: 0x820b,
         actual_fee_b: 0x0,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -161,6 +165,8 @@ fn settlement_3() -> Settlement {
         actual_amount_quote_a: -124117920_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0x6d16,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -202,6 +208,8 @@ fn settlement_4() -> Settlement {
         actual_amount_quote_a: -217850000_i64,
         actual_fee_a: 0xbf78,
         actual_fee_b: 0x0,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -243,6 +251,8 @@ fn settlement_5() -> Settlement {
         actual_amount_quote_a: -177742500_i64,
         actual_fee_a: 0x9c38,
         actual_fee_b: 0x0,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -284,6 +294,8 @@ fn settlement_6() -> Settlement {
         actual_amount_quote_a: -13084650_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0xb80,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -326,6 +338,8 @@ fn settlement_7() -> Settlement {
         actual_amount_quote_a: -12210520_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0xabb,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -367,6 +381,8 @@ fn settlement_8() -> Settlement {
         actual_amount_quote_a: -10464600_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0x932,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -408,6 +424,8 @@ fn settlement_9() -> Settlement {
         actual_amount_quote_a: -84584970_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0x4a57,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -449,6 +467,8 @@ fn settlement_10() -> Settlement {
         actual_amount_quote_a: -82837150_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0x48ce,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -490,6 +510,8 @@ fn settlement_11() -> Settlement {
         actual_amount_quote_a: -24545700_i64,
         actual_fee_a: 0x17f8,
         actual_fee_b: 0x0,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 
@@ -531,6 +553,8 @@ fn settlement_12() -> Settlement {
         actual_amount_quote_a: -31881600_i64,
         actual_fee_a: 0x0,
         actual_fee_b: 0x1f22,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core settlement accounting by changing how collateral diffs are computed and adding interest validation in `_execute_trade`, which could affect balances if parameters are mis-supplied or validation is incorrect.
> 
> **Overview**
> `multi_trade` now accepts per-settlement `interest_amount_a`/`interest_amount_b` and passes them through to `_execute_trade`, which **adds interest into each position’s collateral diff** alongside quote and fees.
> 
> Trade execution now **validates each position’s interest amount is within the allowed rate range** (using shared `current_time`/`max_interest_rate_per_sec`/`2^32` scale read once per `multi_trade` call); single `trade` and `forced_trade` route through the same `_execute_trade` path with zero-interest defaults. Tests and helper facades are updated to populate the new `Settlement` fields (currently set to `0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c26e1376614cc428a373e4e4dd9f09b2a8cf117e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/246)
<!-- Reviewable:end -->
