### PR TITLE
feat(multi-collateral): apply interest in transfer

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -52,6 +52,8 @@ pub trait ITransferManager<TContractState> {
         amount: u64,
         expiration: Timestamp,
         salt: felt252,
+        interest_amount_sender: i64,
+        interest_amount_recipient: i64,
     );
 }
 
@@ -255,6 +257,8 @@ pub(crate) mod TransferManager {
             amount: u64,
             expiration: Timestamp,
             salt: felt252,
+            interest_amount_sender: i64,
+            interest_amount_recipient: i64,
         ) {
             validate_expiration(:expiration, err: SIGNED_TX_EXPIRED);
             assert(recipient != position_id, INVALID_SAME_POSITIONS);
@@ -268,7 +272,35 @@ pub(crate) mod TransferManager {
                     },
                     public_key: position.get_owner_public_key(),
                 );
-            self._execute_transfer(:recipient, :position_id, collateral_id: asset_id, :amount);
+            let sender_position = self.positions.get_position_mut(:position_id);
+            let recipient_position = self.positions.get_position_mut(position_id: recipient);
+
+            // Validate interest in range
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: sender_position,
+                    position_id: position_id,
+                    interest_amount: interest_amount_sender,
+                );
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: recipient_position,
+                    position_id: recipient,
+                    interest_amount: interest_amount_recipient,
+                );
+
+            // Execute transfer
+            self
+                ._execute_transfer(
+                    :recipient,
+                    :position_id,
+                    collateral_id: asset_id,
+                    :amount,
+                    :interest_amount_sender,
+                    :interest_amount_recipient,
+                );
             self
                 .emit(
                     Transfer {
@@ -292,6 +324,8 @@ pub(crate) mod TransferManager {
             position_id: PositionId,
             collateral_id: AssetId,
             amount: u64,
+            interest_amount_sender: i64,
+            interest_amount_recipient: i64,
         ) {
             // Parameters
 
@@ -300,11 +334,13 @@ pub(crate) mod TransferManager {
                 .assets
                 .get_collateral_id()) {
                 let position_diff_sender = PositionDiff {
-                    collateral_diff: -amount.into(), asset_diff: Option::None,
+                    collateral_diff: -amount.into() + interest_amount_sender.into(),
+                    asset_diff: Option::None,
                 };
 
                 let position_diff_recipient = PositionDiff {
-                    collateral_diff: amount.into(), asset_diff: Option::None,
+                    collateral_diff: amount.into() + interest_amount_recipient.into(),
+                    asset_diff: Option::None,
                 };
                 (position_diff_sender, position_diff_recipient)
             } else {
@@ -328,12 +364,12 @@ pub(crate) mod TransferManager {
                         position: sender_position, asset_id: collateral_id, amount: signed_amount,
                     );
                 let position_diff_sender = PositionDiff {
-                    collateral_diff: 0_i64.into(),
+                    collateral_diff: interest_amount_sender.into(),
                     asset_diff: Option::Some((collateral_id, signed_amount.into())),
                 };
 
                 let position_diff_recipient = PositionDiff {
-                    collateral_diff: 0_i64.into(),
+                    collateral_diff: interest_amount_recipient.into(),
                     asset_diff: Option::Some((collateral_id, -signed_amount.into())),
                 };
                 (position_diff_sender, position_diff_recipient)

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -382,6 +382,8 @@ pub mod Core {
             amount: u64,
             expiration: Timestamp,
             salt: felt252,
+            interest_amount_sender: i64,
+            interest_amount_recipient: i64,
         ) {
             self.pausable.assert_not_paused();
             self.assets.validate_assets_integrity();
@@ -397,6 +399,8 @@ pub mod Core {
                     :amount,
                     :expiration,
                     :salt,
+                    :interest_amount_sender,
+                    :interest_amount_recipient,
                 );
         }
 

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -59,6 +59,8 @@ pub trait ICore<TContractState> {
         amount: u64,
         expiration: Timestamp,
         salt: felt252,
+        interest_amount_sender: i64,
+        interest_amount_recipient: i64,
     );
     fn trade(
         ref self: TContractState,

--- a/workspace/apps/perpetuals/contracts/src/tests/components/valid_component.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/components/valid_component.cairo
@@ -36,6 +36,8 @@ pub mod MockValidExternalComponent {
             amount: u64,
             expiration: starkware_utils::time::time::Timestamp,
             salt: felt252,
+            interest_amount_sender: i64,
+            interest_amount_recipient: i64,
         ) {
             println!("MOCK_TRANSFER");
             panic_with_felt252('MOCK_TRANSFER');

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -108,6 +108,8 @@ fn test_transfer_only_operator() {
             amount: TRANSFER_AMOUNT.into(),
             expiration: Time::now(),
             salt: 0,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/external_components_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/external_components_tests.cairo
@@ -196,5 +196,7 @@ fn test_should_activate_registered_component() {
             amount: 100,
             expiration: Timestamp { seconds: 0 },
             salt: 0,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         )
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1258,6 +1258,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 amount: amount,
                 expiration: expiration,
                 salt: salt,
+                interest_amount_sender: 0,
+                interest_amount_recipient: 0,
             );
 
         self

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/transfer_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/transfer_tests.cairo
@@ -88,6 +88,8 @@ fn test_successful_transfer_of_vault_share() {
             amount: transfer_args.amount,
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
 
     validate_asset_balance(
@@ -175,6 +177,8 @@ fn test_unsuccessful_transfer_of_vault_share_not_enough_balance() {
             amount: transfer_args.amount,
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
 }
 
@@ -234,6 +238,8 @@ fn test_transfer_pending_asset() {
             amount: transfer_args.amount,
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
     validate_asset_balance(
         ref :state,
@@ -302,5 +308,7 @@ fn test_transfer_non_existent_asset() {
             amount: transfer_args.amount,
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -4299,6 +4299,8 @@ fn test_successful_transfer() {
             amount: transfer_args.amount,
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
 
     // Catch the event.
@@ -4397,6 +4399,8 @@ fn test_invalid_transfer_request_amount_is_zero() {
             amount: transfer_args.amount,
             expiration: transfer_args.expiration,
             salt: transfer_args.salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/247)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core accounting during `transfer` by modifying collateral diffs and adding new validated inputs; incorrect integration could mis-credit interest or impact health checks across positions.
> 
> **Overview**
> Transfers now accept two new parameters, `interest_amount_sender` and `interest_amount_recipient`, and plumb them through `Core.transfer` to `TransferManager.transfer`.
> 
> `TransferManager` validates each interest amount via `positions.validate_interest_in_range` and applies the interest by incorporating it into the `PositionDiff` collateral deltas for both base-collateral transfers and spot/vault-share transfers, so collateral can change even when the transferred asset is non-collateral. Tests and mocks are updated to pass the new arguments (currently `0`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aa984c9088d689907d3b75ec167285b4738fb61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->