### PR TITLE
feat(perps): add health in all missing flows

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -549,6 +549,21 @@ pub(crate) mod LiquidationManager {
                     tvtr_before: Default::default(),
                 );
 
+            if let Option::Some(liquidator_receive_position_diff) =
+                optional_liquidator_receive_position_diff {
+                let liquidator_receive_position = self
+                    .positions
+                    .get_position_snapshot(position_id: liquidator_order.receive_position());
+                self
+                    .positions
+                    .validate_healthy_or_healthier_position(
+                        position_id: liquidator_order.receive_position(),
+                        position: liquidator_receive_position,
+                        position_diff: liquidator_receive_position_diff,
+                        tvtr_before: Default::default(),
+                    );
+            }
+
             let insurance_position_diff = PositionDiff {
                 collateral_diff: liquidated_fee_amount.into(), asset_diff: Option::None,
             };

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -330,6 +330,7 @@ pub(crate) mod TransferManager {
             // Parameters
 
             let sender_position = self.positions.get_position_snapshot(:position_id);
+            let recipient_position = self.positions.get_position_snapshot(position_id: recipient);
             let (position_diff_sender, position_diff_recipient) = if (collateral_id == self
                 .assets
                 .get_collateral_id()) {
@@ -382,6 +383,15 @@ pub(crate) mod TransferManager {
                     :position_id,
                     position: sender_position,
                     position_diff: position_diff_sender,
+                    tvtr_before: Default::default(),
+                );
+
+            self
+                .positions
+                .validate_healthy_or_healthier_position(
+                    position_id: recipient,
+                    position: recipient_position,
+                    position_diff: position_diff_recipient,
                     tvtr_before: Default::default(),
                 );
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -82,7 +82,6 @@ pub(crate) mod VaultsManager {
     use crate::core::utils::{validate_signature, validate_trade};
     use super::{ConvertPositionToVault, IVaultExternal, LimitOrder, Signature};
 
-
     #[event]
     #[derive(Drop, starknet::Event)]
     pub enum Event {
@@ -457,6 +456,7 @@ pub(crate) mod VaultsManager {
 
             let vault_position = self.positions.get_position_snapshot(vault_position_id);
             let redeeming_position = self.positions.get_position_snapshot(redeeming_position_id);
+            let receiving_position = self.positions.get_position_snapshot(receiving_position_id);
 
             let amount_to_burn = actual_shares_user;
             let value_to_receive = actual_collateral_user;
@@ -626,8 +626,15 @@ pub(crate) mod VaultsManager {
                     position: redeeming_position, asset_id: order.base_asset_id,
                 );
 
-            // no need to validate health as can only receive collateral
             if let Option::Some(position_diff) = receiving_position_diff {
+                self
+                    .positions
+                    .validate_healthy_or_healthier_position(
+                        position_id: receiving_position_id,
+                        position: receiving_position,
+                        position_diff: position_diff,
+                        tvtr_before: Default::default(),
+                    );
                 self
                     .positions
                     .apply_diff(position_id: receiving_position_id, position_diff: position_diff);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/248)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens core execution-path validations, which may cause previously-accepted liquidations/transfers/vault redeems to revert and impact user flows; logic is straightforward but touches critical trading/accounting paths.
> 
> **Overview**
> Adds missing *post-diff health validations* in several perps flows to prevent operations from leaving positions unhealthy.
> 
> In `LiquidationManager`, when a liquidation routes the asset leg to a separate `receive_position`, the PR now also validates that receiving position’s health before applying its diff.
> 
> In `TransferManager`, transfers now validate the recipient position’s health (not just the sender) for both collateral and transferable-asset transfers. In `VaultsManager` redeem flows, when collateral is sent to a different `receive_position`, the receiving position is now health-checked before the collateral diff is applied (replacing the prior assumption that receiving collateral needs no health validation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27b766d5d60a8523e70d9c0e306a5b2f205ee309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->