### PR TITLE
chore(multi-collateral): add interest amount to liquidate and deleverage

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -23,6 +23,8 @@ pub trait IDeleverageManager<TContractState> {
         base_asset_id: AssetId,
         deleveraged_base_amount: i64,
         deleveraged_quote_amount: i64,
+        interest_amount_deleveraged: i64,
+        interest_amount_deleverager: i64,
     );
     fn deleverage_spot_asset(
         ref self: TContractState,
@@ -31,6 +33,8 @@ pub trait IDeleverageManager<TContractState> {
         asset_id: AssetId,
         deleveraged_amount: i64,
         deleveraged_base_collateral_amount: i64,
+        interest_amount_deleveraged: i64,
+        interest_amount_deleverager: i64,
     );
 }
 
@@ -54,7 +58,9 @@ pub(crate) mod DeleverageManager {
     use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
     use perpetuals::core::types::position::PositionId;
-    use starknet::storage::{StorageAsPointer, StoragePath, StoragePathEntry};
+    use starknet::storage::{
+        StorageAsPointer, StoragePath, StoragePathEntry, StoragePointerReadAccess,
+    };
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
@@ -174,13 +180,15 @@ pub(crate) mod DeleverageManager {
             base_asset_id: AssetId,
             deleveraged_base_amount: i64,
             deleveraged_quote_amount: i64,
+            interest_amount_deleveraged: i64,
+            interest_amount_deleverager: i64,
         ) {
             let deleveraged_position = self
                 .positions
-                .get_position_snapshot(position_id: deleveraged_position_id);
+                .get_position_mut(position_id: deleveraged_position_id);
             let deleverager_position = self
                 .positions
-                .get_position_snapshot(position_id: deleverager_position_id);
+                .get_position_mut(position_id: deleverager_position_id);
 
             /// Validation:
             self.assets.validate_asset_active(asset_id: base_asset_id);
@@ -189,11 +197,28 @@ pub(crate) mod DeleverageManager {
                 ._validate_imposed_reduction_trade(
                     position_id_a: deleveraged_position_id,
                     position_id_b: deleverager_position_id,
-                    position_a: deleveraged_position,
-                    position_b: deleverager_position,
+                    position_a: deleveraged_position.into(),
+                    position_b: deleverager_position.into(),
                     :base_asset_id,
                     base_amount_a: deleveraged_base_amount,
                     quote_amount_a: deleveraged_quote_amount,
+                );
+
+            // Validate interest in range for both positions before applying diffs
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: deleveraged_position,
+                    position_id: deleveraged_position_id,
+                    interest_amount: interest_amount_deleveraged,
+                );
+
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: deleverager_position,
+                    position_id: deleverager_position_id,
+                    interest_amount: interest_amount_deleverager,
                 );
 
             /// Execution:
@@ -201,11 +226,13 @@ pub(crate) mod DeleverageManager {
                 ._execute_deleverage(
                     :deleveraged_position_id,
                     :deleverager_position_id,
-                    :deleveraged_position,
-                    :deleverager_position,
+                    deleveraged_position: deleveraged_position.into(),
+                    deleverager_position: deleverager_position.into(),
                     asset_id: base_asset_id,
                     deleveraged_asset_amount: deleveraged_base_amount,
                     deleveraged_collateral_amount: deleveraged_quote_amount,
+                    :interest_amount_deleveraged,
+                    :interest_amount_deleverager,
                 );
         }
         fn deleverage_spot_asset(
@@ -215,13 +242,15 @@ pub(crate) mod DeleverageManager {
             asset_id: AssetId,
             deleveraged_amount: i64,
             deleveraged_base_collateral_amount: i64,
+            interest_amount_deleveraged: i64,
+            interest_amount_deleverager: i64,
         ) {
             let deleveraged_position = self
                 .positions
-                .get_position_snapshot(position_id: deleveraged_position_id);
+                .get_position_mut(position_id: deleveraged_position_id);
             let deleverager_position = self
                 .positions
-                .get_position_snapshot(position_id: deleverager_position_id);
+                .get_position_mut(position_id: deleverager_position_id);
 
             /// Validation:
             self.assets.validate_asset_active(:asset_id);
@@ -230,23 +259,45 @@ pub(crate) mod DeleverageManager {
                 ._validate_imposed_reduction_trade(
                     position_id_a: deleveraged_position_id,
                     position_id_b: deleverager_position_id,
-                    position_a: deleveraged_position,
-                    position_b: deleverager_position,
+                    position_a: deleveraged_position.into(),
+                    position_b: deleverager_position.into(),
                     base_asset_id: asset_id,
                     base_amount_a: deleveraged_amount,
                     quote_amount_a: deleveraged_base_collateral_amount,
                 );
 
+            // Validate interest in range for both positions before applying diffs
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: deleveraged_position,
+                    position_id: deleveraged_position_id,
+                    interest_amount: interest_amount_deleveraged,
+                );
+
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: deleverager_position,
+                    position_id: deleverager_position_id,
+                    interest_amount: interest_amount_deleverager,
+                );
+
             /// Execution:
+            // Pass default values for interest validation parameters since deleverage_spot_asset
+            // doesn't support interest amounts. Interest validation is skipped when interest
+            // amounts are zero, so these parameters are not used.
             self
                 ._execute_deleverage(
                     :deleveraged_position_id,
                     :deleverager_position_id,
-                    :deleveraged_position,
-                    :deleverager_position,
+                    deleveraged_position: deleveraged_position.into(),
+                    deleverager_position: deleverager_position.into(),
                     :asset_id,
                     deleveraged_asset_amount: deleveraged_amount,
                     deleveraged_collateral_amount: deleveraged_base_collateral_amount,
+                    :interest_amount_deleveraged,
+                    :interest_amount_deleverager,
                 );
         }
     }
@@ -318,15 +369,19 @@ pub(crate) mod DeleverageManager {
             asset_id: AssetId,
             deleveraged_asset_amount: i64,
             deleveraged_collateral_amount: i64,
+            interest_amount_deleveraged: i64,
+            interest_amount_deleverager: i64,
         ) {
             let deleveraged_position_diff = PositionDiff {
-                collateral_diff: deleveraged_collateral_amount.into(),
+                collateral_diff: deleveraged_collateral_amount.into()
+                    + interest_amount_deleveraged.into(),
                 asset_diff: Option::Some((asset_id, deleveraged_asset_amount.into())),
             };
             // Passing the negative of actual amounts to deleverager as it is linked to
             // deleveraged.
             let deleverager_position_diff = PositionDiff {
-                collateral_diff: -deleveraged_collateral_amount.into(),
+                collateral_diff: -deleveraged_collateral_amount.into()
+                    + interest_amount_deleverager.into(),
                 asset_diff: Option::Some((asset_id, -deleveraged_asset_amount.into())),
             };
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -36,6 +36,8 @@ pub trait ILiquidationManager<TContractState> {
         actual_amount_quote_liquidated: i64,
         actual_liquidator_fee: u64,
         liquidated_fee_amount: u64,
+        interest_amount_liquidated: i64,
+        interest_amount_liquidator: i64,
     );
 
     fn liquidate_spot_asset(
@@ -47,6 +49,9 @@ pub trait ILiquidationManager<TContractState> {
         actual_amount_base_collateral: i64,
         actual_liquidator_fee: u64,
         liquidated_fee_amount: u64,
+        interest_amount_liquidated: i64,
+        interest_amount_liquidator: i64,
+        interest_amount_liquidator_receiver: i64,
     );
 }
 
@@ -203,6 +208,8 @@ pub(crate) mod LiquidationManager {
             actual_amount_quote_liquidated: i64,
             actual_liquidator_fee: u64,
             liquidated_fee_amount: u64,
+            interest_amount_liquidated: i64,
+            interest_amount_liquidator: i64,
         ) {
             let liquidator_position_id = liquidator_order.position_id;
 
@@ -250,6 +257,9 @@ pub(crate) mod LiquidationManager {
                     :liquidator_order,
                     :liquidated_fee_amount,
                     :actual_liquidator_fee,
+                    :interest_amount_liquidated,
+                    :interest_amount_liquidator,
+                    interest_amount_liquidator_receiver: 0,
                 );
 
             self
@@ -303,6 +313,9 @@ pub(crate) mod LiquidationManager {
             actual_amount_base_collateral: i64,
             actual_liquidator_fee: u64,
             liquidated_fee_amount: u64,
+            interest_amount_liquidated: i64,
+            interest_amount_liquidator: i64,
+            interest_amount_liquidator_receiver: i64,
         ) {
             /// Validations:
             let collateral_id = self.assets.get_collateral_id();
@@ -364,6 +377,9 @@ pub(crate) mod LiquidationManager {
                     :liquidator_order,
                     :liquidated_fee_amount,
                     :actual_liquidator_fee,
+                    :interest_amount_liquidated,
+                    :interest_amount_liquidator,
+                    :interest_amount_liquidator_receiver,
                 );
 
             self
@@ -477,17 +493,21 @@ pub(crate) mod LiquidationManager {
             liquidator_order: T,
             liquidated_fee_amount: u64,
             actual_liquidator_fee: u64,
+            interest_amount_liquidated: i64,
+            interest_amount_liquidator: i64,
+            interest_amount_liquidator_receiver: i64,
         ) {
             let liquidated_position = self
                 .positions
-                .get_position_snapshot(position_id: liquidated_position_id);
+                .get_position_mut(position_id: liquidated_position_id);
             let liquidator_position = self
                 .positions
-                .get_position_snapshot(position_id: liquidator_position_id);
+                .get_position_mut(position_id: liquidator_position_id);
 
             let liquidated_position_diff = PositionDiff {
                 collateral_diff: liquidated_order.quote_amount().into()
-                    - liquidated_order.fee_amount().into(),
+                    - liquidated_order.fee_amount().into()
+                    + interest_amount_liquidated.into(),
                 asset_diff: Option::Some(
                     (liquidated_order.base_asset_id(), liquidated_order.base_amount().into()),
                 ),
@@ -502,12 +522,13 @@ pub(crate) mod LiquidationManager {
                 (
                     PositionDiff {
                         collateral_diff: -liquidated_order.quote_amount().into()
-                            - actual_liquidator_fee.into(),
+                            - actual_liquidator_fee.into()
+                            + interest_amount_liquidator.into(),
                         asset_diff: Option::None,
                     },
                     Option::Some(
                         PositionDiff {
-                            collateral_diff: Zero::zero(),
+                            collateral_diff: interest_amount_liquidator_receiver.into(),
                             asset_diff: Option::Some(
                                 (
                                     liquidated_order.base_asset_id(),
@@ -521,7 +542,8 @@ pub(crate) mod LiquidationManager {
                 (
                     PositionDiff {
                         collateral_diff: -liquidated_order.quote_amount().into()
-                            - actual_liquidator_fee.into(),
+                            - actual_liquidator_fee.into()
+                            + interest_amount_liquidator.into(),
                         asset_diff: Option::Some(
                             (
                                 liquidated_order.base_asset_id(),
@@ -533,18 +555,49 @@ pub(crate) mod LiquidationManager {
                 )
             };
 
+            // Validate interest in range for both positions before applying diffs
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: liquidated_position,
+                    position_id: liquidated_position_id,
+                    interest_amount: interest_amount_liquidated,
+                );
+
+            self
+                .positions
+                .validate_interest_in_range(
+                    position: liquidator_position,
+                    position_id: liquidator_position_id,
+                    interest_amount: interest_amount_liquidator,
+                );
+
+            if liquidator_order.receive_position() != liquidator_order.position_id() {
+                let reciever_position_id = liquidator_order.receive_position();
+
+                self
+                    .positions
+                    .validate_interest_in_range(
+                        position: self
+                            .positions
+                            .get_position_mut(position_id: reciever_position_id),
+                        position_id: reciever_position_id,
+                        interest_amount: interest_amount_liquidator_receiver,
+                    );
+            }
+
             /// Validations - Fundamentals:
             self
                 ._validate_liquidated_position(
                     position_id: liquidated_position_id,
-                    position: liquidated_position,
+                    position: liquidated_position.into(),
                     position_diff: liquidated_position_diff,
                 );
             self
                 .positions
                 .validate_healthy_or_healthier_position(
                     position_id: liquidator_position_id,
-                    position: liquidator_position,
+                    position: liquidator_position.into(),
                     position_diff: liquidator_position_diff,
                     tvtr_before: Default::default(),
                 );

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -551,6 +551,8 @@ pub mod Core {
             /// The `liquidated_fee_amount` is paid by the liquidated position to the
             /// insurance fund position.
             liquidated_fee_amount: u64,
+            interest_amount_liquidated: i64,
+            interest_amount_liquidator: i64,
         ) {
             self.pausable.assert_not_paused();
             self.assets.validate_assets_integrity();
@@ -566,6 +568,8 @@ pub mod Core {
                     :actual_amount_quote_liquidated,
                     :actual_liquidator_fee,
                     :liquidated_fee_amount,
+                    :interest_amount_liquidated,
+                    :interest_amount_liquidator,
                 );
         }
 
@@ -594,6 +598,8 @@ pub mod Core {
             base_asset_id: AssetId,
             deleveraged_base_amount: i64,
             deleveraged_quote_amount: i64,
+            interest_amount_deleveraged: i64,
+            interest_amount_deleverager: i64,
         ) {
             /// Validations:
             self.pausable.assert_not_paused();
@@ -608,7 +614,9 @@ pub mod Core {
                     :base_asset_id,
                     :deleveraged_base_amount,
                     :deleveraged_quote_amount,
-                )
+                    :interest_amount_deleveraged,
+                    :interest_amount_deleverager,
+                );
         }
 
         /// Executes a spot asset deleverage of a user position with a deleverager position.
@@ -635,6 +643,8 @@ pub mod Core {
             asset_id: AssetId,
             deleveraged_amount: i64,
             deleveraged_base_collateral_amount: i64,
+            interest_amount_deleveraged: i64,
+            interest_amount_deleverager: i64,
         ) {
             /// Validations:
             self.pausable.assert_not_paused();
@@ -649,6 +659,8 @@ pub mod Core {
                     :asset_id,
                     :deleveraged_amount,
                     :deleveraged_base_collateral_amount,
+                    :interest_amount_deleveraged,
+                    :interest_amount_deleverager,
                 )
         }
 
@@ -1276,6 +1288,9 @@ pub mod Core {
             actual_amount_base_collateral: i64,
             actual_liquidator_fee: u64,
             liquidated_fee_amount: u64,
+            interest_amount_liquidated: i64,
+            interest_amount_liquidator: i64,
+            interest_amount_liquidator_receiver: i64,
         ) {
             self.pausable.assert_not_paused();
             self.assets.validate_assets_integrity();
@@ -1292,6 +1307,9 @@ pub mod Core {
                     :actual_amount_base_collateral,
                     :actual_liquidator_fee,
                     :liquidated_fee_amount,
+                    :interest_amount_liquidated,
+                    :interest_amount_liquidator,
+                    :interest_amount_liquidator_receiver,
                 );
         }
 

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -91,6 +91,8 @@ pub trait ICore<TContractState> {
         actual_amount_quote_liquidated: i64,
         actual_liquidator_fee: u64,
         liquidated_fee_amount: u64,
+        interest_amount_liquidated: i64,
+        interest_amount_liquidator: i64,
     );
     fn deleverage(
         ref self: TContractState,
@@ -100,6 +102,8 @@ pub trait ICore<TContractState> {
         base_asset_id: AssetId,
         deleveraged_base_amount: i64,
         deleveraged_quote_amount: i64,
+        interest_amount_deleveraged: i64,
+        interest_amount_deleverager: i64,
     );
     fn deleverage_spot_asset(
         ref self: TContractState,
@@ -109,6 +113,8 @@ pub trait ICore<TContractState> {
         asset_id: AssetId,
         deleveraged_amount: i64,
         deleveraged_base_collateral_amount: i64,
+        interest_amount_deleveraged: i64,
+        interest_amount_deleverager: i64,
     );
     fn reduce_asset_position(
         ref self: TContractState,
@@ -209,6 +215,9 @@ pub trait ICore<TContractState> {
         actual_amount_base_collateral: i64,
         actual_liquidator_fee: u64,
         liquidated_fee_amount: u64,
+        interest_amount_liquidated: i64,
+        interest_amount_liquidator: i64,
+        interest_amount_liquidator_receiver: i64,
     );
 
     fn enable_escape_hatch(ref self: TContractState);

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/caller_failure_tests.cairo
@@ -170,6 +170,8 @@ fn test_liquidate_only_operator() {
             actual_amount_quote_liquidated: 0,
             actual_liquidator_fee: 0,
             liquidated_fee_amount: 0,
+            interest_amount_liquidated: 0,
+            interest_amount_liquidator: 0,
         );
 }
 
@@ -186,6 +188,8 @@ fn test_deleverage_only_operator() {
             base_asset_id: cfg.collateral_cfg.collateral_id,
             deleveraged_base_amount: 0,
             deleveraged_quote_amount: 0,
+            interest_amount_deleveraged: 0,
+            interest_amount_deleverager: 0,
         );
 }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1661,6 +1661,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 actual_amount_quote_liquidated: liquidated_quote,
                 actual_liquidator_fee: liquidator_fee,
                 liquidated_fee_amount: liquidated_insurance_fee,
+                interest_amount_liquidated: 0,
+                interest_amount_liquidator: 0,
             );
 
         self
@@ -1820,6 +1822,9 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 :actual_amount_base_collateral,
                 :actual_liquidator_fee,
                 :liquidated_fee_amount,
+                interest_amount_liquidated: 0,
+                interest_amount_liquidator: 0,
+                interest_amount_liquidator_receiver: 0,
             );
 
         // Validate balances after liquidation
@@ -1938,6 +1943,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 base_asset_id: base_asset_id,
                 deleveraged_base_amount: deleveraged_base,
                 deleveraged_quote_amount: deleveraged_quote,
+                interest_amount_deleveraged: 0,
+                interest_amount_deleverager: 0,
             );
 
         self

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -3809,6 +3809,8 @@ fn test_successful_deleverage() {
             base_asset_id: synthetic_id,
             deleveraged_base_amount: BASE,
             deleveraged_quote_amount: QUOTE,
+            interest_amount_deleveraged: 0,
+            interest_amount_deleverager: 0,
         );
 
     // Catch the event.
@@ -3913,6 +3915,8 @@ fn test_successful_liquidate() {
             actual_amount_quote_liquidated: QUOTE,
             actual_liquidator_fee: FEE,
             liquidated_fee_amount: INSURANCE_FEE,
+            interest_amount_liquidated: 0,
+            interest_amount_liquidator: 0,
         );
     // Catch the event.
     let events = spy.get_events().emitted_by(test_address()).events;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches liquidation/deleverage accounting and public interfaces, so incorrect interest inputs or diff composition could impact user collateral balances, though changes are localized and add range validation.
> 
> **Overview**
> Adds explicit *interest collateral adjustments* to `liquidate`, `liquidate_spot_asset`, `deleverage`, and `deleverage_spot_asset` by extending the Core/manager ABIs with new `interest_amount_*` parameters.
> 
> Execution now fetches mutable positions and **validates each provided interest amount** via `positions.validate_interest_in_range(...)` before applying diffs; the interest amounts are then folded into each position’s `collateral_diff` (including an optional receiver position in liquidation). Tests and facades are updated to pass `0` interest values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a040287568437b66db5d7e9ca9e493b7f267a2ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/249)
<!-- Reviewable:end -->
