### PR TITLE
fix(vault): get caller address instead of perps address

### DIFF
--- a/workspace/vault/src/protocol_vault.cairo
+++ b/workspace/vault/src/protocol_vault.cairo
@@ -12,8 +12,8 @@ pub mod ProtocolVault {
     use perpetuals::core::components::positions::interface::{
         IPositionsDispatcher, IPositionsDispatcherTrait,
     };
-    use starknet::ContractAddress;
     use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
+    use starknet::{ContractAddress, get_caller_address};
     use starkware_utils::components::replaceability::ReplaceabilityComponent;
     use starkware_utils::components::replaceability::ReplaceabilityComponent::InternalReplaceabilityTrait;
     use starkware_utils::components::roles::RolesComponent;
@@ -134,7 +134,7 @@ pub mod ProtocolVault {
             self
                 .erc4626
                 ._withdraw(
-                    caller: perps,
+                    caller: get_caller_address(),
                     receiver: perps,
                     owner: perps,
                     assets: value_of_shares,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/251)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches withdrawal call semantics in the vault, which can affect ERC4626 hook checks and authorization assumptions during redemptions.
> 
> **Overview**
> Fixes `ProtocolVault.redeem_with_price` to pass the *actual transaction caller* (`get_caller_address()`) into ERC4626 `_withdraw` instead of spoofing the caller as the stored `perps_contract` address.
> 
> This also updates imports accordingly, but does not change the receiver/owner semantics (assets still flow to/from `perps_contract`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac6e0af31ab9b82eee2b19feff05a2ad3bc941a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->