### PR TITLE
test(multi-collateral): apply interest deposit tests

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -150,7 +150,6 @@ pub struct DepositInfo {
     quantized_amount: u64,
     salt: felt252,
     asset_id: AssetId,
-    interest_amount: i64,
 }
 
 #[derive(Copy, Drop)]
@@ -916,15 +915,11 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             :salt,
         );
 
-        DepositInfo {
-            depositor, position_id, quantized_amount, salt, asset_id, interest_amount: 0_i64,
-        }
+        DepositInfo { depositor, position_id, quantized_amount, salt, asset_id }
     }
 
     fn cancel_deposit(ref self: PerpsTestsFacade, deposit_info: DepositInfo) {
-        let DepositInfo {
-            depositor, position_id, quantized_amount, salt, asset_id, interest_amount: _,
-        } = deposit_info;
+        let DepositInfo { depositor, position_id, quantized_amount, salt, asset_id } = deposit_info;
         let token_state = self.find_contract_for_asset_id(:asset_id);
         let user_balance_before = token_state.balance_of(depositor.address);
         let contract_balance_before = token_state.balance_of(self.perpetuals_contract);
@@ -969,11 +964,17 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     }
 
     fn process_deposit(ref self: PerpsTestsFacade, deposit_info: DepositInfo) {
-        let DepositInfo {
-            depositor, position_id, quantized_amount, salt, asset_id, interest_amount,
-        } = deposit_info;
-        let collateral_balance_before = if (asset_id == self.collateral_id) {
-            self.get_position_collateral_balance(position_id)
+        self.process_deposit_with_interest(:deposit_info, interest_amount: 0)
+    }
+
+    fn process_deposit_with_interest(
+        ref self: PerpsTestsFacade, deposit_info: DepositInfo, interest_amount: i64,
+    ) {
+        let DepositInfo { depositor, position_id, quantized_amount, salt, asset_id } = deposit_info;
+
+        let base_collateral_balance_before = self.get_position_collateral_balance(position_id);
+        let asset_balance_before = if (asset_id == self.collateral_id) {
+            base_collateral_balance_before
         } else {
             self.get_position_asset_balance(position_id, asset_id)
         };
@@ -997,12 +998,21 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             self
                 .validate_collateral_balance(
                     :position_id,
-                    expected_balance: collateral_balance_before + quantized_amount.into(),
+                    expected_balance: base_collateral_balance_before
+                        + quantized_amount.into()
+                        + interest_amount.into(),
                 );
         } else {
             self
                 .validate_asset_balance(
-                    :position_id, asset_id: asset_id, expected_balance: quantized_amount.into(),
+                    :position_id,
+                    asset_id: asset_id,
+                    expected_balance: asset_balance_before + quantized_amount.into(),
+                );
+            self
+                .validate_collateral_balance(
+                    :position_id,
+                    expected_balance: base_collateral_balance_before + interest_amount.into(),
                 );
         }
 
@@ -2359,7 +2369,6 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             quantized_amount: deposit_event.quantized_amount,
             salt,
             asset_id: vault.asset_id,
-            interest_amount: 0_i64,
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -4275,3 +4275,239 @@ fn test_withdraw_spot_with_interest() {
         );
     state.facade.validate_collateral_balance(user.position_id, 9_990_u64.into());
 }
+
+#[test]
+fn test_deposit_spot_with_positive_interest() {
+    // Setup.
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.token_state.fund(state.facade.perpetuals_contract, 1_000_000);
+
+    // Create a custom asset configuration.
+    let token = snforge_std::Token::STRK;
+    let erc20_contract_address = token.contract_address();
+    let asset_info = AssetInfoTrait::new_collateral(
+        asset_name: 'COL', :risk_factor_data, oracles_len: 1, :erc20_contract_address,
+    );
+    let asset_id = asset_info.asset_id;
+    state.facade.add_active_collateral(asset_info: @asset_info, initial_price: 100);
+
+    // Create user
+    let user = state.new_user_with_position();
+    snforge_std::set_balance(target: user.account.address, new_balance: 5000000, :token);
+
+    // Deposit base collateral for PnL so it will be non-zero
+    let deposit_info = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 10_000);
+    state.facade.process_deposit(deposit_info: deposit_info);
+    state.facade.validate_collateral_balance(user.position_id, 10_000_u64.into());
+
+    // Deposit spot collateral to user.
+    let deposit_info_user = state
+        .facade
+        .deposit_spot(
+            depositor: user.account, :asset_id, position_id: user.position_id, quantized_amount: 2,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info_user);
+
+    // Advance time by 1 hour
+    state.facade.advance_time(seconds: HOUR);
+
+    // Calculate positive interest
+    let balance: u64 = 10_000;
+    let time_diff: u64 = HOUR.into();
+    let scale: u64 = 2_u64.pow(32);
+    let max_allowed: u64 = (balance * time_diff * MAX_INTEREST_RATE_PER_SEC.into()) / scale;
+    let interest_amount: i64 = max_allowed.try_into().unwrap();
+
+    // Second spot deposit with positive interest
+    let deposit_info_2 = state
+        .facade
+        .deposit_spot(
+            depositor: user.account, :asset_id, position_id: user.position_id, quantized_amount: 1,
+        );
+    state.facade.process_deposit_with_interest(deposit_info: deposit_info_2, :interest_amount);
+    state
+        .facade
+        .validate_asset_balance(
+            position_id: user.position_id, :asset_id, expected_balance: 3_u64.into(),
+        );
+    state.facade.validate_collateral_balance(user.position_id, (10_000_u64 + max_allowed).into());
+}
+
+#[test]
+fn test_deposit_spot_with_negative_interest() {
+    // Setup.
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.token_state.fund(state.facade.perpetuals_contract, 1_000_000);
+
+    // Create a custom asset configuration.
+    let token = snforge_std::Token::STRK;
+    let erc20_contract_address = token.contract_address();
+    let asset_info = AssetInfoTrait::new_collateral(
+        asset_name: 'COL', :risk_factor_data, oracles_len: 1, :erc20_contract_address,
+    );
+    let asset_id = asset_info.asset_id;
+    state.facade.add_active_collateral(asset_info: @asset_info, initial_price: 100);
+
+    // Create user
+    let user = state.new_user_with_position();
+    snforge_std::set_balance(target: user.account.address, new_balance: 5000000, :token);
+
+    // Deposit base collateral
+    let deposit_info = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 10_000);
+    state.facade.process_deposit(deposit_info: deposit_info);
+    state.facade.validate_collateral_balance(user.position_id, 10_000_u64.into());
+
+    // Deposit spot collateral to user.
+    let deposit_info_user = state
+        .facade
+        .deposit_spot(
+            depositor: user.account, :asset_id, position_id: user.position_id, quantized_amount: 2,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info_user);
+
+    // Advance time by 1 hour
+    state.facade.advance_time(seconds: HOUR);
+
+    // Calculate negative interest
+    let balance: u64 = 10_000;
+    let time_diff: u64 = HOUR.into();
+    let scale: u64 = 2_u64.pow(32);
+    let max_allowed: u64 = (balance * time_diff * MAX_INTEREST_RATE_PER_SEC.into()) / scale;
+    let interest_amount: i64 = -(max_allowed).try_into().unwrap();
+
+    // Second spot deposit with negative interest
+    let deposit_info_2 = state
+        .facade
+        .deposit_spot(
+            depositor: user.account, :asset_id, position_id: user.position_id, quantized_amount: 1,
+        );
+    state.facade.process_deposit_with_interest(deposit_info: deposit_info_2, :interest_amount);
+    state
+        .facade
+        .validate_asset_balance(
+            position_id: user.position_id, :asset_id, expected_balance: 3_u64.into(),
+        );
+    state.facade.validate_collateral_balance(user.position_id, (10_000_u64 - max_allowed).into());
+}
+
+#[test]
+#[should_panic(
+    expected: "POSITION_NOT_HEALTHY_NOR_HEALTHIER position_id: PositionId { value: 101 } TV before 10000, TR before 0, TV after -53, TR after 0",
+)]
+fn test_deposit_base_with_negative_interest_becomes_unhealthy() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    // Deposit collateral
+    let deposit_info = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 10_000);
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    // Advance time by ~42 days so max interest exceeds collateral
+    let long_duration: u64 = 3_600_000;
+    state.facade.advance_time(seconds: long_duration);
+
+    // Calculate large negative interest
+    let balance: u64 = 10_000;
+    let time_diff: u64 = long_duration;
+    let scale: u64 = 2_u64.pow(32);
+    let max_allowed: u64 = (balance * time_diff * MAX_INTEREST_RATE_PER_SEC.into()) / scale;
+    let interest_amount: i64 = -(max_allowed).try_into().unwrap();
+
+    // Deposit with large negative interest that exceeds deposit amount
+    let deposit_info_2 = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 5);
+    state.facade.process_deposit_with_interest(deposit_info: deposit_info_2, :interest_amount);
+}
+
+#[test]
+fn test_deposit_base_with_negative_interest_exceeds_deposit_but_healthy() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let user = state.new_user_with_position();
+
+    // Deposit collateral
+    let deposit_info = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 10_000);
+    state.facade.process_deposit(deposit_info: deposit_info);
+    state.facade.validate_collateral_balance(user.position_id, 10_000_u64.into());
+
+    // Advance time by 1 hour
+    state.facade.advance_time(seconds: HOUR);
+
+    // Calculate negative interest
+    let balance: u64 = 10_000;
+    let time_diff: u64 = HOUR.into();
+    let scale: u64 = 2_u64.pow(32);
+    let max_allowed: u64 = (balance * time_diff * MAX_INTEREST_RATE_PER_SEC.into()) / scale;
+    let interest_amount: i64 = -(max_allowed).try_into().unwrap();
+
+    // Deposit with negative interest (|interest| > deposit amount, but position stays healthy)
+    let deposit_info_2 = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 5);
+    state.facade.process_deposit_with_interest(deposit_info: deposit_info_2, :interest_amount);
+    state
+        .facade
+        .validate_collateral_balance(user.position_id, (10_000_u64 + 5_u64 - max_allowed).into());
+}
+
+#[test]
+#[should_panic(expected: "POSITION_NOT_HEALTHY_NOR_HEALTHIER")]
+fn test_deposit_spot_with_negative_interest_becomes_unhealthy() {
+    // Setup.
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+
+    // Create a custom asset configuration.
+    let token = snforge_std::Token::STRK;
+    let erc20_contract_address = token.contract_address();
+    let asset_info = AssetInfoTrait::new_collateral(
+        asset_name: 'COL', :risk_factor_data, oracles_len: 1, :erc20_contract_address,
+    );
+    let asset_id = asset_info.asset_id;
+    state.facade.add_active_collateral(asset_info: @asset_info, initial_price: 50);
+
+    // Create user
+    let user = state.new_user_with_position();
+    snforge_std::set_balance(target: user.account.address, new_balance: 5000000, :token);
+
+    // Deposit base collateral
+    let deposit_info = state
+        .facade
+        .deposit(depositor: user.account, position_id: user.position_id, quantized_amount: 10_000);
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    // Advance time by ~42 days so max interest exceeds collateral
+    let long_duration: u64 = 3_600_000;
+    state.facade.advance_time(seconds: long_duration);
+
+    // Calculate large negative interest
+    let balance: u64 = 10_000;
+    let time_diff: u64 = long_duration;
+    let scale: u64 = 2_u64.pow(32);
+    let max_allowed: u64 = (balance * time_diff * MAX_INTEREST_RATE_PER_SEC.into()) / scale;
+    let interest_amount: i64 = -(max_allowed).try_into().unwrap();
+
+    // Spot deposit with large negative interest that makes position unhealthy
+    let deposit_info_2 = state
+        .facade
+        .deposit_spot(
+            depositor: user.account, :asset_id, position_id: user.position_id, quantized_amount: 1,
+        );
+    state.facade.process_deposit_with_interest(deposit_info: deposit_info_2, :interest_amount);
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/252)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust balance assertions and add new edge-case coverage for deposit interest handling; no production contract logic is modified.
> 
> **Overview**
> Updates the test `PerpsTestsFacade` to stop carrying `interest_amount` inside `DepositInfo` and instead adds `process_deposit_with_interest`, which processes a deposit with an explicit interest delta and validates resulting balances (including collateral adjustments for spot deposits).
> 
> Adds new unit flow tests covering spot deposits with *positive* and *negative* interest, plus base/spot deposit cases where large negative interest can exceed the deposit and either remain healthy or revert with `POSITION_NOT_HEALTHY_NOR_HEALTHIER`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acca9890644795696f451a37c90cc74a770dfb04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->