### PR TITLE
refactor(perps): tiny changes in apply interest from pre-internal audit

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -32,8 +32,7 @@ pub mod Positions {
     use perpetuals::core::types::set_owner_account::SetOwnerAccountArgs;
     use perpetuals::core::types::set_public_key::SetPublicKeyArgs;
     use perpetuals::core::value_risk_calculator::{
-        PositionState, PositionTVTR, calculate_position_pnl, calculate_position_tvtr,
-        evaluate_position,
+        PositionState, PositionTVTR, calculate_pnl, calculate_position_tvtr, evaluate_position,
     };
     use starknet::storage::{
         Map, Mutable, StorageAsPointer, StoragePath, StoragePathEntry, StoragePointerReadAccess,
@@ -52,7 +51,7 @@ pub mod Positions {
         IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
     };
     use starkware_utils::storage::utils::AddToStorage;
-    use starkware_utils::time::time::{Timestamp, validate_expiration};
+    use starkware_utils::time::time::{Time, Timestamp, validate_expiration};
     use crate::core::components::assets::errors::NO_SUCH_ASSET;
     use crate::core::components::snip::SNIP12MetadataImpl;
     use crate::core::errors::{
@@ -513,32 +512,30 @@ pub mod Positions {
         /// plus base collateral. Similar to TV calculation but without vault and spot assets.
         /// Includes funding ticks in the calculation.
         fn calculate_position_pnl(
-            self: @ComponentState<TContractState>,
-            position_id: PositionId,
-            collateral_balance: Balance,
+            self: @ComponentState<TContractState>, position_id: PositionId,
         ) -> i64 {
             let position = self.get_position_snapshot(:position_id);
-            let assets = get_dep_component!(self, Assets);
+            let assets_component = get_dep_component!(self, Assets);
 
             // Use existing function to derive funding delta and unchanged assets
             // This already calculates funding and builds AssetBalanceInfo array
-            let (funding_delta, unchanged_assets) = self
+            let (funding_delta, assets) = self
                 .derive_funding_delta_and_unchanged_assets(
                     :position, position_diff: Default::default(),
                 );
 
             // Filter to only include synthetic assets (exclude vault and spot)
             let mut synthetic_assets = array![];
-            for asset in unchanged_assets {
-                let asset_config = assets.get_asset_config(*asset.id);
+            for asset in assets {
+                let asset_config = assets_component.get_asset_config(*asset.id);
                 if asset_config.asset_type == AssetType::SYNTHETIC {
                     synthetic_assets.append(*asset);
                 }
             }
-
+            let collateral_balance = position.collateral_balance.read();
             let collateral_balance_with_funding = collateral_balance + funding_delta;
-            calculate_position_pnl(
-                assets: synthetic_assets.span(),
+            calculate_pnl(
+                synthetic_assets: synthetic_assets.span(),
                 collateral_balance: collateral_balance_with_funding,
             )
         }
@@ -575,7 +572,7 @@ pub mod Positions {
                         tvtr_before: Default::default(),
                     );
 
-                self.apply_diff(position_id: position_id, position_diff: position_diff);
+                self.apply_diff(:position_id, :position_diff);
             }
         }
 
@@ -632,10 +629,10 @@ pub mod Positions {
             }
 
             // Calculate position PnL (total value of synthetic assets + base collateral)
-            let pnl = self.calculate_position_pnl(position_id, position.collateral_balance.read());
+            let pnl = self.calculate_position_pnl(position_id);
 
             // Calculate time difference
-            let time_diff: u64 = current_time.seconds - previous_timestamp.seconds;
+            let time_diff: u64 = current_time.sub(previous_timestamp).into();
 
             // Calculate maximum allowed change: |pnl| * time_diff *
             // max_interest_rate_per_sec / 2^32.

--- a/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
@@ -197,7 +197,7 @@ pub fn calculate_position_tvtr(
     calculate_position_tvtr_before(:unchanged_assets, :position_diff_enriched)
 }
 
-/// Calculates the position PnL (profit and loss) as the total value of synthetic assets
+/// Calculates the PnL (profit and loss) as the total value of synthetic assets
 /// plus base collateral. Similar to TV calculation but without vault and spot assets.
 ///
 /// # Arguments
@@ -208,8 +208,8 @@ pub fn calculate_position_tvtr(
 ///
 /// # Returns
 ///
-/// The position PnL in units of 10^-6 USD
-pub fn calculate_position_pnl(assets: Span<AssetBalanceInfo>, collateral_balance: Balance) -> i64 {
+/// The PnL in units of 10^-6 USD
+pub fn calculate_pnl(synthetic_assets: Span<AssetBalanceInfo>, collateral_balance: Balance) -> i64 {
     let mut pnl: i128 = 0_i128;
 
     // Add base collateral value.
@@ -217,7 +217,7 @@ pub fn calculate_position_pnl(assets: Span<AssetBalanceInfo>, collateral_balance
     pnl += collateral_price.mul(rhs: collateral_balance);
 
     // Vault and spot assets should already be excluded.
-    for synthetic in assets {
+    for synthetic in synthetic_assets {
         let asset_value: i128 = (*synthetic.price).mul(rhs: *synthetic.balance);
         pnl += asset_value;
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/253)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core interest-rate safety checks and PnL calculation plumbing; behavior should be equivalent but mistakes could loosen/tighten interest bounds or miscompute PnL due to asset filtering/funding timing.
> 
> **Overview**
> Refactors interest-rate validation to compute PnL internally from `position_id` (including funding deltas and filtering to synthetic assets) rather than passing in a collateral balance.
> 
> Renames the shared PnL helper in `value_risk_calculator.cairo` from `calculate_position_pnl` to `calculate_pnl`, updates call sites, and switches timestamp delta computation to the new `Time`/`Timestamp.sub` API (plus a small `apply_diff` call cleanup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf2fe1165f76ebd4f3c82aefca16541faec1654. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->