### PR TITLE
refactor(perps): add position id to apply interest errors

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -58,9 +58,7 @@ pub(crate) mod DeleverageManager {
     use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
     use perpetuals::core::types::position::PositionId;
-    use starknet::storage::{
-        StorageAsPointer, StoragePath, StoragePathEntry, StoragePointerReadAccess,
-    };
+    use starknet::storage::{StorageAsPointer, StoragePath, StoragePathEntry};
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/errors.cairo
@@ -1,3 +1,5 @@
+use perpetuals::core::types::position::PositionId;
+
 pub const POSITION_DOESNT_EXIST: felt252 = 'POSITION_DOESNT_EXIST';
 pub const ALREADY_INITIALIZED: felt252 = 'ALREADY_INITIALIZED';
 pub const CALLER_IS_NOT_OWNER_ACCOUNT: felt252 = 'CALLER_IS_NOT_OWNER_ACCOUNT';
@@ -10,5 +12,8 @@ pub const INVALID_ZERO_PUBLIC_KEY: felt252 = 'INVALID_ZERO_PUBLIC_KEY';
 pub const INVALID_ZERO_OWNER_ACCOUNT: felt252 = 'INVALID_ZERO_OWNER_ACCOUNT';
 pub const SAME_PUBLIC_KEY: felt252 = 'SAME_PUBLIC_KEY';
 pub const POSITION_SPOT_BALANCE_NEGATIVE: felt252 = 'POSITION_SPOT_BALANCE_NEGATIVE';
-pub const INVALID_INTEREST_RATE: felt252 = 'INVALID_INTEREST_RATE';
 pub const ZERO_MAX_INTEREST_RATE: felt252 = 'ZERO_MAX_INTEREST_RATE';
+
+pub fn invalid_interest_rate_err(position_id: PositionId) -> ByteArray {
+    format!("INVALID_INTEREST_RATE position_id: {:?}", position_id)
+}

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -3,6 +3,7 @@ pub mod Positions {
     use core::nullable::{FromNullableResult, match_nullable};
     use core::num::traits::{Pow, Zero};
     use core::panic_with_felt252;
+    use core::panics::panic_with_byte_array;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::introspection::src5::SRC5Component;
     use perpetuals::core::components::assets::AssetsComponent;
@@ -11,11 +12,11 @@ pub mod Positions {
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent;
     use perpetuals::core::components::operator_nonce::OperatorNonceComponent::InternalTrait as NonceInternal;
     use perpetuals::core::components::positions::errors::{
-        ALREADY_INITIALIZED, CALLER_IS_NOT_OWNER_ACCOUNT, INVALID_INTEREST_RATE,
-        INVALID_ZERO_OWNER_ACCOUNT, INVALID_ZERO_PUBLIC_KEY, NO_OWNER_ACCOUNT,
-        POSITION_ALREADY_EXISTS, POSITION_DOESNT_EXIST, POSITION_HAS_OWNER_ACCOUNT,
-        POSITION_SPOT_BALANCE_NEGATIVE, SAME_PUBLIC_KEY, SET_POSITION_OWNER_EXPIRED,
-        SET_PUBLIC_KEY_EXPIRED, ZERO_MAX_INTEREST_RATE,
+        ALREADY_INITIALIZED, CALLER_IS_NOT_OWNER_ACCOUNT, INVALID_ZERO_OWNER_ACCOUNT,
+        INVALID_ZERO_PUBLIC_KEY, NO_OWNER_ACCOUNT, POSITION_ALREADY_EXISTS, POSITION_DOESNT_EXIST,
+        POSITION_HAS_OWNER_ACCOUNT, POSITION_SPOT_BALANCE_NEGATIVE, SAME_PUBLIC_KEY,
+        SET_POSITION_OWNER_EXPIRED, SET_PUBLIC_KEY_EXPIRED, ZERO_MAX_INTEREST_RATE,
+        invalid_interest_rate_err,
     };
     use perpetuals::core::components::positions::events;
     use perpetuals::core::components::positions::interface::IPositions;
@@ -619,7 +620,9 @@ pub mod Positions {
                 // If `previous_timestamp` is zero, this indicates the first interest calculation,
                 // and the interest amount is required to be zero.
                 // so we need to set the current time.
-                assert(interest_amount.is_zero(), INVALID_INTEREST_RATE);
+                if !interest_amount.is_zero() {
+                    panic_with_byte_array(@invalid_interest_rate_err(:position_id));
+                }
                 position.last_interest_applied_time.write(current_time);
                 return;
             }
@@ -643,7 +646,9 @@ pub mod Positions {
                 .expect(AMOUNT_OVERFLOW);
 
             // Check: |interest_amount| <= max_allowed_change
-            assert(interest_amount.abs().into() <= max_allowed_change, INVALID_INTEREST_RATE);
+            if interest_amount.abs().into() > max_allowed_change {
+                panic_with_byte_array(@invalid_interest_rate_err(:position_id));
+            }
 
             position.last_interest_applied_time.write(current_time);
         }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -3622,7 +3622,7 @@ fn test_liquidate_spot_with_different_source_and_receive_positions() {
 }
 
 #[test]
-#[should_panic(expected: ('INVALID_INTEREST_RATE',))]
+#[should_panic(expected: "INVALID_INTEREST_RATE position_id: PositionId { value: 101 }")]
 fn test_apply_interest_to_position_with_zero_balance() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let user_1 = state.new_user_with_position();
@@ -3720,7 +3720,7 @@ fn test_apply_interest_to_multiple_positions() {
 }
 
 #[test]
-#[should_panic(expected: ('INVALID_INTEREST_RATE',))]
+#[should_panic(expected: "INVALID_INTEREST_RATE position_id: PositionId { value: 101 }")]
 fn test_apply_interest_exceeds_max_rate() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let user = state.new_user_with_position();
@@ -3749,7 +3749,7 @@ fn test_apply_interest_exceeds_max_rate() {
 }
 
 #[test]
-#[should_panic(expected: ('INVALID_INTEREST_RATE',))]
+#[should_panic(expected: "INVALID_INTEREST_RATE position_id: PositionId { value: 101 }")]
 fn test_apply_non_zero_interest_to_zero_balance() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let user = state.new_user_with_position();
@@ -3837,7 +3837,7 @@ fn test_apply_interest_sequential_updates() {
 }
 
 #[test]
-#[should_panic(expected: ('INVALID_INTEREST_RATE',))]
+#[should_panic(expected: "INVALID_INTEREST_RATE position_id: PositionId { value: 101 }")]
 fn test_apply_interest_twice_without_advancing_time() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
     let user = state.new_user_with_position();


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/254)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error reporting/test expectation changes only; core interest validation logic and bounds checks are unchanged aside from panic formatting.
> 
> **Overview**
> Interest-rate validation failures in `Positions` now panic with a `ByteArray` message that includes the `position_id`, via a new helper `invalid_interest_rate_err`, replacing the previous felt252 `INVALID_INTEREST_RATE` constant.
> 
> This updates the `apply_interest`/`validate_interest_in_range_with_params` checks (first-time non-zero interest and max-rate exceed) to use `panic_with_byte_array`, and adjusts flow tests to assert the new, more descriptive panic string. Minor import cleanup is included.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5297f034e2d86e92be6d265a7cb3a32c744b749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->