### PR TITLE
refactor(perps): apply interest

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -207,7 +207,7 @@ pub(crate) mod DeleverageManager {
             // Validate interest in range for both positions before applying diffs
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: deleveraged_position,
                     position_id: deleveraged_position_id,
                     interest_amount: interest_amount_deleveraged,
@@ -215,7 +215,7 @@ pub(crate) mod DeleverageManager {
 
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: deleverager_position,
                     position_id: deleverager_position_id,
                     interest_amount: interest_amount_deleverager,
@@ -269,7 +269,7 @@ pub(crate) mod DeleverageManager {
             // Validate interest in range for both positions before applying diffs
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: deleveraged_position,
                     position_id: deleveraged_position_id,
                     interest_amount: interest_amount_deleveraged,
@@ -277,7 +277,7 @@ pub(crate) mod DeleverageManager {
 
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: deleverager_position,
                     position_id: deleverager_position_id,
                     interest_amount: interest_amount_deleverager,

--- a/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deposit/deposit_manager.cairo
@@ -281,7 +281,9 @@ pub(crate) mod DepositManager {
 
             let position = self.positions.get_position_mut(:position_id);
             // Validate interest in range
-            self.positions.validate_interest_in_range(:position, :position_id, :interest_amount);
+            self
+                .positions
+                .verify_and_update_interest_range(:position, :position_id, :interest_amount);
             // Validate healthy or healthier position
             self
                 .positions

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -79,7 +79,7 @@ pub(crate) mod LiquidationManager {
     use perpetuals::core::components::system_time::SystemTimeComponent;
     use perpetuals::core::types::asset::synthetic::SyntheticTrait;
     use perpetuals::core::types::position::{PositionId, PositionTrait};
-    use starknet::storage::{StorageAsPointer, StoragePath, StoragePathEntry};
+    use starknet::storage::{Mutable, StorageAsPointer, StoragePath, StoragePathEntry};
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::pausable::PausableComponent::InternalImpl as PausableInternal;
     use starkware_utils::components::request_approvals::RequestApprovalsComponent;
@@ -512,6 +512,8 @@ pub(crate) mod LiquidationManager {
             let liquidator_position = self
                 .positions
                 .get_position_mut(position_id: liquidator_position_id);
+            let mut optional_reciever_position: Option<StoragePath<Mutable<Position>>> =
+                Option::None;
 
             let liquidated_position_diff = PositionDiff {
                 collateral_diff: liquidated_order.quote_amount().into()
@@ -567,7 +569,7 @@ pub(crate) mod LiquidationManager {
             // Validate interest in range for both positions before applying diffs
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: liquidated_position,
                     position_id: liquidated_position_id,
                     interest_amount: interest_amount_liquidated,
@@ -575,7 +577,7 @@ pub(crate) mod LiquidationManager {
 
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: liquidator_position,
                     position_id: liquidator_position_id,
                     interest_amount: interest_amount_liquidator,
@@ -583,13 +585,15 @@ pub(crate) mod LiquidationManager {
 
             if liquidator_order.receive_position() != liquidator_order.position_id() {
                 let reciever_position_id = liquidator_order.receive_position();
+                let reciever_position = self
+                    .positions
+                    .get_position_mut(position_id: liquidator_order.receive_position());
+                optional_reciever_position = Option::Some(reciever_position);
 
                 self
                     .positions
-                    .validate_interest_in_range(
-                        position: self
-                            .positions
-                            .get_position_mut(position_id: reciever_position_id),
+                    .verify_and_update_interest_range(
+                        position: reciever_position,
                         position_id: reciever_position_id,
                         interest_amount: interest_amount_liquidator_receiver,
                     );
@@ -613,14 +617,15 @@ pub(crate) mod LiquidationManager {
 
             if let Option::Some(liquidator_receive_position_diff) =
                 optional_liquidator_receive_position_diff {
-                let liquidator_receive_position = self
-                    .positions
-                    .get_position_snapshot(position_id: liquidator_order.receive_position());
+                let reciever_position: StoragePath<Position> = optional_reciever_position
+                    .unwrap()
+                    .into();
+
                 self
                     .positions
                     .validate_healthy_or_healthier_position(
                         position_id: liquidator_order.receive_position(),
-                        position: liquidator_receive_position,
+                        position: reciever_position,
                         position_diff: liquidator_receive_position_diff,
                         tvtr_before: Default::default(),
                     );

--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -66,6 +66,7 @@ pub mod Positions {
     };
     pub const FEE_POSITION: PositionId = PositionId { value: 0 };
     pub const INSURANCE_FUND_POSITION: PositionId = PositionId { value: 1 };
+    pub const INTEREST_RATE_SCALE: u64 = 2_u64.pow(32);
 
     impl SnipImpl = SNIP12MetadataImpl;
 
@@ -512,9 +513,8 @@ pub mod Positions {
         /// plus base collateral. Similar to TV calculation but without vault and spot assets.
         /// Includes funding ticks in the calculation.
         fn calculate_position_pnl(
-            self: @ComponentState<TContractState>, position_id: PositionId,
+            self: @ComponentState<TContractState>, position: StoragePath<Position>,
         ) -> i64 {
-            let position = self.get_position_snapshot(:position_id);
             let assets_component = get_dep_component!(self, Assets);
 
             // Use existing function to derive funding delta and unchanged assets
@@ -540,47 +540,7 @@ pub mod Positions {
             )
         }
 
-        fn apply_interest(
-            ref self: ComponentState<TContractState>,
-            position_id: PositionId,
-            interest_amount: i64,
-            current_time: Timestamp,
-            max_interest_rate_per_sec: u32,
-            interest_rate_scale: u64,
-        ) {
-            let position = self.get_position_mut(:position_id);
-            self
-                .validate_interest_in_range_with_params(
-                    :position,
-                    :position_id,
-                    :interest_amount,
-                    :current_time,
-                    :max_interest_rate_per_sec,
-                    :interest_rate_scale,
-                );
-
-            // Validate position health and apply interest.
-            if interest_amount.is_non_zero() {
-                let position_diff = PositionDiff {
-                    collateral_diff: interest_amount.into(), asset_diff: Option::None,
-                };
-                self
-                    .validate_healthy_or_healthier_position(
-                        position_id: position_id,
-                        position: position.into(),
-                        position_diff: position_diff,
-                        tvtr_before: Default::default(),
-                    );
-
-                self.apply_diff(:position_id, :position_diff);
-            }
-        }
-
-        /// Validates that the interest amount is within the allowed range.
-        /// This version reads current_time, max_interest_rate_per_sec, and calculates
-        /// interest_rate_scale internally.
-        /// Use this when you want the function to read these values from storage/components.
-        fn validate_interest_in_range(
+        fn verify_and_update_interest_range(
             ref self: ComponentState<TContractState>,
             position: StoragePath<Mutable<Position>>,
             position_id: PositionId,
@@ -589,65 +549,45 @@ pub mod Positions {
             let system_time_component = get_dep_component!(@self, SystemTime);
             let current_time = system_time_component.get_system_time();
             let max_interest_rate_per_sec = self.max_interest_rate_per_sec.read();
-            let interest_rate_scale: u64 = 2_u64.pow(32);
+
             self
-                .validate_interest_in_range_with_params(
+                .verify_and_update_interest_range_with_params(
                     :position,
                     :position_id,
                     :interest_amount,
                     :current_time,
                     :max_interest_rate_per_sec,
-                    :interest_rate_scale,
-                );
+                )
         }
 
-        /// Validates that the interest amount is within the allowed range.
-        /// This version receives all parameters explicitly (current_time,
-        /// max_interest_rate_per_sec, interest_rate_scale).
-        /// Use this when you already have these values to avoid redundant storage reads.
-        fn validate_interest_in_range_with_params(
+        fn verify_and_update_interest_range_with_params(
             ref self: ComponentState<TContractState>,
             position: StoragePath<Mutable<Position>>,
             position_id: PositionId,
             interest_amount: i64,
             current_time: Timestamp,
             max_interest_rate_per_sec: u32,
-            interest_rate_scale: u64,
         ) {
             let previous_timestamp = position.last_interest_applied_time.read();
-            if previous_timestamp.is_zero() {
-                // If `previous_timestamp` is zero, this indicates the first interest calculation,
-                // and the interest amount is required to be zero.
-                // so we need to set the current time.
-                if !interest_amount.is_zero() {
-                    panic_with_byte_array(@invalid_interest_rate_err(:position_id));
-                }
-                position.last_interest_applied_time.write(current_time);
-                return;
-            }
-
             if interest_amount.is_zero() {
+                if previous_timestamp.is_zero() {
+                    // If `previous_timestamp` is zero, this indicates the first interest
+                    // calculation, and the interest amount is required to be zero.
+                    // so we need to set the current time.
+                    position.last_interest_applied_time.write(current_time);
+                }
                 return;
             }
 
-            // Calculate position PnL (total value of synthetic assets + base collateral)
-            let pnl = self.calculate_position_pnl(position_id);
-
-            // Calculate time difference
-            let time_diff: u64 = current_time.sub(previous_timestamp).into();
-
-            // Calculate maximum allowed change: |pnl| * time_diff *
-            // max_interest_rate_per_sec / 2^32.
-            let balance_time_product: u128 = pnl.abs().into() * time_diff.into();
-            let max_allowed_change = mul_wide_and_floor_div(
-                balance_time_product, max_interest_rate_per_sec.into(), interest_rate_scale.into(),
-            )
-                .expect(AMOUNT_OVERFLOW);
-
-            // Check: |interest_amount| <= max_allowed_change
-            if interest_amount.abs().into() > max_allowed_change {
-                panic_with_byte_array(@invalid_interest_rate_err(:position_id));
-            }
+            self
+                ._validate_interest_in_range(
+                    :position,
+                    :position_id,
+                    :interest_amount,
+                    :current_time,
+                    :previous_timestamp,
+                    :max_interest_rate_per_sec,
+                );
 
             position.last_interest_applied_time.write(current_time);
         }
@@ -974,6 +914,45 @@ pub mod Positions {
                     :position, provisional_delta: Option::Some(provisional_delta),
                 );
             evaluate_position(:unchanged_assets, :collateral_balance)
+        }
+
+        /// Validates that the interest amount is within the allowed range.
+        /// This version receives all parameters explicitly (current_time,
+        /// max_interest_rate_per_sec, interest_rate_scale).
+        /// Use this when you already have these values to avoid redundant storage reads.
+        fn _validate_interest_in_range(
+            ref self: ComponentState<TContractState>,
+            position: StoragePath<Mutable<Position>>,
+            position_id: PositionId,
+            interest_amount: i64,
+            current_time: Timestamp,
+            previous_timestamp: Timestamp,
+            max_interest_rate_per_sec: u32,
+        ) {
+            // If `previous_timestamp` is zero, this indicates the first interest calculation,
+            // and the interest amount is required to be zero.
+            if previous_timestamp.is_zero() {
+                panic_with_byte_array(@invalid_interest_rate_err(:position_id));
+            }
+
+            // Calculate position PnL (total value of synthetic assets + base collateral)
+            let pnl = self.calculate_position_pnl(position: position.into());
+
+            // Calculate time difference
+            let time_diff: u64 = current_time.sub(previous_timestamp).into();
+
+            // Calculate maximum allowed change: |pnl| * time_diff *
+            // max_interest_rate_per_sec / 2^32.
+            let balance_time_product: u128 = pnl.abs().into() * time_diff.into();
+            let max_allowed_change = mul_wide_and_floor_div(
+                balance_time_product, max_interest_rate_per_sec.into(), INTEREST_RATE_SCALE.into(),
+            )
+                .expect(AMOUNT_OVERFLOW);
+
+            // Check: |interest_amount| <= max_allowed_change
+            if interest_amount.abs().into() > max_allowed_change {
+                panic_with_byte_array(@invalid_interest_rate_err(:position_id));
+            }
         }
     }
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -280,14 +280,14 @@ pub(crate) mod TransferManager {
             // Validate interest in range
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: sender_position,
-                    position_id: position_id,
+                    :position_id,
                     interest_amount: interest_amount_sender,
                 );
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: recipient_position,
                     position_id: recipient,
                     interest_amount: interest_amount_recipient,

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -283,7 +283,7 @@ pub(crate) mod VaultsManager {
             // Validate interest amounts in range
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: sending_position,
                     position_id: from_position_id,
                     interest_amount: interest_amount_sender,
@@ -291,7 +291,7 @@ pub(crate) mod VaultsManager {
             let vault_position = self.positions.get_position_mut(vault_position_id);
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: vault_position,
                     position_id: vault_position_id,
                     interest_amount: interest_amount_vault_position,
@@ -548,19 +548,19 @@ pub(crate) mod VaultsManager {
 
             let vault_position = self.positions.get_position_mut(vault_position_id);
             let redeeming_position = self.positions.get_position_mut(redeeming_position_id);
-            let receiving_position = self.positions.get_position_snapshot(receiving_position_id);
+            let receiving_position = self.positions.get_position_mut(receiving_position_id);
 
             // Validate interest amounts in range
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: vault_position,
                     position_id: vault_position_id,
                     interest_amount: interest_amount_vault_position,
                 );
             self
                 .positions
-                .validate_interest_in_range(
+                .verify_and_update_interest_range(
                     position: redeeming_position,
                     position_id: redeeming_position_id,
                     interest_amount: interest_amount_sender,
@@ -685,13 +685,10 @@ pub(crate) mod VaultsManager {
                 )
             } else {
                 // Validate receiver interest if different position
-                let receiving_position_mut = self
-                    .positions
-                    .get_position_mut(position_id: receiving_position_id);
                 self
                     .positions
-                    .validate_interest_in_range(
-                        position: receiving_position_mut,
+                    .verify_and_update_interest_range(
+                        position: receiving_position,
                         position_id: receiving_position_id,
                         interest_amount: interest_amount_receiver,
                     );
@@ -760,7 +757,7 @@ pub(crate) mod VaultsManager {
                     .positions
                     .validate_healthy_or_healthier_position(
                         position_id: receiving_position_id,
-                        position: receiving_position,
+                        position: receiving_position.into(),
                         position_diff: position_diff,
                         tvtr_before: Default::default(),
                     );

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -135,7 +135,7 @@ pub(crate) mod WithdrawalManager {
     use perpetuals::core::types::price::PriceImpl;
     use perpetuals::core::types::withdraw::{ForcedWithdrawArgs, WithdrawArgs};
     use starknet::storage::{
-        StorageAsPointer, StoragePath, StoragePathEntry, StoragePointerReadAccess,
+        Mutable, StorageAsPointer, StoragePath, StoragePathEntry, StoragePointerReadAccess,
     };
     use starknet::{ContractAddress, get_block_info, get_caller_address};
     use starkware_utils::components::pausable::PausableComponent;
@@ -290,7 +290,7 @@ pub(crate) mod WithdrawalManager {
             salt: felt252,
             interest_amount: i64,
         ) {
-            let position = self.positions.get_position_snapshot(:position_id);
+            let position = self.positions.get_position_mut(:position_id);
 
             let (hash, token_address) = self
                 ._withdraw(
@@ -403,8 +403,8 @@ pub(crate) mod WithdrawalManager {
             expiration: Timestamp,
             salt: felt252,
         ) {
-            let position = self.positions.get_position_snapshot(:position_id);
-            let public_key = position.get_owner_public_key();
+            let position = self.positions.get_position_mut(:position_id);
+            let public_key = position.into().get_owner_public_key();
 
             // Calculate forced withdraw hash
             let withdraw_args = WithdrawArgs {
@@ -459,7 +459,7 @@ pub(crate) mod WithdrawalManager {
             amount: u64,
             expiration: Timestamp,
             salt: felt252,
-            position: StoragePath<Position>,
+            position: StoragePath<Mutable<Position>>,
             collateral_id: AssetId,
             interest_amount: i64,
         ) -> (HashType, ContractAddress) {
@@ -471,15 +471,13 @@ pub(crate) mod WithdrawalManager {
                     args: WithdrawArgs {
                         position_id, salt, expiration, collateral_id, amount, recipient,
                     },
-                    public_key: position.get_owner_public_key(),
+                    public_key: position.into().get_owner_public_key(),
                 );
 
             self
                 .positions
-                .validate_interest_in_range(
-                    position: position.into(),
-                    position_id: position_id,
-                    interest_amount: interest_amount,
+                .verify_and_update_interest_range(
+                    :position, :position_id, interest_amount: interest_amount,
                 );
 
             /// Validations - Fundamentals:
@@ -496,7 +494,7 @@ pub(crate) mod WithdrawalManager {
                 self
                     .positions
                     ._validate_asset_shrink_non_negative(
-                        :position, asset_id: collateral_id, amount: negative_amount,
+                        position: position.into(), asset_id: collateral_id, amount: negative_amount,
                     );
                 (
                     PositionDiff {
@@ -519,7 +517,10 @@ pub(crate) mod WithdrawalManager {
             self
                 .positions
                 .validate_healthy_or_healthier_position(
-                    :position_id, :position, :position_diff, tvtr_before: Default::default(),
+                    :position_id,
+                    position: position.into(),
+                    :position_diff,
+                    tvtr_before: Default::default(),
                 );
 
             self.positions.apply_diff(:position_id, :position_diff);

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -423,7 +423,6 @@ pub mod Core {
             // Read interest validation parameters once for all settlements
             let current_time = self.get_system_time();
             let max_interest_rate_per_sec = self.get_max_interest_rate_per_sec();
-            let interest_rate_scale: u64 = 2_u64.pow(32);
 
             let mut tvtr_cache: Felt252Dict<Nullable<PositionTVTR>> = Default::default();
 
@@ -448,7 +447,6 @@ pub mod Core {
                         interest_amount_b: trade.interest_amount_b,
                         :current_time,
                         :max_interest_rate_per_sec,
-                        :interest_rate_scale,
                         tvtr_a_before: cached_pos_a_tvtr,
                         tvtr_b_before: cached_pos_b_tvtr,
                         check_signature: true,
@@ -534,7 +532,6 @@ pub mod Core {
                     interest_amount_b: 0,
                     current_time: Timestamp { seconds: 0 },
                     max_interest_rate_per_sec: 0,
-                    interest_rate_scale: 0,
                     tvtr_a_before: Default::default(),
                     tvtr_b_before: Default::default(),
                     check_signature: true,
@@ -1060,7 +1057,6 @@ pub mod Core {
                     interest_amount_b: 0,
                     current_time: Timestamp { seconds: 0 },
                     max_interest_rate_per_sec: 0,
-                    interest_rate_scale: 0,
                     tvtr_a_before: Default::default(),
                     tvtr_b_before: Default::default(),
                     check_signature: false,
@@ -1262,10 +1258,8 @@ pub mod Core {
         fn apply_interests(
             ref self: ContractState,
             operator_nonce: u64,
-            position_ids: Span<PositionId>,
-            interest_amounts: Span<i64>,
+            position_interest_amounts: Span<(PositionId, i64)>,
         ) {
-            assert(position_ids.len() == interest_amounts.len(), LENGTH_MISMATCH);
             self.pausable.assert_not_paused();
             self.assets.validate_assets_integrity();
             self.operator_nonce.use_checked_nonce(:operator_nonce);
@@ -1273,28 +1267,38 @@ pub mod Core {
             // Read once and pass as arguments to avoid redundant storage reads
             let current_time = self.get_system_time();
             let max_interest_rate_per_sec = self.positions.max_interest_rate_per_sec.read();
-            let interest_rate_scale: u64 = 2_u64.pow(32);
 
-            let mut i: usize = 0;
-            for position_id in position_ids {
-                let interest_amount = *interest_amounts[i];
+            for (position_id, interest_amount) in position_interest_amounts {
+                let position_id = *position_id;
+                let interest_amount = *interest_amount;
+                let position = self.positions.get_position_mut(:position_id);
                 self
                     .positions
-                    .apply_interest(
-                        position_id: *position_id,
+                    .verify_and_update_interest_range_with_params(
+                        :position,
+                        :position_id,
                         :interest_amount,
                         :current_time,
                         :max_interest_rate_per_sec,
-                        :interest_rate_scale,
                     );
 
-                self
-                    .emit(
-                        events::InterestApplied {
-                            position_id: *position_id, interest_amount: interest_amount,
-                        },
-                    );
-                i += 1;
+                if interest_amount.is_non_zero() {
+                    let position_diff = PositionDiff {
+                        collateral_diff: interest_amount.into(), asset_diff: Option::None,
+                    };
+                    self
+                        .positions
+                        .validate_healthy_or_healthier_position(
+                            :position_id,
+                            position: position.into(),
+                            position_diff: position_diff,
+                            tvtr_before: Default::default(),
+                        );
+
+                    self.positions.apply_diff(:position_id, :position_diff);
+                }
+
+                self.emit(events::InterestApplied { position_id, interest_amount });
             }
         }
 
@@ -1372,7 +1376,6 @@ pub mod Core {
             interest_amount_b: i64,
             current_time: Timestamp,
             max_interest_rate_per_sec: u32,
-            interest_rate_scale: u64,
             tvtr_a_before: Nullable<PositionTVTR>,
             tvtr_b_before: Nullable<PositionTVTR>,
             check_signature: bool,
@@ -1398,24 +1401,22 @@ pub mod Core {
             // Validate interest in range for both positions before applying diffs
             self
                 .positions
-                .validate_interest_in_range_with_params(
+                .verify_and_update_interest_range_with_params(
                     position: position_a,
                     position_id: position_id_a,
                     interest_amount: interest_amount_a,
                     :current_time,
                     :max_interest_rate_per_sec,
-                    :interest_rate_scale,
                 );
 
             self
                 .positions
-                .validate_interest_in_range_with_params(
+                .verify_and_update_interest_range_with_params(
                     position: position_b,
                     position_id: position_id_b,
                     interest_amount: interest_amount_b,
                     :current_time,
                     :max_interest_rate_per_sec,
-                    :interest_rate_scale,
                 );
 
             // Signatures validation:

--- a/workspace/apps/perpetuals/contracts/src/core/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/interface.cairo
@@ -209,8 +209,7 @@ pub trait ICore<TContractState> {
     fn apply_interests(
         ref self: TContractState,
         operator_nonce: u64,
-        position_ids: Span<PositionId>,
-        interest_amounts: Span<i64>,
+        position_interest_amounts: Span<(PositionId, i64)>,
     );
     fn liquidate_spot_asset(
         ref self: TContractState,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -2173,12 +2173,12 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     }
 
     fn apply_interests(
-        ref self: PerpsTestsFacade, position_ids: Span<PositionId>, interest_amounts: Span<i64>,
+        ref self: PerpsTestsFacade, position_interest_amounts: Span<(PositionId, i64)>,
     ) {
         let operator_nonce = self.get_nonce();
         self.operator.set_as_caller(self.perpetuals_contract);
         ICoreDispatcher { contract_address: self.perpetuals_contract }
-            .apply_interests(:operator_nonce, :position_ids, :interest_amounts);
+            .apply_interests(:operator_nonce, :position_interest_amounts);
     }
 
     fn get_position_asset_balance(

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -3660,16 +3660,15 @@ fn test_apply_interest_to_position_with_zero_balance() {
     );
 
     // Apply zero interest to position with balance (first time, timestamp is zero)
-    let position_ids = array![user_1.position_id].span();
-    let interest_amounts = array![0].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user_1.position_id, 0)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     // Advance time by 1 hour
     state.facade.advance_time(seconds: HOUR);
 
-    let position_ids = array![user_1.position_id, user_2.position_id].span();
-    let interest_amounts = array![100, 100].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user_1.position_id, 100), (user_2.position_id, 100)]
+        .span();
+    state.facade.apply_interests(:position_interest_amounts);
 }
 
 #[test]
@@ -3708,9 +3707,11 @@ fn test_apply_interest_to_multiple_positions() {
     // Apply valid interest to both positions
     let interest_a: i64 = (max_allowed_a / 2).try_into().unwrap();
     let interest_b: i64 = (max_allowed_b / 2).try_into().unwrap();
-    let position_ids = array![user_a.position_id, user_b.position_id].span();
-    let interest_amounts = array![interest_a, interest_b].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![
+        (user_a.position_id, interest_a), (user_b.position_id, interest_b),
+    ]
+        .span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     // Validate balances
     let expected_balance_a: i64 = 10_000 + interest_a;
@@ -3743,9 +3744,8 @@ fn test_apply_interest_exceeds_max_rate() {
 
     // Try to apply interest that exceeds max rate
     let invalid_interest: i64 = (max_allowed + 1).try_into().unwrap();
-    let position_ids = array![user.position_id].span();
-    let interest_amounts = array![invalid_interest].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, invalid_interest)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 }
 
 #[test]
@@ -3757,9 +3757,8 @@ fn test_apply_non_zero_interest_to_zero_balance() {
     // Don't deposit anything, pnl is zero.
 
     // Try to apply non-zero interest to zero balance (first time)
-    let position_ids = array![user.position_id].span();
-    let interest_amounts = array![100_i64].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, 100)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 }
 
 #[test]
@@ -3785,9 +3784,8 @@ fn test_apply_negative_interest() {
 
     // Apply valid negative interest
     let valid_interest: i64 = -(max_allowed / 2).try_into().unwrap();
-    let position_ids = array![user.position_id].span();
-    let interest_amounts = array![valid_interest].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, valid_interest)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     // Balance should decrease
     let expected_balance: i64 = 10_000 + valid_interest;
@@ -3815,9 +3813,8 @@ fn test_apply_interest_sequential_updates() {
     let scale: u128 = 2_u128.pow(32);
     let max_allowed: u128 = (balance * time_diff * max_rate) / scale;
     let interest_1: i64 = (max_allowed / 2).try_into().unwrap();
-    let position_ids = array![user.position_id].span();
-    let interest_amounts = array![interest_1].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, interest_1)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     let balance_after_first: i64 = 10_000 + interest_1;
     state.facade.validate_collateral_balance(user.position_id, balance_after_first.into());
@@ -3829,8 +3826,8 @@ fn test_apply_interest_sequential_updates() {
     let new_balance: u128 = balance_after_first.try_into().unwrap();
     let max_allowed_2: u128 = (new_balance * time_diff * max_rate) / scale;
     let interest_2: i64 = (max_allowed_2 / 2).try_into().unwrap();
-    let interest_amounts = array![interest_2].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, interest_2)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     let expected_final_balance: i64 = balance_after_first + interest_2;
     state.facade.validate_collateral_balance(user.position_id, expected_final_balance.into());
@@ -3856,14 +3853,13 @@ fn test_apply_interest_twice_without_advancing_time() {
     let max_allowed: u128 = (balance * time_diff * max_rate) / scale;
     let interest_1: i64 = (max_allowed / 2).try_into().unwrap();
 
-    let position_ids = array![user.position_id].span();
-    let interest_amounts = array![interest_1].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, interest_1)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     // Since time hasn't advanced, time_diff will be 0, so max_allowed_change will be 0
     // Any non-zero interest should fail with INVALID_INTEREST_RATE
-    let interest_amounts = array![interest_1].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, interest_1)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 }
 
 #[test]
@@ -3889,9 +3885,8 @@ fn test_apply_zero_interest_does_not_update_last_time() {
         },
     );
 
-    let position_ids = array![user.position_id].span();
-    let interest_amounts = array![0].span();
-    state.facade.apply_interests(:position_ids, :interest_amounts);
+    let position_interest_amounts = array![(user.position_id, 0)].span();
+    state.facade.apply_interests(:position_interest_amounts);
 
     // Check last applied time wasnt changed.
     snforge_std::interact_with_state(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple trading-critical flows (liquidation, withdrawals, vault redeem/invest) and changes how interest timestamps are updated, so subtle ordering/state bugs could impact validation or accounting despite largely being a refactor.
> 
> **Overview**
> Refactors per-position interest validation into `Positions.verify_and_update_interest_range*`, which **validates the interest delta and updates `last_interest_applied_time` in one place**, and switches call sites (deposit, transfer, withdrawal, deleverage, liquidation, vault invest/redeem) to use the new API.
> 
> Updates `Core.apply_interests` to accept a single `Span<(PositionId, i64)>`, performs the new verify/update step per position, then applies non-zero interest via normal health checks and diffs; related interface and flow tests are adjusted accordingly. Liquidation/vault flows are also tweaked to keep mutable position handles when validating receiver interest/health to avoid re-fetching snapshots.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c617f657e8346c4324ddfc57b740e0affa9bb3c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/255)
<!-- Reviewable:end -->
