### PR TITLE
feat(perps): add interest amount to events

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/deleverage/deleverage_manager.cairo
@@ -12,6 +12,8 @@ pub struct Deleverage {
     pub deleveraged_base_amount: i64,
     pub quote_asset_id: AssetId,
     pub deleveraged_quote_amount: i64,
+    pub interest_amount_deleveraged: i64,
+    pub interest_amount_deleverager: i64,
 }
 
 #[starknet::interface]
@@ -429,6 +431,8 @@ pub(crate) mod DeleverageManager {
                         deleveraged_base_amount: deleveraged_asset_amount,
                         quote_asset_id: self.assets.get_collateral_id(),
                         deleveraged_quote_amount: deleveraged_collateral_amount,
+                        interest_amount_deleveraged,
+                        interest_amount_deleverager,
                     },
                 )
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -23,6 +23,9 @@ pub struct Liquidate {
     pub insurance_fund_fee_amount: u64,
     #[key]
     pub liquidator_order_hash: felt252,
+    pub interest_amount_liquidated: i64,
+    pub interest_amount_liquidator: i64,
+    pub interest_amount_liquidator_receiver: i64,
 }
 
 #[starknet::interface]
@@ -279,6 +282,9 @@ pub(crate) mod LiquidationManager {
                         insurance_fund_fee_asset_id: self.assets.get_collateral_id(),
                         insurance_fund_fee_amount: liquidated_fee_amount,
                         liquidator_order_hash: liquidator_order_hash,
+                        interest_amount_liquidated,
+                        interest_amount_liquidator,
+                        interest_amount_liquidator_receiver: 0,
                     },
                 );
         }
@@ -399,6 +405,9 @@ pub(crate) mod LiquidationManager {
                         insurance_fund_fee_asset_id: collateral_id,
                         insurance_fund_fee_amount: liquidated_fee_amount,
                         liquidator_order_hash: liquidator_order_hash,
+                        interest_amount_liquidated,
+                        interest_amount_liquidator,
+                        interest_amount_liquidator_receiver,
                     },
                 );
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -29,6 +29,8 @@ pub struct Transfer {
     #[key]
     pub transfer_request_hash: felt252,
     pub salt: felt252,
+    pub interest_amount_sender: i64,
+    pub interest_amount_recipient: i64,
 }
 
 #[starknet::interface]
@@ -311,6 +313,8 @@ pub(crate) mod TransferManager {
                         expiration,
                         transfer_request_hash: hash,
                         salt,
+                        interest_amount_sender,
+                        interest_amount_recipient,
                     },
                 );
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -27,6 +27,8 @@ pub struct InvestInVault {
     pub shares_received: u64,
     pub user_investment: u64,
     pub correlation_id: felt252,
+    pub interest_amount_vault_position: i64,
+    pub interest_amount_sender: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -358,6 +358,8 @@ pub(crate) mod VaultsManager {
                         vault_asset_id: vault_config.asset_id,
                         invested_asset_id: self.assets.get_collateral_id(),
                         correlation_id: correlation_id,
+                        interest_amount_vault_position,
+                        interest_amount_sender,
                     },
                 );
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/withdrawal/withdrawal_manager.cairo
@@ -31,6 +31,7 @@ pub struct Withdraw {
     #[key]
     pub withdraw_request_hash: felt252,
     pub salt: felt252,
+    pub interest_amount: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
@@ -314,6 +315,7 @@ pub(crate) mod WithdrawalManager {
                         expiration,
                         withdraw_request_hash: hash,
                         salt,
+                        interest_amount,
                     },
                 );
         }

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1530,6 +1530,8 @@ pub mod Core {
                         actual_fee_b,
                         order_a_hash: hash_a,
                         order_b_hash: hash_b,
+                        interest_amount_a,
+                        interest_amount_b,
                     },
                 );
             (tvtr_a_after, tvtr_b_after)

--- a/workspace/apps/perpetuals/contracts/src/core/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/events.cairo
@@ -30,6 +30,7 @@ pub struct Withdraw {
     #[key]
     pub withdraw_request_hash: felt252,
     pub salt: felt252,
+    pub interest_amount: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
@@ -58,6 +59,8 @@ pub struct Trade {
     pub order_a_hash: felt252,
     #[key]
     pub order_b_hash: felt252,
+    pub interest_amount_a: i64,
+    pub interest_amount_b: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
@@ -79,6 +82,9 @@ pub struct Liquidate {
     pub insurance_fund_fee_amount: u64,
     #[key]
     pub liquidator_order_hash: felt252,
+    pub interest_amount_liquidated: i64,
+    pub interest_amount_liquidator: i64,
+    pub interest_amount_liquidator_receiver: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
@@ -103,6 +109,8 @@ pub struct Deleverage {
     pub deleveraged_base_amount: i64,
     pub quote_asset_id: AssetId,
     pub deleveraged_quote_amount: i64,
+    pub interest_amount_deleveraged: i64,
+    pub interest_amount_deleverager: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]

--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -157,6 +157,7 @@ pub fn assert_withdraw_event_with_expected(
     expiration: Timestamp,
     withdraw_request_hash: felt252,
     salt: felt252,
+    interest_amount: i64,
 ) {
     let expected_event = events::Withdraw {
         position_id,
@@ -167,6 +168,7 @@ pub fn assert_withdraw_event_with_expected(
         expiration,
         withdraw_request_hash,
         salt,
+        interest_amount,
     };
     assert_expected_event_emitted(
         :spied_event,
@@ -250,6 +252,8 @@ pub fn assert_trade_event_with_expected(
     actual_fee_b: u64,
     order_a_hash: felt252,
     order_b_hash: felt252,
+    interest_amount_a: i64,
+    interest_amount_b: i64,
 ) {
     let expected_event = events::Trade {
         order_a_position_id,
@@ -272,6 +276,8 @@ pub fn assert_trade_event_with_expected(
         actual_fee_b,
         order_a_hash,
         order_b_hash,
+        interest_amount_a,
+        interest_amount_b,
     };
     assert_expected_event_emitted(
         :spied_event,
@@ -311,6 +317,9 @@ pub fn assert_liquidate_event_with_expected(
         insurance_fund_fee_asset_id: collateral_id,
         insurance_fund_fee_amount,
         liquidator_order_hash,
+        interest_amount_liquidated: 0,
+        interest_amount_liquidator: 0,
+        interest_amount_liquidator_receiver: 0,
     };
     assert_expected_event_emitted(
         :spied_event,
@@ -336,6 +345,8 @@ pub fn assert_deleverage_event_with_expected(
         deleveraged_base_amount,
         quote_asset_id: collateral_id,
         deleveraged_quote_amount,
+        interest_amount_deleveraged: 0,
+        interest_amount_deleverager: 0,
     };
     assert_expected_event_emitted(
         :spied_event,
@@ -375,9 +386,19 @@ pub fn assert_transfer_event_with_expected(
     expiration: Timestamp,
     transfer_request_hash: felt252,
     salt: felt252,
+    interest_amount_sender: i64,
+    interest_amount_recipient: i64,
 ) {
     let expected_event = Transfer {
-        position_id, recipient, collateral_id, amount, expiration, transfer_request_hash, salt,
+        position_id,
+        recipient,
+        collateral_id,
+        amount,
+        expiration,
+        transfer_request_hash,
+        salt,
+        interest_amount_sender,
+        interest_amount_recipient,
     };
     assert_expected_event_emitted(
         :spied_event,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -1177,6 +1177,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             :expiration,
             withdraw_request_hash: request_hash,
             :salt,
+            :interest_amount,
         );
     }
 
@@ -1319,6 +1320,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             expiration: expiration,
             transfer_request_hash: request_hash,
             :salt,
+            interest_amount_sender: 0,
+            interest_amount_recipient: 0,
         );
     }
 
@@ -1443,6 +1446,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             actual_fee_b: fee_b,
             order_a_hash: hash_a,
             order_b_hash: hash_b,
+            interest_amount_a: 0,
+            interest_amount_b: 0,
         );
     }
 

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -2774,6 +2774,8 @@ fn test_successful_trade() {
         actual_fee_b: FEE,
         order_a_hash: hash_a,
         order_b_hash: hash_b,
+        interest_amount_a: 0,
+        interest_amount_b: 0,
     );
 
     // Check:
@@ -4333,6 +4335,8 @@ fn test_successful_transfer() {
         expiration: transfer_args.expiration,
         transfer_request_hash: msg_hash,
         salt: transfer_args.salt,
+        interest_amount_sender: 0,
+        interest_amount_recipient: 0,
     );
 
     // Check:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/256)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core state-transition flows (trades, liquidations, transfers, vault ops) by adding new interest deltas and validations; incorrect wiring could impact balances or event consumers despite changes being mostly additive.
> 
> **Overview**
> Adds explicit `interest_amount_*` fields to multiple on-chain events (`Trade`, `Liquidate`, `Deleverage`, `Withdraw`, `Transfer`, `InvestInVault`) and threads these amounts through the corresponding manager interfaces and emit sites.
> 
> Execution paths for trade/liquidation/deleverage/transfer/withdraw/vault invest+redeem now validate interest inputs and apply them via `PositionDiff` collateral deltas, with tests updated to expect the new event fields (defaulting to `0` where not provided).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc32aab29ca6fd223fd030ca2029b516d2fabef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->