### PR TITLE
chore(perpetuals): fix pre internal audit comments

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/liquidation/liquidation_manager.cairo
@@ -531,7 +531,7 @@ pub(crate) mod LiquidationManager {
                             collateral_diff: interest_amount_liquidator_receiver.into(),
                             asset_diff: Option::Some(
                                 (
-                                    liquidated_order.base_asset_id(),
+                                    liquidator_order.base_asset_id(),
                                     -liquidated_order.base_amount().into(),
                                 ),
                             ),
@@ -546,7 +546,7 @@ pub(crate) mod LiquidationManager {
                             + interest_amount_liquidator.into(),
                         asset_diff: Option::Some(
                             (
-                                liquidated_order.base_asset_id(),
+                                liquidator_order.base_asset_id(),
                                 -liquidated_order.base_amount().into(),
                             ),
                         ),

--- a/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/transfer/transfer_manager.cairo
@@ -358,20 +358,21 @@ pub(crate) mod TransferManager {
                     assert(!self.vaults.is_vault_position(recipient), VAULT_CANNOT_HOLD_SHARES);
                 }
 
-                let signed_amount: i64 = -amount.try_into().expect(AMOUNT_OVERFLOW);
                 self
                     .positions
                     ._validate_asset_shrink_non_negative(
-                        position: sender_position, asset_id: collateral_id, amount: signed_amount,
+                        position: sender_position,
+                        asset_id: collateral_id,
+                        amount: -amount.try_into().expect(AMOUNT_OVERFLOW),
                     );
                 let position_diff_sender = PositionDiff {
                     collateral_diff: interest_amount_sender.into(),
-                    asset_diff: Option::Some((collateral_id, signed_amount.into())),
+                    asset_diff: Option::Some((collateral_id, -amount.into())),
                 };
 
                 let position_diff_recipient = PositionDiff {
                     collateral_diff: interest_amount_recipient.into(),
-                    asset_diff: Option::Some((collateral_id, -signed_amount.into())),
+                    asset_diff: Option::Some((collateral_id, amount.into())),
                 };
                 (position_diff_sender, position_diff_recipient)
             };

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1390,15 +1390,14 @@ pub mod Core {
             let position_id_a = order_a.position_id;
             let position_id_b = order_b.position_id;
 
-            let position_a = self.positions.get_position_snapshot(position_id_a);
-            let position_b = self.positions.get_position_snapshot(position_id_b);
+            let position_a = self.positions.get_position_mut(position_id_a);
+            let position_b = self.positions.get_position_mut(position_id_b);
 
             // Validate interest in range for both positions before applying diffs
-            let position_mut_a = self.positions.get_position_mut(position_id_a);
             self
                 .positions
                 .validate_interest_in_range_with_params(
-                    position: position_mut_a,
+                    position: position_a,
                     position_id: position_id_a,
                     interest_amount: interest_amount_a,
                     :current_time,
@@ -1406,11 +1405,10 @@ pub mod Core {
                     :interest_rate_scale,
                 );
 
-            let position_mut_b = self.positions.get_position_mut(position_id_b);
             self
                 .positions
                 .validate_interest_in_range_with_params(
-                    position: position_mut_b,
+                    position: position_b,
                     position_id: position_id_b,
                     interest_amount: interest_amount_b,
                     :current_time,
@@ -1422,19 +1420,19 @@ pub mod Core {
             let (hash_a, hash_b) = match check_signature {
                 true => (
                     validate_signature(
-                        public_key: position_a.get_owner_public_key(),
+                        public_key: position_a.into().get_owner_public_key(),
                         message: order_a,
                         signature: signature_a,
                     ),
                     validate_signature(
-                        public_key: position_b.get_owner_public_key(),
+                        public_key: position_b.into().get_owner_public_key(),
                         message: order_b,
                         signature: signature_b,
                     ),
                 ),
                 false => (
-                    order_a.get_message_hash(public_key: position_a.get_owner_public_key()),
-                    order_b.get_message_hash(public_key: position_b.get_owner_public_key()),
+                    order_a.get_message_hash(public_key: position_a.into().get_owner_public_key()),
+                    order_b.get_message_hash(public_key: position_b.into().get_owner_public_key()),
                 ),
             };
 
@@ -1485,7 +1483,7 @@ pub mod Core {
                 .positions
                 .validate_healthy_or_healthier_position(
                     position_id: order_a.position_id,
-                    position: position_a,
+                    position: position_a.into(),
                     position_diff: position_diff_a,
                     tvtr_before: tvtr_a_before,
                 );
@@ -1493,7 +1491,7 @@ pub mod Core {
                 .positions
                 .validate_healthy_or_healthier_position(
                     position_id: order_b.position_id,
-                    position: position_b,
+                    position: position_b.into(),
                     position_diff: position_diff_b,
                     tvtr_before: tvtr_b_before,
                 );

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -786,10 +786,10 @@ fn test_liquidate_after_price_tick() {
         .facade
         .create_order(
             user: liquidator_user_1,
-            base_amount: -2,
+            base_amount: -4,
             base_asset_id: asset_id,
-            quote_amount: 41,
-            fee_amount: 1,
+            quote_amount: 82,
+            fee_amount: 2,
         );
     state
         .facade


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches liquidation, transfer, and trade settlement accounting where small sign/asset-id mistakes can misapply balances; changes are localized but impact core financial correctness.
> 
> **Overview**
> Fixes accounting/sign issues in core position-diff application.
> 
> In `LiquidationManager`, the liquidator (and optional receive-position) `asset_diff` now uses `liquidator_order.base_asset_id()` instead of the constructed `liquidated_order` asset id, preventing asset movements from being applied under the wrong asset key.
> 
> In `TransferManager`, removes an intermediate signed cast and applies the negative amount consistently in `_validate_asset_shrink_non_negative` and the sender/recipient `asset_diff` entries for non-collateral asset transfers. In `Core::_execute_trade`, switches to using `get_position_mut` for interest validation and derives public keys via `position.into()` to avoid mixed snapshot/mutable reads. Updates a liquidation flow test to use larger liquidator order amounts/fees.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78005310f02278cd2c0d74bde0dff617be03b210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/257)
<!-- Reviewable:end -->
