### PR TITLE
feat(multi-collateral): add interest amounts to redeem and liquidate vaults shares events

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/events.cairo
@@ -99,6 +99,8 @@ pub struct LiquidateVaultShares {
     pub vault_asset_id: AssetId,
     pub shares_liquidated_amount: u64,
     pub collateral_received_amount: u64,
+    pub interest_amount_vault_position: i64,
+    pub interest_amount_liquidated_position: i64,
 }
 
 #[derive(Debug, Drop, PartialEq, starknet::Event)]
@@ -116,4 +118,7 @@ pub struct RedeemVaultShares {
     pub shares_redeemed_amount: u64,
     pub collateral_received_amount: u64,
     pub collateral_requested_amount: u64,
+    pub interest_amount_vault_position: i64,
+    pub interest_amount_redeeming_position: i64,
+    pub interest_amount_receiver: i64,
 }

--- a/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/vaults/vaults_contract.cairo
@@ -418,6 +418,9 @@ pub(crate) mod VaultsManager {
                         collateral_requested_amount: order.quote_amount.abs(),
                         vault_asset_id: vault_config.asset_id,
                         invested_asset_id: self.assets.get_base_collateral_id(),
+                        interest_amount_vault_position: interest_amount_vault_position,
+                        interest_amount_redeeming_position: interest_amount_sender,
+                        interest_amount_receiver: interest_amount_receiver,
                     },
                 );
         }
@@ -477,6 +480,8 @@ pub(crate) mod VaultsManager {
                         vault_asset_id: liquidated_asset_id,
                         shares_liquidated_amount: actual_shares_user.abs(),
                         collateral_received_amount: actual_collateral_user.abs(),
+                        interest_amount_vault_position: interest_amount_vault_position,
+                        interest_amount_liquidated_position: interest_amount_liquidated,
                     },
                 );
         }

--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -1,7 +1,7 @@
 #[starknet::contract]
 pub mod Core {
     use core::dict::{Felt252Dict, Felt252DictTrait};
-    use core::num::traits::{Pow, Zero};
+    use core::num::traits::Zero;
     use core::panic_with_felt252;
     use openzeppelin::access::accesscontrol::AccessControlComponent;
     use openzeppelin::interfaces::erc20::IERC20DispatcherTrait;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/263)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily an event/ABI shape change and additional emitted data; core execution logic is unchanged but downstream consumers must handle the new event fields.
> 
> **Overview**
> Adds new `interest_amount_*` fields to the `RedeemVaultShares` and `LiquidateVaultShares` Starknet events so indexers can observe the interest deltas applied to the vault, sender/liquidated, and receiver positions.
> 
> Updates `vaults_contract.cairo` to populate and emit these new event fields during `redeem_from_vault` and `liquidate_vault_shares`. Also removes an unused `Pow` import from `core.cairo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 137322e339d922df50ccc05241ec2d9bb56d6779. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->