### PR TITLE
cursor: add minor fix

### DIFF
--- a/.cursor/rules/cairo-testing-workflow.mdc
+++ b/.cursor/rules/cairo-testing-workflow.mdc
@@ -32,10 +32,15 @@ scarb --release build
 
 Always run `scarb fmt -w` after finishing code changes and before running tests. This ensures all code is properly formatted before review.
 
-## Task Timing
+## Task Timing (MANDATORY)
 
-When executing a plan with to-dos, track and report:
-- Time taken to complete each individual to-do
-- Total elapsed time for the entire task
+**Before starting execution**, record the current time. For EVERY to-do item:
+1. Note the start time when marking it `in_progress`
+2. Note the end time when marking it `completed`
+3. Include the duration in the todo update message
 
-Report these timings when summarizing completed work.
+**After completing all to-dos**, include a timing summary table in the final message with:
+- Each task name and its duration
+- Total elapsed time from first task start to last task completion
+
+This is NOT optional -- every summary of completed work MUST include timing data.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/265)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to internal workflow rules; no code or runtime behavior is affected.
> 
> **Overview**
> Updates the Cursor rule doc `cairo-testing-workflow.mdc` to make task timing requirements *mandatory*, with explicit instructions to record start/end times per to-do and include a final timing summary table (per-task durations and total elapsed time).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a84c5392836622f672f1d9711ddd3ea3b03c53d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->