### PR TITLE
tests(multi-collateral): add interest test for all flows

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -301,41 +301,6 @@ pub fn assert_liquidate_event_with_expected(
     actual_liquidator_fee: u64,
     insurance_fund_fee_amount: u64,
     liquidator_order_hash: felt252,
-) {
-    assert_liquidate_event_with_expected_and_interest(
-        :spied_event,
-        :liquidated_position_id,
-        :liquidator_order_position_id,
-        :liquidator_order_base_asset_id,
-        :liquidator_order_base_amount,
-        :collateral_id,
-        :liquidator_order_quote_amount,
-        :liquidator_order_fee_amount,
-        :actual_amount_base_liquidated,
-        :actual_amount_quote_liquidated,
-        :actual_liquidator_fee,
-        :insurance_fund_fee_amount,
-        :liquidator_order_hash,
-        interest_amount_liquidated: 0,
-        interest_amount_liquidator: 0,
-        interest_amount_liquidator_receiver: 0,
-    );
-}
-
-pub fn assert_liquidate_event_with_expected_and_interest(
-    spied_event: @(ContractAddress, Event),
-    liquidated_position_id: PositionId,
-    liquidator_order_position_id: PositionId,
-    liquidator_order_base_asset_id: AssetId,
-    liquidator_order_base_amount: i64,
-    collateral_id: AssetId,
-    liquidator_order_quote_amount: i64,
-    liquidator_order_fee_amount: u64,
-    actual_amount_base_liquidated: i64,
-    actual_amount_quote_liquidated: i64,
-    actual_liquidator_fee: u64,
-    insurance_fund_fee_amount: u64,
-    liquidator_order_hash: felt252,
     interest_amount_liquidated: i64,
     interest_amount_liquidator: i64,
     interest_amount_liquidator_receiver: i64,
@@ -375,6 +340,8 @@ pub fn assert_deleverage_event_with_expected(
     collateral_id: AssetId,
     deleveraged_base_amount: i64,
     deleveraged_quote_amount: i64,
+    interest_amount_deleveraged: i64,
+    interest_amount_deleverager: i64,
 ) {
     let expected_event = events::Deleverage {
         deleveraged_position_id,
@@ -383,8 +350,8 @@ pub fn assert_deleverage_event_with_expected(
         deleveraged_base_amount,
         quote_asset_id: collateral_id,
         deleveraged_quote_amount,
-        interest_amount_deleveraged: 0,
-        interest_amount_deleverager: 0,
+        interest_amount_deleveraged,
+        interest_amount_deleverager,
     };
     assert_expected_event_emitted(
         :spied_event,
@@ -889,5 +856,100 @@ pub fn assert_forced_redeem_from_vault_event_with_expected(
         :expected_event,
         expected_event_selector: @selector!("ForcedRedeemFromVault"),
         expected_event_name: "ForcedRedeemFromVault",
+    );
+}
+
+pub fn assert_invest_in_vault_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    vault_position_id: PositionId,
+    investing_position_id: PositionId,
+    receiving_position_id: PositionId,
+    vault_asset_id: AssetId,
+    invested_asset_id: AssetId,
+    shares_received: u64,
+    user_investment: u64,
+    correlation_id: felt252,
+    interest_amount_vault_position: i64,
+    interest_amount_sender: i64,
+) {
+    let expected_event = vault_events::InvestInVault {
+        vault_position_id,
+        investing_position_id,
+        receiving_position_id,
+        vault_asset_id,
+        invested_asset_id,
+        shares_received,
+        user_investment,
+        correlation_id,
+        interest_amount_vault_position,
+        interest_amount_sender,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("InvestInVault"),
+        expected_event_name: "InvestInVault",
+    );
+}
+
+pub fn assert_liquidate_vault_shares_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    vault_position_id: PositionId,
+    liquidated_position_id: PositionId,
+    vault_asset_id: AssetId,
+    shares_liquidated_amount: u64,
+    collateral_received_amount: u64,
+    interest_amount_vault_position: i64,
+    interest_amount_liquidated_position: i64,
+) {
+    let expected_event = vault_events::LiquidateVaultShares {
+        vault_position_id,
+        liquidated_position_id,
+        vault_asset_id,
+        shares_liquidated_amount,
+        collateral_received_amount,
+        interest_amount_vault_position,
+        interest_amount_liquidated_position,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("LiquidateVaultShares"),
+        expected_event_name: "LiquidateVaultShares",
+    );
+}
+
+pub fn assert_redeem_vault_shares_event_with_expected(
+    spied_event: @(ContractAddress, Event),
+    vault_position_id: PositionId,
+    redeeming_position_id: PositionId,
+    receiving_position_id: PositionId,
+    vault_asset_id: AssetId,
+    invested_asset_id: AssetId,
+    shares_redeemed_amount: u64,
+    collateral_received_amount: u64,
+    collateral_requested_amount: u64,
+    interest_amount_vault_position: i64,
+    interest_amount_redeeming_position: i64,
+    interest_amount_receiver: i64,
+) {
+    let expected_event = vault_events::RedeemVaultShares {
+        vault_position_id,
+        redeeming_position_id,
+        receiving_position_id,
+        vault_asset_id,
+        invested_asset_id,
+        shares_redeemed_amount,
+        collateral_received_amount,
+        collateral_requested_amount,
+        interest_amount_vault_position,
+        interest_amount_redeeming_position,
+        interest_amount_receiver,
+    };
+    assert_expected_event_emitted(
+        :spied_event,
+        :expected_event,
+        expected_event_selector: @selector!("RedeemVaultShares"),
+        expected_event_name: "RedeemVaultShares",
     );
 }

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -46,8 +46,9 @@ use perpetuals::tests::event_test_utils::{
     assert_add_spot_event_with_expected, assert_add_synthetic_event_with_expected,
     assert_deactivate_synthetic_asset_event_with_expected, assert_deleverage_event_with_expected,
     assert_deposit_canceled_event_with_expected, assert_deposit_event_with_expected,
-    assert_deposit_processed_event_with_expected, assert_liquidate_event_with_expected,
-    assert_liquidate_event_with_expected_and_interest, assert_trade_event_with_expected,
+    assert_deposit_processed_event_with_expected, assert_invest_in_vault_event_with_expected,
+    assert_liquidate_event_with_expected, assert_liquidate_vault_shares_event_with_expected,
+    assert_redeem_vault_shares_event_with_expected, assert_trade_event_with_expected,
     assert_transfer_event_with_expected, assert_transfer_request_event_with_expected,
     assert_withdraw_event_with_expected, assert_withdraw_request_event_with_expected,
 };
@@ -1258,6 +1259,18 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
     }
 
     fn transfer(ref self: PerpsTestsFacade, transfer_info: RequestInfo) {
+        self
+            .transfer_with_interest(
+                :transfer_info, interest_amount_sender: 0, interest_amount_recipient: 0,
+            )
+    }
+
+    fn transfer_with_interest(
+        ref self: PerpsTestsFacade,
+        transfer_info: RequestInfo,
+        interest_amount_sender: i64,
+        interest_amount_recipient: i64,
+    ) {
         let RequestInfo {
             asset_id, recipient, position_id, amount, expiration, salt, request_hash,
         } = transfer_info;
@@ -1268,11 +1281,16 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             self.get_position_asset_balance(position_id, asset_id)
         };
 
+        let sender_collateral_before = self.get_position_collateral_balance(position_id);
+
         let recipient_balance_before = if (asset_id == self.collateral_id) {
             self.get_position_collateral_balance(recipient.position_id)
         } else {
             self.get_position_asset_balance(recipient.position_id, asset_id)
         };
+
+        let recipient_collateral_before = self
+            .get_position_collateral_balance(recipient.position_id);
 
         let operator_nonce = self.get_nonce();
         self.operator.set_as_caller(self.perpetuals_contract);
@@ -1285,8 +1303,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 amount: amount,
                 expiration: expiration,
                 salt: salt,
-                interest_amount_sender: 0,
-                interest_amount_recipient: 0,
+                :interest_amount_sender,
+                :interest_amount_recipient,
             );
 
         self
@@ -1297,13 +1315,18 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         if (asset_id == self.collateral_id) {
             self
                 .validate_collateral_balance(
-                    :position_id, expected_balance: sender_balance_before - amount.into(),
+                    :position_id,
+                    expected_balance: sender_balance_before
+                        - amount.into()
+                        + interest_amount_sender.into(),
                 );
 
             self
                 .validate_collateral_balance(
                     position_id: recipient.position_id,
-                    expected_balance: recipient_balance_before + amount.into(),
+                    expected_balance: recipient_balance_before
+                        + amount.into()
+                        + interest_amount_recipient.into(),
                 );
         } else {
             self
@@ -1314,10 +1337,23 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 );
 
             self
+                .validate_collateral_balance(
+                    :position_id,
+                    expected_balance: sender_collateral_before + interest_amount_sender.into(),
+                );
+
+            self
                 .validate_asset_balance(
                     position_id: recipient.position_id,
                     :asset_id,
                     expected_balance: recipient_balance_before + amount.into(),
+                );
+
+            self
+                .validate_collateral_balance(
+                    position_id: recipient.position_id,
+                    expected_balance: recipient_collateral_before
+                        + interest_amount_recipient.into(),
                 );
         }
 
@@ -1330,8 +1366,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             expiration: expiration,
             transfer_request_hash: request_hash,
             :salt,
-            interest_amount_sender: 0,
-            interest_amount_recipient: 0,
+            :interest_amount_sender,
+            :interest_amount_recipient,
         );
     }
 
@@ -1665,6 +1701,30 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         liquidated_insurance_fee: u64,
         liquidator_fee: u64,
     ) {
+        self
+            .liquidate_with_interest(
+                :liquidated_user,
+                :liquidator_order,
+                :liquidated_base,
+                :liquidated_quote,
+                :liquidated_insurance_fee,
+                :liquidator_fee,
+                interest_amount_liquidated: 0,
+                interest_amount_liquidator: 0,
+            )
+    }
+
+    fn liquidate_with_interest(
+        ref self: PerpsTestsFacade,
+        liquidated_user: User,
+        liquidator_order: OrderInfo,
+        liquidated_base: i64,
+        liquidated_quote: i64,
+        liquidated_insurance_fee: u64,
+        liquidator_fee: u64,
+        interest_amount_liquidated: i64,
+        interest_amount_liquidator: i64,
+    ) {
         let OrderInfo {
             order: liquidator_order, signature: liquidator_signature, hash: liquidator_hash,
         } = liquidator_order;
@@ -1702,8 +1762,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 actual_amount_quote_liquidated: liquidated_quote,
                 actual_liquidator_fee: liquidator_fee,
                 liquidated_fee_amount: liquidated_insurance_fee,
-                interest_amount_liquidated: 0,
-                interest_amount_liquidator: 0,
+                :interest_amount_liquidated,
+                :interest_amount_liquidator,
             );
 
         self
@@ -1711,7 +1771,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 position_id: liquidated_user.position_id,
                 expected_balance: liquidated_collateral_balance_before
                     - liquidated_insurance_fee.into()
-                    + liquidated_quote.into(),
+                    + liquidated_quote.into()
+                    + interest_amount_liquidated.into(),
             );
 
         self
@@ -1726,7 +1787,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 position_id: liquidator_order.position_id,
                 expected_balance: liquidator_collateral_balance_before
                     - liquidator_fee.into()
-                    - liquidated_quote.into(),
+                    - liquidated_quote.into()
+                    + interest_amount_liquidator.into(),
             );
 
         self
@@ -1763,6 +1825,9 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             actual_liquidator_fee: liquidator_fee,
             insurance_fund_fee_amount: liquidated_insurance_fee,
             liquidator_order_hash: liquidator_hash,
+            :interest_amount_liquidated,
+            :interest_amount_liquidator,
+            interest_amount_liquidator_receiver: 0,
         );
     }
 
@@ -1820,7 +1885,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 interest_amount_liquidated: 0,
                 interest_amount_liquidator: 0,
                 interest_amount_liquidator_receiver: 0,
-            )
+            );
     }
 
     fn liquidate_spot_asset_with_interest(
@@ -1972,7 +2037,7 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             );
 
         // Verify liquidation event was emitted
-        assert_liquidate_event_with_expected_and_interest(
+        assert_liquidate_event_with_expected(
             spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
             liquidated_position_id: liquidated_user.position_id,
             liquidator_order_position_id: liquidator_order_info.order.source_position,
@@ -2000,6 +2065,28 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         deleveraged_base: i64,
         deleveraged_quote: i64,
     ) {
+        self
+            .deleverage_with_interest(
+                :deleveraged_user,
+                :deleverager_user,
+                :base_asset_id,
+                :deleveraged_base,
+                :deleveraged_quote,
+                interest_amount_deleveraged: 0,
+                interest_amount_deleverager: 0,
+            )
+    }
+
+    fn deleverage_with_interest(
+        ref self: PerpsTestsFacade,
+        deleveraged_user: User,
+        deleverager_user: User,
+        base_asset_id: AssetId,
+        deleveraged_base: i64,
+        deleveraged_quote: i64,
+        interest_amount_deleveraged: i64,
+        interest_amount_deleverager: i64,
+    ) {
         let dispatcher = IPositionsDispatcher { contract_address: self.perpetuals_contract };
         let deleveraged_balance_before = dispatcher
             .get_position_assets(position_id: deleveraged_user.position_id);
@@ -2024,14 +2111,16 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 base_asset_id: base_asset_id,
                 deleveraged_base_amount: deleveraged_base,
                 deleveraged_quote_amount: deleveraged_quote,
-                interest_amount_deleveraged: 0,
-                interest_amount_deleverager: 0,
+                :interest_amount_deleveraged,
+                :interest_amount_deleverager,
             );
 
         self
             .validate_collateral_balance(
                 position_id: deleveraged_user.position_id,
-                expected_balance: deleveraged_collateral_balance_before + deleveraged_quote.into(),
+                expected_balance: deleveraged_collateral_balance_before
+                    + deleveraged_quote.into()
+                    + interest_amount_deleveraged.into(),
             );
 
         self
@@ -2044,7 +2133,9 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         self
             .validate_collateral_balance(
                 position_id: deleverager_user.position_id,
-                expected_balance: deleverager_collateral_balance_before - deleveraged_quote.into(),
+                expected_balance: deleverager_collateral_balance_before
+                    - deleveraged_quote.into()
+                    + interest_amount_deleverager.into(),
             );
 
         self
@@ -2062,6 +2153,8 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             collateral_id: self.collateral_id,
             deleveraged_base_amount: deleveraged_base,
             deleveraged_quote_amount: deleveraged_quote,
+            :interest_amount_deleveraged,
+            :interest_amount_deleverager,
         );
     }
 
@@ -2315,6 +2408,23 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         interest_amount_sender: i64,
         interest_amount_receiver: i64,
     ) {
+        let dispatcher = IPositionsDispatcher { contract_address: self.perpetuals_contract };
+
+        let vault_collateral_before = self.get_position_collateral_balance(vault.position_id);
+        let sender_balance_before = dispatcher
+            .get_position_assets(position_id: withdrawing_user.position_id);
+        let sender_collateral_before = sender_balance_before.collateral_balance;
+        let sender_shares_before = get_synthetic_balance(
+            assets: sender_balance_before.assets, asset_id: vault.asset_id,
+        );
+
+        let is_different_receiver = withdrawing_user.position_id != receiving_user.position_id;
+        let receiver_collateral_before = if is_different_receiver {
+            self.get_position_collateral_balance(receiving_user.position_id)
+        } else {
+            sender_collateral_before
+        };
+
         let operator_nonce = self.get_nonce();
         self.operator.set_as_caller(self.perpetuals_contract);
 
@@ -2368,6 +2478,61 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 :interest_amount_sender,
                 :interest_amount_receiver,
             );
+
+        // Validate vault collateral
+        self
+            .validate_collateral_balance(
+                position_id: vault.position_id,
+                expected_balance: vault_collateral_before
+                    - actual_collateral_user.into()
+                    + interest_amount_vault_position.into(),
+            );
+
+        // Validate sender shares burned
+        self
+            .validate_asset_balance(
+                position_id: withdrawing_user.position_id,
+                asset_id: vault.asset_id,
+                expected_balance: sender_shares_before - actual_shares_user.into(),
+            );
+
+        if !is_different_receiver {
+            self
+                .validate_collateral_balance(
+                    position_id: withdrawing_user.position_id,
+                    expected_balance: sender_collateral_before
+                        + actual_collateral_user.into()
+                        + interest_amount_sender.into(),
+                );
+        } else {
+            self
+                .validate_collateral_balance(
+                    position_id: withdrawing_user.position_id,
+                    expected_balance: sender_collateral_before + interest_amount_sender.into(),
+                );
+            self
+                .validate_collateral_balance(
+                    position_id: receiving_user.position_id,
+                    expected_balance: receiver_collateral_before
+                        + actual_collateral_user.into()
+                        + interest_amount_receiver.into(),
+                );
+        }
+
+        assert_redeem_vault_shares_event_with_expected(
+            spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
+            vault_position_id: vault.position_id,
+            redeeming_position_id: withdrawing_user.position_id,
+            receiving_position_id: receiving_user.position_id,
+            vault_asset_id: vault.asset_id,
+            invested_asset_id: self.collateral_id,
+            shares_redeemed_amount: actual_shares_user,
+            collateral_received_amount: actual_collateral_user,
+            collateral_requested_amount: value_of_shares_user,
+            :interest_amount_vault_position,
+            interest_amount_redeeming_position: interest_amount_sender,
+            :interest_amount_receiver,
+        );
     }
 
     fn liquidate_shares(
@@ -2379,6 +2544,41 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         actual_shares_user: u64,
         actual_collateral_user: u64,
     ) {
+        self
+            .liquidate_shares_with_interest(
+                :vault,
+                :liquidated_user,
+                :shares_to_burn_vault,
+                :value_of_shares_vault,
+                :actual_shares_user,
+                :actual_collateral_user,
+                interest_amount_vault_position: 0,
+                interest_amount_liquidated: 0,
+            )
+    }
+
+    fn liquidate_shares_with_interest(
+        ref self: PerpsTestsFacade,
+        vault: VaultState,
+        liquidated_user: User,
+        shares_to_burn_vault: u64,
+        value_of_shares_vault: u64,
+        actual_shares_user: u64,
+        actual_collateral_user: u64,
+        interest_amount_vault_position: i64,
+        interest_amount_liquidated: i64,
+    ) {
+        let dispatcher = IPositionsDispatcher { contract_address: self.perpetuals_contract };
+        let vault_collateral_before = dispatcher
+            .get_position_assets(position_id: vault.position_id)
+            .collateral_balance;
+        let liquidated_balance_before = dispatcher
+            .get_position_assets(position_id: liquidated_user.position_id);
+        let liquidated_collateral_before = liquidated_balance_before.collateral_balance;
+        let liquidated_shares_before = get_synthetic_balance(
+            assets: liquidated_balance_before.assets, asset_id: vault.asset_id,
+        );
+
         let operator_nonce = self.get_nonce();
         self.operator.set_as_caller(self.perpetuals_contract);
 
@@ -2409,9 +2609,43 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 liquidated_asset_id: vault.asset_id,
                 actual_shares_user: -actual_shares_user.try_into().unwrap(),
                 actual_collateral_user: actual_collateral_user.try_into().unwrap(),
-                interest_amount_vault_position: 0,
-                interest_amount_liquidated: 0,
+                :interest_amount_vault_position,
+                :interest_amount_liquidated,
             );
+
+        self
+            .validate_collateral_balance(
+                position_id: vault.position_id,
+                expected_balance: vault_collateral_before
+                    - actual_collateral_user.into()
+                    + interest_amount_vault_position.into(),
+            );
+
+        self
+            .validate_collateral_balance(
+                position_id: liquidated_user.position_id,
+                expected_balance: liquidated_collateral_before
+                    + actual_collateral_user.into()
+                    + interest_amount_liquidated.into(),
+            );
+
+        self
+            .validate_synthetic_balance(
+                position_id: liquidated_user.position_id,
+                asset_id: vault.asset_id,
+                expected_balance: liquidated_shares_before - actual_shares_user.into(),
+            );
+
+        assert_liquidate_vault_shares_event_with_expected(
+            spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
+            vault_position_id: vault.position_id,
+            liquidated_position_id: liquidated_user.position_id,
+            vault_asset_id: vault.asset_id,
+            shares_liquidated_amount: actual_shares_user,
+            collateral_received_amount: actual_collateral_user,
+            :interest_amount_vault_position,
+            interest_amount_liquidated_position: interest_amount_liquidated,
+        );
     }
 
     fn deposit_into_vault(
@@ -2422,6 +2656,32 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
         depositing_user: User,
         receiving_user: User,
     ) -> DepositInfo {
+        self
+            .deposit_into_vault_with_interest(
+                :vault,
+                :amount_to_invest,
+                :min_shares_to_receive,
+                :depositing_user,
+                :receiving_user,
+                interest_amount_vault_position: 0,
+                interest_amount_sender: 0,
+            )
+    }
+
+    fn deposit_into_vault_with_interest(
+        ref self: PerpsTestsFacade,
+        vault: VaultState,
+        amount_to_invest: u64,
+        min_shares_to_receive: u64,
+        depositing_user: User,
+        receiving_user: User,
+        interest_amount_vault_position: i64,
+        interest_amount_sender: i64,
+    ) -> DepositInfo {
+        let sender_collateral_before = self
+            .get_position_collateral_balance(depositing_user.position_id);
+        let vault_collateral_before = self.get_position_collateral_balance(vault.position_id);
+
         let operator_nonce = self.get_nonce();
         self.operator.set_as_caller(self.perpetuals_contract);
         let salt = self.generate_salt();
@@ -2448,8 +2708,24 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 signature: signature,
                 order: order,
                 correlation_id: 1,
-                interest_amount_vault_position: 0,
-                interest_amount_sender: 0,
+                :interest_amount_vault_position,
+                :interest_amount_sender,
+            );
+
+        self
+            .validate_collateral_balance(
+                position_id: depositing_user.position_id,
+                expected_balance: sender_collateral_before
+                    - amount_to_invest.into()
+                    + interest_amount_sender.into(),
+            );
+
+        self
+            .validate_collateral_balance(
+                position_id: vault.position_id,
+                expected_balance: vault_collateral_before
+                    + amount_to_invest.into()
+                    + interest_amount_vault_position.into(),
             );
 
         let last_event = self.get_last_event(contract_address: self.perpetuals_contract);
@@ -2459,6 +2735,22 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
             spied_event: last_event,
             expected_event_selector: @selector!("Deposit"),
             expected_event_name: "Deposit",
+        );
+
+        let events = self.event_info.get_events().emitted_by(self.perpetuals_contract).events;
+        let invest_event = events[events.len() - 2];
+        assert_invest_in_vault_event_with_expected(
+            spied_event: invest_event,
+            vault_position_id: vault.position_id,
+            investing_position_id: depositing_user.position_id,
+            receiving_position_id: receiving_user.position_id,
+            vault_asset_id: vault.asset_id,
+            invested_asset_id: self.collateral_id,
+            shares_received: deposit_event.quantized_amount,
+            user_investment: amount_to_invest,
+            correlation_id: 1,
+            :interest_amount_vault_position,
+            :interest_amount_sender,
         );
 
         DepositInfo {

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -6595,3 +6595,413 @@ fn test_liquidate_spot_with_interest_different_receiver() {
 
     assert(state.facade.is_healthy(position_id: liquidated_user.position_id), 'should be healthy');
 }
+
+#[test]
+fn test_transfer_with_interest() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+
+    let user_1 = state.new_user_with_position();
+    let user_2 = state.new_user_with_position();
+
+    let deposit_info = state
+        .facade
+        .deposit(
+            depositor: user_1.account, position_id: user_1.position_id, quantized_amount: 100_000,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info);
+
+    let deposit_info_2 = state
+        .facade
+        .deposit(
+            depositor: user_2.account, position_id: user_2.position_id, quantized_amount: 50_000,
+        );
+    state.facade.process_deposit(deposit_info: deposit_info_2);
+
+    state.facade.advance_time(seconds: HOUR);
+
+    let transfer_info = state
+        .facade
+        .transfer_request(sender: user_1, recipient: user_2, amount: 40_000);
+    state
+        .facade
+        .transfer_with_interest(
+            :transfer_info, interest_amount_sender: 50, interest_amount_recipient: -30,
+        );
+}
+
+#[test]
+fn test_liquidate_with_interest() {
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let synthetic_info = AssetInfoTrait::new(
+        asset_name: 'BTC_1', :risk_factor_data, oracles_len: 1,
+    );
+    let asset_id = synthetic_info.asset_id;
+
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.add_active_synthetic(synthetic_info: @synthetic_info, initial_price: 100);
+
+    let liquidated_user = state.new_user_with_position();
+    let liquidator_user = state.new_user_with_position();
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit(
+                    depositor: liquidated_user.account,
+                    position_id: liquidated_user.position_id,
+                    quantized_amount: 100_000,
+                ),
+        );
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit(
+                    depositor: liquidator_user.account,
+                    position_id: liquidator_user.position_id,
+                    quantized_amount: 100_000,
+                ),
+        );
+
+    // Buy 30,000 BTC at 100. collateral = -2,900,000, synth_value = 3,000,000.
+    // PnL = 100,000. TR = 30,000.
+    let order_liquidated = state
+        .facade
+        .create_order(
+            user: liquidated_user,
+            base_amount: 30_000,
+            base_asset_id: asset_id,
+            quote_amount: -3_000_000,
+            fee_amount: 0,
+        );
+    let order_liquidator = state
+        .facade
+        .create_order(
+            user: liquidator_user,
+            base_amount: -30_000,
+            base_asset_id: asset_id,
+            quote_amount: 3_000_000,
+            fee_amount: 0,
+        );
+    state
+        .facade
+        .trade(
+            order_info_a: order_liquidated,
+            order_info_b: order_liquidator,
+            base: 30_000,
+            quote: -3_000_000,
+            fee_a: 0,
+            fee_b: 0,
+        );
+
+    // New Funding index is 3, delta = (old - new) * balance = (0 -3) * 30,000 = -90,000.
+    // TV = 100,000 - 90,000 = 10,000 < TR = 30,000 → liquidatable.
+    // PnL ≈ 10,000.
+    state.facade.advance_time(10000);
+    let new_funding_index = FundingIndex { value: 3 * FUNDING_SCALE };
+    state
+        .facade
+        .funding_tick(
+            funding_ticks: array![
+                FundingTick { asset_id: asset_id, funding_index: new_funding_index },
+            ]
+                .span(),
+        );
+
+    assert(
+        state.facade.is_liquidatable(position_id: liquidated_user.position_id),
+        'user is not liquidatable',
+    );
+
+    // max_allowed ≈ 10,000 * 36,000 * 1,200 / 2^32 ≈ 100.
+    state.facade.advance_time(seconds: 10 * HOUR);
+
+    let liquidator_order = state
+        .facade
+        .create_order(
+            user: liquidator_user,
+            base_amount: 30_000,
+            base_asset_id: asset_id,
+            quote_amount: -3_000_000,
+            fee_amount: 1,
+        );
+
+    state
+        .facade
+        .liquidate_with_interest(
+            :liquidated_user,
+            :liquidator_order,
+            liquidated_base: -30_000,
+            liquidated_quote: 3_000_000,
+            liquidated_insurance_fee: 3,
+            liquidator_fee: 1,
+            interest_amount_liquidated: -20,
+            interest_amount_liquidator: 50,
+        );
+}
+
+#[test]
+fn test_deleverage_with_interest() {
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![10].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let synthetic_info = AssetInfoTrait::new(
+        asset_name: 'BTC_1', :risk_factor_data, oracles_len: 1,
+    );
+    let asset_id = synthetic_info.asset_id;
+
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    state.facade.add_active_synthetic(synthetic_info: @synthetic_info, initial_price: 100);
+
+    let deleveraged_user = state.new_user_with_position();
+    let deleverager_user = state.new_user_with_position();
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit(
+                    depositor: deleveraged_user.account,
+                    position_id: deleveraged_user.position_id,
+                    quantized_amount: 100_000,
+                ),
+        );
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit(
+                    depositor: deleverager_user.account,
+                    position_id: deleverager_user.position_id,
+                    quantized_amount: 100_000,
+                ),
+        );
+
+    // Buy 30,000 BTC at 100. collateral = -2,900,000, synth_value = 3,000,000.
+    // PnL = 100,000.
+    let order_deleveraged = state
+        .facade
+        .create_order(
+            user: deleveraged_user,
+            base_amount: 30_000,
+            base_asset_id: asset_id,
+            quote_amount: -3_000_000,
+            fee_amount: 0,
+        );
+    let order_deleverager = state
+        .facade
+        .create_order(
+            user: deleverager_user,
+            base_amount: -30_000,
+            base_asset_id: asset_id,
+            quote_amount: 3_000_000,
+            fee_amount: 0,
+        );
+    state
+        .facade
+        .trade(
+            order_info_a: order_deleveraged,
+            order_info_b: order_deleverager,
+            base: 30_000,
+            quote: -3_000_000,
+            fee_a: 0,
+            fee_b: 0,
+        );
+
+    // New Funding index is 4, delta = (old - new) * balance = (0 - 4) * 30,000 = -120,000.
+    // TV = 100,000 - 120,000 = -20,000 < 0 → deleveragable.
+    // |PnL| ≈ 20,000.
+    state.facade.advance_time(10000);
+    let new_funding_index = FundingIndex { value: 4 * FUNDING_SCALE };
+    state
+        .facade
+        .funding_tick(
+            funding_ticks: array![
+                FundingTick { asset_id: asset_id, funding_index: new_funding_index },
+            ]
+                .span(),
+        );
+
+    assert(
+        state.facade.is_deleveragable(position_id: deleveraged_user.position_id),
+        'user is not deleveragable',
+    );
+
+    // max_allowed ≈ 20,000 * 36,000 * 1,200 / 2^32 ≈ 200.
+    state.facade.advance_time(seconds: 10 * HOUR);
+
+    // Full close. Collateral balance: -2,900,000 - 120,000 = -3,020,000.
+    // For fair deleverage (TR=0 requires TV=0): quote_amount = 3,020,000 - interest = 3,019,990.
+    state
+        .facade
+        .deleverage_with_interest(
+            :deleveraged_user,
+            :deleverager_user,
+            base_asset_id: asset_id,
+            deleveraged_base: -30_000,
+            deleveraged_quote: 3_019_990,
+            interest_amount_deleveraged: 10,
+            interest_amount_deleverager: -50,
+        );
+}
+
+#[test]
+fn test_invest_in_vault_with_interest() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position();
+    let investing_user = state.new_user_with_position();
+
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 100_000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(investing_user.account, investing_user.position_id, 100_000_u64),
+        );
+
+    state.facade.advance_time(seconds: HOUR);
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault_with_interest(
+                    vault: vault_config,
+                    amount_to_invest: 1000,
+                    min_shares_to_receive: 500,
+                    depositing_user: investing_user,
+                    receiving_user: investing_user,
+                    interest_amount_vault_position: 50,
+                    interest_amount_sender: -30,
+                ),
+        );
+}
+
+#[test]
+fn test_liquidate_vault_shares_with_interest() {
+    let mut state: FlowTestBase = FlowTestBaseTrait::new();
+    let vault_user = state.new_user_with_position_id(333_u32.into());
+    let trade_user = state.new_user_with_position();
+    let liquidated_user = state.new_user_with_position_id(555_u32.into());
+
+    // Large vault deposit so vault position PnL supports interest amount.
+    let vault_init_deposit = state
+        .facade
+        .deposit(vault_user.account, vault_user.position_id, 100_000_u64);
+    state.facade.process_deposit(vault_init_deposit);
+    let vault_config = state.facade.register_vault_share_spot_asset(vault_user, asset_name: 'VS_1');
+    state.facade.price_tick(@vault_config.asset_info, 1);
+
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(liquidated_user.account, liquidated_user.position_id, 1000_u64),
+        );
+    state
+        .facade
+        .process_deposit(
+            state.facade.deposit(trade_user.account, trade_user.position_id, 1000_u64),
+        );
+
+    state
+        .facade
+        .process_deposit(
+            state
+                .facade
+                .deposit_into_vault(
+                    vault: vault_config,
+                    amount_to_invest: 1000,
+                    min_shares_to_receive: 500,
+                    depositing_user: liquidated_user,
+                    receiving_user: liquidated_user,
+                ),
+        );
+
+    let risk_factor_data = RiskFactorTiers {
+        tiers: array![300].span(), first_tier_boundary: MAX_U128, tier_size: 1,
+    };
+    let synthetic_info = AssetInfoTrait::new(
+        asset_name: 'BTC_1', :risk_factor_data, oracles_len: 1,
+    );
+    let asset_id = synthetic_info.asset_id;
+    state.facade.add_active_synthetic(synthetic_info: @synthetic_info, initial_price: 1000);
+
+    let user_order = state
+        .facade
+        .create_order(
+            user: liquidated_user,
+            base_amount: 2,
+            base_asset_id: asset_id,
+            quote_amount: -2000,
+            fee_amount: 0,
+        );
+    let other_side_order = state
+        .facade
+        .create_order(
+            user: trade_user,
+            base_amount: -2,
+            base_asset_id: asset_id,
+            quote_amount: 2000,
+            fee_amount: 0,
+        );
+    state
+        .facade
+        .trade(
+            order_info_a: user_order,
+            order_info_b: other_side_order,
+            base: 2,
+            quote: -2000,
+            fee_a: 0,
+            fee_b: 0,
+        );
+
+    state.facade.price_tick(@synthetic_info, 600);
+
+    assert(
+        state.facade.is_liquidatable(position_id: liquidated_user.position_id),
+        'user is not liquidatable',
+    );
+
+    // Advance time then refresh prices + funding for validity.
+    // Liquidated PnL (synth only) ≈ -800. Vault PnL ≈ 100,000.
+    // max_allowed (100 hours): liquidated ≈ 80, vault ≈ 10,000.
+    state.facade.advance_time(seconds: 100 * HOUR);
+    state.facade.price_tick(@synthetic_info, 600);
+    state.facade.price_tick(@vault_config.asset_info, 1);
+    state
+        .facade
+        .funding_tick(
+            funding_ticks: array![
+                FundingTick {
+                    asset_id: synthetic_info.asset_id, funding_index: FundingIndex { value: 0 },
+                },
+            ]
+                .span(),
+        );
+
+    state
+        .facade
+        .liquidate_shares_with_interest(
+            vault: vault_config,
+            :liquidated_user,
+            shares_to_burn_vault: 400,
+            value_of_shares_vault: 400,
+            actual_shares_user: 400,
+            actual_collateral_user: 400,
+            interest_amount_vault_position: 50,
+            interest_amount_liquidated: -20,
+        );
+}

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -3825,6 +3825,8 @@ fn test_successful_deleverage() {
         collateral_id: cfg.collateral_cfg.collateral_id,
         deleveraged_base_amount: BASE,
         deleveraged_quote_amount: QUOTE,
+        interest_amount_deleveraged: 0,
+        interest_amount_deleverager: 0,
     );
 
     // Check:
@@ -3936,6 +3938,9 @@ fn test_successful_liquidate() {
         actual_liquidator_fee: FEE,
         insurance_fund_fee_amount: INSURANCE_FEE,
         liquidator_order_hash: liquidator_hash,
+        interest_amount_liquidated: 0,
+        interest_amount_liquidator: 0,
+        interest_amount_liquidator_receiver: 0,
     );
 
     // Check:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/267)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that expand coverage and tweak test helpers; risk is limited to potential brittle event indexing/assertion updates causing flaky failures.
> 
> **Overview**
> Adds explicit interest-amount coverage to the test harness for multiple flows, ensuring balance assertions and emitted events reflect non-zero interest deltas.
> 
> Updates `PerpsTestsFacade` wrappers to accept interest parameters (e.g. `transfer_with_interest`, `liquidate_with_interest`, `deleverage_with_interest`, and vault invest/redeem/liquidate-shares helpers), adjusts event assertion utilities to take interest fields instead of hardcoding `0`, and introduces new unit/flow tests that exercise positive/negative interest scenarios for transfers, liquidations, deleveraging, and vault share operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d00be1e4360f4625cfad376b805e02c8316f4c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->