### PR TITLE
chore: add a todo for cancel_invest_in_vault

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/core.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/core.cairo
@@ -823,6 +823,9 @@ pub mod Core {
                 ._get_vault_manager_dispatcher()
                 .activate_vault(:order, :signature)
         }
+        // TODO: Add cancel invest in vault. Currently, this flow depend on a non-atomic
+        // `process_deposit` step. A malicious operator could refuse to process the deposit,
+        // effectively locking user funds.
         fn invest_in_vault(
             ref self: ContractState,
             operator_nonce: u64,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Comment-only change; no executable logic or contract behavior is modified.
> 
> **Overview**
> Adds a TODO above `Core::invest_in_vault` noting the current invest flow depends on a non-atomic `process_deposit` step and should support a `cancel_invest_in_vault` path to avoid an operator locking user funds by refusing to process the deposit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d163b43907daf5b8ada5864ef52545d0ec5dd9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/270)
<!-- Reviewable:end -->
