### PR TITLE
refactor(perpetuals): refactor calculate pnl

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/positions/positions.cairo
@@ -515,8 +515,6 @@ pub mod Positions {
         fn calculate_position_pnl(
             self: @ComponentState<TContractState>, position: StoragePath<Position>,
         ) -> i64 {
-            let assets_component = get_dep_component!(self, Assets);
-
             // Use existing function to derive funding delta and unchanged assets
             // This already calculates funding and builds AssetBalanceInfo array
             let (funding_delta, assets) = self
@@ -524,20 +522,9 @@ pub mod Positions {
                     :position, position_diff: Default::default(),
                 );
 
-            // Filter to only include synthetic assets (exclude vault and spot)
-            let mut synthetic_assets = array![];
-            for asset in assets {
-                let asset_config = assets_component.get_asset_config(*asset.id);
-                if asset_config.asset_type == AssetType::SYNTHETIC {
-                    synthetic_assets.append(*asset);
-                }
-            }
             let collateral_balance = position.collateral_balance.read();
             let collateral_balance_with_funding = collateral_balance + funding_delta;
-            calculate_pnl(
-                synthetic_assets: synthetic_assets.span(),
-                collateral_balance: collateral_balance_with_funding,
-            )
+            calculate_pnl(:assets, collateral_balance: collateral_balance_with_funding)
         }
 
         fn verify_and_update_interest_range(

--- a/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/value_risk_calculator.cairo
@@ -214,7 +214,7 @@ pub fn calculate_position_tvtr(
 /// # Returns
 ///
 /// The PnL in units of 10^-6 USD
-pub fn calculate_pnl(synthetic_assets: Span<AssetBalanceInfo>, collateral_balance: Balance) -> i64 {
+pub fn calculate_pnl(assets: Span<AssetBalanceInfo>, collateral_balance: Balance) -> i64 {
     let mut pnl: i128 = 0_i128;
 
     // Add base collateral value.
@@ -222,8 +222,11 @@ pub fn calculate_pnl(synthetic_assets: Span<AssetBalanceInfo>, collateral_balanc
     pnl += collateral_price.mul(rhs: collateral_balance);
 
     // Vault and spot assets should already be excluded.
-    for synthetic in synthetic_assets {
-        let asset_value: i128 = (*synthetic.price).mul(rhs: *synthetic.balance);
+    for asset in assets {
+        if *asset.asset_type != AssetType::SYNTHETIC {
+            continue;
+        }
+        let asset_value: i128 = (*asset.price).mul(rhs: *asset.balance);
         pnl += asset_value;
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small refactor in PnL computation logic with minimal behavioral change; risk is limited to edge cases if non-synthetic assets were previously incorrectly included/excluded.
> 
> **Overview**
> Refactors position PnL calculation to stop pre-filtering assets in `Positions.calculate_position_pnl`, and instead pass the full `AssetBalanceInfo` span through.
> 
> Updates `calculate_pnl` to accept generic `assets` and internally sum only `AssetType::SYNTHETIC`, making the helper more defensive if callers include spot/vault entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d89c572209ae36909671c04d1bf59a46debcd548. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/272)
<!-- Reviewable:end -->
