### PR TITLE
chore(perpetuals): remove risk factor tiers from add spot

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets.cairo
@@ -305,9 +305,7 @@ pub mod AssetsComponent {
             asset_id: AssetId,
             erc20_contract_address: ContractAddress,
             quantum: u64,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
+            risk_factor: u16,
             quorum: u8,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
@@ -318,9 +316,7 @@ pub mod AssetsComponent {
                     asset_id: asset_id,
                     erc20_contract_address: erc20_contract_address,
                     quantum: quantum,
-                    risk_factor_tiers: risk_factor_tiers,
-                    risk_factor_first_tier_boundary: risk_factor_first_tier_boundary,
-                    risk_factor_tier_size: risk_factor_tier_size,
+                    :risk_factor,
                     quorum: quorum,
                 );
         }
@@ -331,9 +327,7 @@ pub mod AssetsComponent {
             erc20_contract_address: ContractAddress,
             quantum: u64,
             resolution_factor: u64,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
+            risk_factor: u16,
             quorum: u8,
         ) {
             get_dep_component!(@self, Roles).only_app_governor();
@@ -345,9 +339,7 @@ pub mod AssetsComponent {
                     :erc20_contract_address,
                     :quantum,
                     :resolution_factor,
-                    :risk_factor_tiers,
-                    :risk_factor_first_tier_boundary,
-                    :risk_factor_tier_size,
+                    :risk_factor,
                     :quorum,
                 );
         }

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets_manager.cairo
@@ -28,9 +28,7 @@ pub trait IAssetsExternal<TContractState> {
         asset_id: AssetId,
         erc20_contract_address: ContractAddress,
         quantum: u64,
-        risk_factor_tiers: Span<u16>,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
+        risk_factor: u16,
         quorum: u8,
     );
     fn add_spot_asset(
@@ -39,9 +37,7 @@ pub trait IAssetsExternal<TContractState> {
         erc20_contract_address: ContractAddress,
         quantum: u64,
         resolution_factor: u64,
-        risk_factor_tiers: Span<u16>,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
+        risk_factor: u16,
         quorum: u8,
     );
     fn update_asset_risk_factor(
@@ -87,11 +83,11 @@ pub(crate) mod AssetsManager {
     use perpetuals::core::types::asset::synthetic::{AssetType, SyntheticTrait};
     use perpetuals::core::types::asset::{AssetId, AssetStatus};
     use perpetuals::core::types::risk_factor::RiskFactorTrait;
-    use starknet::ContractAddress;
     use starknet::storage::{
         MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
         StoragePointerReadAccess, StoragePointerWriteAccess,
     };
+    use starknet::{ContractAddress, SyscallResultTrait};
     use starkware_utils::components::pausable::PausableComponent;
     use starkware_utils::components::roles::RolesComponent;
     use starkware_utils::constants::{TWO_POW_128, TWO_POW_40};
@@ -280,9 +276,7 @@ pub(crate) mod AssetsManager {
             asset_id: AssetId,
             erc20_contract_address: ContractAddress,
             quantum: u64,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
+            risk_factor: u16,
             quorum: u8,
         ) {
             assert(quantum == 1, 'INVALID_SHARE_QUANTUM');
@@ -300,7 +294,6 @@ pub(crate) mod AssetsManager {
                 calculated_resolution == SN_PERPS_SCALE.try_into().unwrap(),
                 'INVALID_SHARE_RESOLUTION',
             );
-            assert(risk_factor_tiers.len() == 1, 'INVALID_VAULT_RF_TIERS');
 
             assert(self.assets.asset_config.read(asset_id).is_none(), 'SYNTHETIC_ALREADY_EXISTS');
             if let Option::Some(collateral_id) = self.assets.collateral_id.read() {
@@ -308,14 +301,10 @@ pub(crate) mod AssetsManager {
             }
 
             assert(asset_id.is_non_zero(), 'INVALID_ZERO_ASSET_ID');
-            assert(risk_factor_first_tier_boundary.is_non_zero(), 'INVALID_ZERO_RF_FIRST_BOUNDRY');
-            assert(risk_factor_tier_size.is_non_zero(), 'INVALID_ZERO_RF_TIER_SIZE');
             assert(quorum.is_non_zero(), 'INVALID_ZERO_QUORUM');
 
             let asset_config = SyntheticTrait::vault_share(
                 AssetStatus::PENDING,
-                risk_factor_first_tier_boundary,
-                risk_factor_tier_size,
                 quorum,
                 calculated_resolution,
                 quantum,
@@ -326,24 +315,13 @@ pub(crate) mod AssetsManager {
 
             self.assets.timely_data.write(asset_id, Default::default());
 
-            let mut prev_risk_factor = 0_u16;
-            for risk_factor in risk_factor_tiers {
-                assert(prev_risk_factor < *risk_factor, UNSORTED_RISK_FACTOR_TIERS);
-                self
-                    .assets
-                    .risk_factor_tiers
-                    .entry(asset_id)
-                    .push(RiskFactorTrait::new(*risk_factor));
-                prev_risk_factor = *risk_factor;
-            }
+            self.assets.risk_factor_tiers.entry(asset_id).push(RiskFactorTrait::new(risk_factor));
 
             self
                 .emit(
                     events::SpotAssetAdded {
                         asset_id,
-                        risk_factor_tiers,
-                        risk_factor_first_tier_boundary,
-                        risk_factor_tier_size,
+                        risk_factor,
                         resolution_factor: calculated_resolution,
                         quorum,
                         contract_address: erc20_contract_address,
@@ -358,18 +336,15 @@ pub(crate) mod AssetsManager {
             erc20_contract_address: ContractAddress,
             quantum: u64,
             resolution_factor: u64,
-            risk_factor_tiers: Span<u16>,
-            risk_factor_first_tier_boundary: u128,
-            risk_factor_tier_size: u128,
+            risk_factor: u16,
             quorum: u8,
         ) {
-            assert(erc20_contract_address.is_non_zero(), 'INVALID_ZERO_ADDRESS');
+            let class_hash = starknet::syscalls::get_class_hash_at_syscall(erc20_contract_address)
+                .unwrap_syscall();
+            assert(class_hash.is_non_zero(), 'UNDEPLOYED_ADDRESS');
             assert(quantum.is_non_zero(), 'INVALID_SPOT_QUANTUM');
-            assert(risk_factor_tiers.len() == 1, 'INVALID_VAULT_RF_TIERS');
             assert(resolution_factor.is_non_zero(), 'INVALID_ZERO_RESOLUTION_FACTOR');
             assert(asset_id.is_non_zero(), 'INVALID_ZERO_ASSET_ID');
-            assert(risk_factor_first_tier_boundary.is_non_zero(), 'INVALID_ZERO_RF_FIRST_BOUNDRY');
-            assert(risk_factor_tier_size.is_non_zero(), 'INVALID_ZERO_RF_TIER_SIZE');
             assert(quorum.is_non_zero(), 'INVALID_ZERO_QUORUM');
 
             assert(self.assets.asset_config.read(asset_id).is_none(), 'ASSET_ALREADY_EXISTS');
@@ -378,37 +353,20 @@ pub(crate) mod AssetsManager {
             }
 
             let asset_config = SyntheticTrait::spot(
-                AssetStatus::PENDING,
-                risk_factor_first_tier_boundary,
-                risk_factor_tier_size,
-                quorum,
-                resolution_factor,
-                quantum,
-                erc20_contract_address,
+                AssetStatus::PENDING, quorum, resolution_factor, quantum, erc20_contract_address,
             );
 
             self.assets.asset_config.write(asset_id, Option::Some(asset_config));
 
             self.assets.timely_data.write(asset_id, Default::default());
 
-            let mut prev_risk_factor = 0_u16;
-            for risk_factor in risk_factor_tiers {
-                assert(prev_risk_factor < *risk_factor, UNSORTED_RISK_FACTOR_TIERS);
-                self
-                    .assets
-                    .risk_factor_tiers
-                    .entry(asset_id)
-                    .push(RiskFactorTrait::new(*risk_factor));
-                prev_risk_factor = *risk_factor;
-            }
+            self.assets.risk_factor_tiers.entry(asset_id).push(RiskFactorTrait::new(risk_factor));
 
             self
                 .emit(
                     events::SpotAssetAdded {
                         asset_id,
-                        risk_factor_tiers,
-                        risk_factor_first_tier_boundary,
-                        risk_factor_tier_size,
+                        risk_factor,
                         resolution_factor,
                         quorum,
                         contract_address: erc20_contract_address,

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/events.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/events.cairo
@@ -40,9 +40,7 @@ pub struct AssetChanged {
 pub struct SpotAssetAdded {
     #[key]
     pub asset_id: AssetId,
-    pub risk_factor_tiers: Span<u16>,
-    pub risk_factor_first_tier_boundary: u128,
-    pub risk_factor_tier_size: u128,
+    pub risk_factor: u16,
     pub resolution_factor: u64,
     pub quorum: u8,
     pub contract_address: ContractAddress,

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/interface.cairo
@@ -80,9 +80,7 @@ pub trait IAssetsManager<TContractState> {
         asset_id: AssetId,
         erc20_contract_address: ContractAddress,
         quantum: u64,
-        risk_factor_tiers: Span<u16>,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
+        risk_factor: u16,
         quorum: u8,
     );
     fn add_spot_asset(
@@ -91,9 +89,7 @@ pub trait IAssetsManager<TContractState> {
         erc20_contract_address: ContractAddress,
         quantum: u64,
         resolution_factor: u64,
-        risk_factor_tiers: Span<u16>,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
+        risk_factor: u16,
         quorum: u8,
     );
     fn deactivate_synthetic(ref self: TContractState, synthetic_id: AssetId);

--- a/workspace/apps/perpetuals/contracts/src/core/types/asset/synthetic.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/types/asset/synthetic.cairo
@@ -1,4 +1,4 @@
-use core::num::traits::Zero;
+use core::num::traits::{Bounded, Zero};
 use perpetuals::core::types::asset::{AssetId, AssetStatus};
 use perpetuals::core::types::balance::Balance;
 use perpetuals::core::types::funding::FundingIndex;
@@ -10,8 +10,8 @@ use starknet::syscalls::storage_read_syscall;
 use starknet::{ContractAddress, SyscallResultTrait};
 use starkware_utils::time::time::Timestamp;
 
-
 const VERSION: u8 = 1;
+pub const MAX_U128: u128 = Bounded::<u128>::MAX;
 
 #[derive(Copy, Debug, Drop, PartialEq, Serde, starknet::Store, Default)]
 pub enum AssetType {
@@ -112,8 +112,6 @@ pub impl SyntheticImpl of SyntheticTrait {
 
     fn spot(
         status: AssetStatus,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
         quorum: u8,
         resolution_factor: u64,
         quantum: u64,
@@ -122,8 +120,8 @@ pub impl SyntheticImpl of SyntheticTrait {
         AssetConfig {
             version: VERSION,
             status,
-            risk_factor_first_tier_boundary,
-            risk_factor_tier_size,
+            risk_factor_first_tier_boundary: MAX_U128,
+            risk_factor_tier_size: 0,
             quorum,
             resolution_factor,
             quantum: quantum,
@@ -134,8 +132,6 @@ pub impl SyntheticImpl of SyntheticTrait {
 
     fn vault_share(
         status: AssetStatus,
-        risk_factor_first_tier_boundary: u128,
-        risk_factor_tier_size: u128,
         quorum: u8,
         resolution_factor: u64,
         quantum: u64,
@@ -144,8 +140,8 @@ pub impl SyntheticImpl of SyntheticTrait {
         AssetConfig {
             version: VERSION,
             status,
-            risk_factor_first_tier_boundary,
-            risk_factor_tier_size,
+            risk_factor_first_tier_boundary: MAX_U128,
+            risk_factor_tier_size: 0,
             quorum,
             resolution_factor,
             quantum: quantum,

--- a/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/event_test_utils.cairo
@@ -576,23 +576,14 @@ pub fn assert_change_asset_event_with_expected(
 pub fn assert_add_spot_event_with_expected(
     spied_event: @(ContractAddress, Event),
     asset_id: AssetId,
-    risk_factor_tiers: Span<u16>,
-    risk_factor_first_tier_boundary: u128,
-    risk_factor_tier_size: u128,
+    risk_factor: u16,
     resolution_factor: u64,
     quorum: u8,
     contract_address: ContractAddress,
     quantum: u64,
 ) {
     let expected_event = assets_events::SpotAssetAdded {
-        asset_id,
-        risk_factor_tiers,
-        risk_factor_first_tier_boundary,
-        risk_factor_tier_size,
-        resolution_factor,
-        quorum,
-        contract_address,
-        quantum,
+        asset_id, risk_factor, resolution_factor, quorum, contract_address, quantum,
     };
     assert_expected_event_emitted(
         :spied_event,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/perps_tests_facade.cairo
@@ -735,18 +735,14 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 asset_id,
                 erc20_contract_address: vault.contract_address,
                 quantum: 1,
-                risk_factor_tiers: risk_factor_1,
-                :risk_factor_first_tier_boundary,
-                :risk_factor_tier_size,
+                risk_factor: *risk_factor_1[0],
                 quorum: asset_info.oracles.len().try_into().unwrap(),
             );
 
         assert_add_spot_event_with_expected(
             spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
             asset_id: asset_info.asset_id,
-            risk_factor_tiers: asset_info.risk_factor_data.tiers,
-            risk_factor_first_tier_boundary: asset_info.risk_factor_data.first_tier_boundary,
-            risk_factor_tier_size: asset_info.risk_factor_data.tier_size,
+            risk_factor: *asset_info.risk_factor_data.tiers[0],
             resolution_factor: asset_info.resolution_factor,
             quorum: asset_info.oracles.len().try_into().unwrap(),
             contract_address: vault.contract_address,
@@ -2222,18 +2218,14 @@ pub impl PerpsTestsFacadeImpl of PerpsTestsFacadeTrait {
                 erc20_contract_address: *asset_info.erc20_contract_address,
                 quantum: *asset_info.quantum,
                 resolution_factor: *asset_info.resolution_factor,
-                risk_factor_tiers: risk_factor_data.tiers,
-                risk_factor_first_tier_boundary: risk_factor_data.first_tier_boundary,
-                risk_factor_tier_size: risk_factor_data.tier_size,
+                risk_factor: *risk_factor_data.tiers[0],
                 quorum: asset_info.oracles.len().try_into().unwrap(),
             );
 
         assert_add_spot_event_with_expected(
             spied_event: self.get_last_event(contract_address: self.perpetuals_contract),
             asset_id: *asset_info.asset_id,
-            risk_factor_tiers: risk_factor_data.tiers,
-            risk_factor_first_tier_boundary: risk_factor_data.first_tier_boundary,
-            risk_factor_tier_size: risk_factor_data.tier_size,
+            risk_factor: *risk_factor_data.tiers[0],
             resolution_factor: *asset_info.resolution_factor,
             quorum: asset_info.oracles.len().try_into().unwrap(),
             contract_address: *asset_info.erc20_contract_address,

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_deposit_tests.cairo
@@ -1,65 +1,9 @@
 use openzeppelin::interfaces::erc4626::{IERC4626Dispatcher, IERC4626DispatcherTrait};
-use perpetuals::core::components::assets::interface::{
-    IAssetsManagerDispatcher, IAssetsManagerDispatcherTrait,
-};
 use perpetuals::tests::constants::*;
 use perpetuals::tests::flow_tests::infra::*;
 use perpetuals::tests::flow_tests::perps_tests_facade::*;
 use perpetuals::tests::test_utils::assert_with_error;
-use starkware_utils_testing::test_utils::{TokenTrait, cheat_caller_address_once};
-
-#[test]
-#[should_panic(expected: 'INVALID_VAULT_RF_TIERS')]
-fn test_registering_vault_shares_with_more_than_one_risk_tier_fails() {
-    let mut state: FlowTestBase = FlowTestBaseTrait::new();
-    let vault_user = state.new_user_with_position();
-    let vault_init_deposit = state
-        .facade
-        .deposit(vault_user.account, vault_user.position_id, 5000_u64);
-    state.facade.process_deposit(vault_init_deposit);
-
-    let vault = deploy_protocol_vault_with_dispatcher(
-        perps_address: state.facade.perpetuals_contract,
-        vault_position_id: vault_user.position_id,
-        usdc_token_state: state.facade.token_state,
-    );
-
-    let risk_factor_first_tier_boundary = 1000;
-    let risk_factor_tier_size = 1;
-    let risk_factor_1 = array![100, 200].span();
-
-    let asset_info = AssetInfoTrait::new_with_resolution(
-        asset_name: 'VS_1',
-        risk_factor_data: RiskFactorTiers {
-            tiers: risk_factor_1,
-            first_tier_boundary: risk_factor_first_tier_boundary,
-            tier_size: risk_factor_tier_size,
-        },
-        oracles_len: 1,
-        resolution: 1000000,
-    );
-
-    let asset_id = asset_info.asset_id;
-    let assets_dispatcher = IAssetsManagerDispatcher {
-        contract_address: state.facade.perpetuals_contract,
-    };
-
-    cheat_caller_address_once(
-        contract_address: state.facade.perpetuals_contract,
-        caller_address: state.facade.app_governor,
-    );
-
-    assets_dispatcher
-        .add_vault_collateral_asset(
-            asset_id,
-            erc20_contract_address: vault.contract_address,
-            quantum: 1,
-            risk_factor_tiers: risk_factor_1,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
-            quorum: asset_info.oracles.len().try_into().unwrap(),
-        );
-}
+use starkware_utils_testing::test_utils::TokenTrait;
 
 #[test]
 fn test_deposit_into_protocol_vault_recieve_to_same_position() {

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/procotol_vault_redeem_tests.cairo
@@ -15,7 +15,6 @@ use starkware_utils::hash::message_hash::OffchainMessageHash;
 use starkware_utils_testing::test_utils::TokenTrait;
 use super::perps_tests_facade::PerpsTestsFacadeTrait;
 
-
 pub const MAX_U128: u128 = Bounded::<u128>::MAX;
 
 #[test]

--- a/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/test_utils.cairo
@@ -213,9 +213,7 @@ impl PerpetualsInitConfigDefault of Default<PerpetualsInitConfig> {
 
         let vault_share_state = deploy_vault_share(@vault_share_cfg);
 
-        let vault_share_risk_factor_first_tier_boundary = MAX_U128;
-        let vault_share_risk_factor_tier_size = 1;
-        let vault_share_risk_factor_1 = array![10].span();
+        let vault_share_risk_factor = 10;
 
         PerpetualsInitConfig {
             governance_admin: GOVERNANCE_ADMIN(),
@@ -254,9 +252,7 @@ impl PerpetualsInitConfigDefault of Default<PerpetualsInitConfig> {
                 token_state: vault_share_state,
                 collateral_id: VAULT_SHARE_COLLATERAL_1_ID(),
                 quantum: 1,
-                risk_factor_tiers: vault_share_risk_factor_1,
-                risk_factor_first_tier_boundary: vault_share_risk_factor_first_tier_boundary,
-                risk_factor_tier_size: vault_share_risk_factor_tier_size,
+                risk_factor: vault_share_risk_factor,
                 quorum: 1,
                 contract_address: vault_share_state.address,
                 resolution_factor: 1000000,
@@ -266,9 +262,7 @@ impl PerpetualsInitConfigDefault of Default<PerpetualsInitConfig> {
                 token_state: spot_token_state,
                 collateral_id: SPOT_COLLATERAL_ASSET_ID(),
                 quantum: 1,
-                risk_factor_tiers: vault_share_risk_factor_1,
-                risk_factor_first_tier_boundary: vault_share_risk_factor_first_tier_boundary,
-                risk_factor_tier_size: vault_share_risk_factor_tier_size,
+                risk_factor: vault_share_risk_factor,
                 quorum: 1,
                 contract_address: spot_token_state.address,
                 resolution_factor: 1,
@@ -295,9 +289,7 @@ pub struct SpotCollateralCfg {
     pub token_state: TokenState,
     pub collateral_id: AssetId,
     pub quantum: u64,
-    pub risk_factor_tiers: Span<u16>,
-    pub risk_factor_first_tier_boundary: u128,
-    pub risk_factor_tier_size: u128,
+    pub risk_factor: u16,
     pub quorum: u8,
     pub contract_address: ContractAddress,
     pub resolution_factor: u64,
@@ -416,15 +408,10 @@ pub fn setup_state_with_pending_spot_asset(
             erc20_contract_address: *cfg.spot_cfg.contract_address,
             quantum: *cfg.spot_cfg.quantum,
             resolution_factor: *cfg.spot_cfg.resolution_factor,
-            risk_factor_tiers: array![RISK_FACTOR].span(),
-            risk_factor_first_tier_boundary: MAX_U128,
-            risk_factor_tier_size: MAX_U128,
+            risk_factor: RISK_FACTOR,
             quorum: *cfg.spot_cfg.quorum,
         );
-    cfg
-        .spot_cfg
-        .token_state
-        .fund(recipient: test_address(), amount: CONTRACT_INIT_BALANCE.try_into().unwrap());
+    cfg.spot_cfg.token_state.fund(recipient: test_address(), amount: CONTRACT_INIT_BALANCE);
     state
 }
 
@@ -450,9 +437,7 @@ pub fn setup_state_with_pending_vault_share(
             asset_id: *cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: *cfg.vault_share_cfg.contract_address,
             quantum: *cfg.vault_share_cfg.quantum,
-            risk_factor_tiers: *cfg.vault_share_cfg.risk_factor_tiers,
-            risk_factor_first_tier_boundary: *cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-            risk_factor_tier_size: *cfg.vault_share_cfg.risk_factor_tier_size,
+            risk_factor: *cfg.vault_share_cfg.risk_factor,
             quorum: 1_u8,
         );
     state

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -1720,7 +1720,7 @@ fn test_rf_increase_with_request_spot() {
     let spot_asset_id = SYNTHETIC_ASSET_ID_2();
     let risk_factor_first_tier_boundary = MAX_U128;
     let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let risk_factor_tiers_increased = array![15].span();
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
@@ -1735,9 +1735,7 @@ fn test_rf_increase_with_request_spot() {
             :erc20_contract_address,
             :quantum,
             :resolution_factor,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             :quorum,
         );
 
@@ -1784,7 +1782,7 @@ fn test_rf_increase_with_request_vault() {
     let vault_asset_id = cfg.vault_share_cfg.collateral_id;
     let risk_factor_first_tier_boundary = MAX_U128;
     let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let risk_factor_tiers_increased = array![15].span();
     let quorum = 1_u8;
     let quantum = cfg.vault_share_cfg.quantum;
@@ -1794,13 +1792,7 @@ fn test_rf_increase_with_request_vault() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     assets_manager_dispatcher
         .add_vault_collateral_asset(
-            asset_id: vault_asset_id,
-            :erc20_contract_address,
-            :quantum,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
-            :quorum,
+            asset_id: vault_asset_id, :erc20_contract_address, :quantum, :risk_factor, :quorum,
         );
 
     // Request risk factor increase (app governor)
@@ -1984,7 +1976,7 @@ fn test_rf_update_spot_multiple_tiers_invalid() {
     let spot_asset_id = SYNTHETIC_ASSET_ID_2();
     let risk_factor_first_tier_boundary = MAX_U128;
     let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let risk_factor_tiers_invalid = array![10, 15].span();
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
@@ -1999,9 +1991,7 @@ fn test_rf_update_spot_multiple_tiers_invalid() {
             :erc20_contract_address,
             :quantum,
             :resolution_factor,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             :quorum,
         );
 
@@ -2030,7 +2020,7 @@ fn test_rf_update_vault_multiple_tiers_invalid() {
     let vault_asset_id = cfg.vault_share_cfg.collateral_id;
     let risk_factor_first_tier_boundary = MAX_U128;
     let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let risk_factor_tiers_invalid = array![10, 15].span();
     let quorum = 1_u8;
     let quantum = cfg.vault_share_cfg.quantum;
@@ -2040,13 +2030,7 @@ fn test_rf_update_vault_multiple_tiers_invalid() {
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
     assets_manager_dispatcher
         .add_vault_collateral_asset(
-            asset_id: vault_asset_id,
-            :erc20_contract_address,
-            :quantum,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
-            :quorum,
+            asset_id: vault_asset_id, :erc20_contract_address, :quantum, :risk_factor, :quorum,
         );
 
     // Try to update with multiple tiers (should fail - vault assets can only have 1 tier)
@@ -4790,9 +4774,7 @@ fn test_funding_tick_vault_share_asset() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
-            risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-            risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
+            risk_factor: cfg.vault_share_cfg.risk_factor,
             quorum: 1_u8,
         );
 
@@ -5383,9 +5365,7 @@ fn test_unsuccessful_add_vault_share_asset_zero_quantum() {
     let vault_share_state = cfg.vault_share_cfg.token_cfg.deploy();
 
     // Setup test parameters:
-    let risk_factor_first_tier_boundary = MAX_U128;
-    let risk_factor_tier_size = 1;
-    let risk_factor_1 = array![10].span();
+    let risk_factor = 10;
 
     // Test:
     cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
@@ -5394,9 +5374,7 @@ fn test_unsuccessful_add_vault_share_asset_zero_quantum() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: vault_share_state.address,
             quantum: 0,
-            risk_factor_tiers: risk_factor_1,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             quorum: 1_u8,
         );
 }
@@ -5410,9 +5388,7 @@ fn test_unsuccessful_add_vault_share_asset_not_erc20() {
     let mut state = setup_state_with_active_synthetic(cfg: @cfg, token_state: @token_state);
 
     // Setup test parameters:
-    let risk_factor_first_tier_boundary = MAX_U128;
-    let risk_factor_tier_size = 1;
-    let risk_factor_1 = array![10].span();
+    let risk_factor = 10;
 
     // Test:
     cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
@@ -5421,9 +5397,7 @@ fn test_unsuccessful_add_vault_share_asset_not_erc20() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: test_address(),
             quantum: 1,
-            risk_factor_tiers: risk_factor_1,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             quorum: 1_u8,
         );
 }
@@ -5447,9 +5421,7 @@ fn test_successful_add_vault_share_asset() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
-            risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-            risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
+            risk_factor: cfg.vault_share_cfg.risk_factor,
             quorum: 1_u8,
         );
 
@@ -5458,9 +5430,7 @@ fn test_successful_add_vault_share_asset() {
     assert_add_spot_event_with_expected(
         spied_event: events[0],
         asset_id: cfg.vault_share_cfg.collateral_id,
-        risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
-        risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-        risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
+        risk_factor: cfg.vault_share_cfg.risk_factor,
         resolution_factor: cfg.vault_share_cfg.resolution_factor,
         quorum: 1_u8,
         contract_address: cfg.vault_share_cfg.contract_address,
@@ -5470,13 +5440,6 @@ fn test_successful_add_vault_share_asset() {
     let asset_config = state.assets.get_asset_config(cfg.vault_share_cfg.collateral_id);
 
     assert!(asset_config.resolution_factor == 1000000);
-    assert!(
-        asset_config
-            .risk_factor_first_tier_boundary == cfg
-            .vault_share_cfg
-            .risk_factor_first_tier_boundary,
-    );
-    assert!(asset_config.risk_factor_tier_size == cfg.vault_share_cfg.risk_factor_tier_size);
     assert!(asset_config.quorum == 1_u8);
     assert!(asset_config.status == AssetStatus::PENDING);
 }
@@ -5491,9 +5454,7 @@ fn test_successful_add_spot_asset() {
 
     // Setup test parameters:
     let spot_asset_id = SYNTHETIC_ASSET_ID_2();
-    let risk_factor_first_tier_boundary = MAX_U128;
-    let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
     let quantum = 12_u64;
@@ -5507,9 +5468,7 @@ fn test_successful_add_spot_asset() {
             :erc20_contract_address,
             :quantum,
             :resolution_factor,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             :quorum,
         );
 
@@ -5518,9 +5477,7 @@ fn test_successful_add_spot_asset() {
     assert_add_spot_event_with_expected(
         spied_event: events[0],
         asset_id: spot_asset_id,
-        risk_factor_tiers: risk_factor_tiers,
-        :risk_factor_first_tier_boundary,
-        :risk_factor_tier_size,
+        :risk_factor,
         :resolution_factor,
         :quorum,
         contract_address: erc20_contract_address,
@@ -5530,8 +5487,6 @@ fn test_successful_add_spot_asset() {
     // Check:
     let asset_config = state.assets.get_asset_config(spot_asset_id);
     assert!(asset_config.resolution_factor == resolution_factor);
-    assert!(asset_config.risk_factor_first_tier_boundary == risk_factor_first_tier_boundary);
-    assert!(asset_config.risk_factor_tier_size == risk_factor_tier_size);
     assert!(asset_config.quorum == quorum);
     assert!(asset_config.quantum == quantum);
     assert!(asset_config.status == AssetStatus::PENDING);
@@ -5547,9 +5502,7 @@ fn test_unsuccessful_add_spot_asset_zero_quantum() {
 
     // Setup test parameters:
     let spot_asset_id = SYNTHETIC_ASSET_ID_2();
-    let risk_factor_first_tier_boundary = MAX_U128;
-    let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
     let quantum = 0_u64;
@@ -5563,9 +5516,7 @@ fn test_unsuccessful_add_spot_asset_zero_quantum() {
             :erc20_contract_address,
             :quantum,
             :resolution_factor,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             :quorum,
         );
 }
@@ -5580,9 +5531,7 @@ fn test_unsuccessful_add_spot_asset_existing_asset() {
 
     // Use the existing synthetic asset id so that the asset is already registered.
     let spot_asset_id = cfg.synthetic_cfg.synthetic_id;
-    let risk_factor_first_tier_boundary = MAX_U128;
-    let risk_factor_tier_size = 1;
-    let risk_factor_tiers = array![10].span();
+    let risk_factor = 10;
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
     let quantum = 1_u64;
@@ -5596,9 +5545,7 @@ fn test_unsuccessful_add_spot_asset_existing_asset() {
             :erc20_contract_address,
             :quantum,
             :resolution_factor,
-            :risk_factor_tiers,
-            :risk_factor_first_tier_boundary,
-            :risk_factor_tier_size,
+            :risk_factor,
             :quorum,
         );
 }
@@ -5619,9 +5566,7 @@ fn test_successful_vault_token_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
-            risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-            risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
+            risk_factor: cfg.vault_share_cfg.risk_factor,
             quorum: 1_u8,
         );
 
@@ -5762,9 +5707,7 @@ fn test_successful_vault_token_cancel_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
-            risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-            risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
+            risk_factor: cfg.vault_share_cfg.risk_factor,
             quorum: 1_u8,
         );
 
@@ -5870,9 +5813,7 @@ fn test_successful_vault_share_process_deposit() {
             asset_id: cfg.vault_share_cfg.collateral_id,
             erc20_contract_address: cfg.vault_share_cfg.contract_address,
             quantum: cfg.vault_share_cfg.quantum,
-            risk_factor_tiers: cfg.vault_share_cfg.risk_factor_tiers,
-            risk_factor_first_tier_boundary: cfg.vault_share_cfg.risk_factor_first_tier_boundary,
-            risk_factor_tier_size: cfg.vault_share_cfg.risk_factor_tier_size,
+            risk_factor: cfg.vault_share_cfg.risk_factor,
             quorum: 1_u8,
         );
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches asset-registration entrypoints/events and adds a new deployment validation, which can affect integrations and on-chain behavior for adding spot/vault collateral assets; changes are localized but protocol-critical.
> 
> **Overview**
> Simplifies spot-collateral and vault-share asset registration APIs to accept a single `risk_factor` instead of `risk_factor_tiers` plus tier-boundary parameters, and updates the `SpotAssetAdded` event payload accordingly.
> 
> On-chain registration now stores exactly one risk factor tier for these asset types, sets their tier-boundary config fields to sentinel defaults in `SyntheticTrait::spot`/`vault_share`, and adds an explicit deployed-contract check for `add_spot_asset` via `get_class_hash_at`.
> 
> Updates all affected interfaces, dispatchers, and tests, and removes the test that expected vault share registration to fail with multiple tiers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ddbb675cf5087bd4f1e68d89f22d2633f5f4618. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/275)
<!-- Reviewable:end -->
