### PR TITLE
chore(perpetuals): validate unique address in add asset

### DIFF
--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/assets_manager.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/assets_manager.cairo
@@ -84,8 +84,8 @@ pub(crate) mod AssetsManager {
     use perpetuals::core::types::asset::{AssetId, AssetStatus};
     use perpetuals::core::types::risk_factor::RiskFactorTrait;
     use starknet::storage::{
-        MutableVecTrait, StorageMapReadAccess, StorageMapWriteAccess, StoragePathEntry,
-        StoragePointerReadAccess, StoragePointerWriteAccess,
+        MutableVecTrait, StorageAsPointer, StorageMapReadAccess, StorageMapWriteAccess,
+        StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
     };
     use starknet::{ContractAddress, SyscallResultTrait};
     use starkware_utils::components::pausable::PausableComponent;
@@ -93,19 +93,20 @@ pub(crate) mod AssetsManager {
     use starkware_utils::constants::{TWO_POW_128, TWO_POW_40};
     use starkware_utils::signature::stark::{HashType, PublicKey};
     use starkware_utils::storage::iterable_map::{
-        IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapWriteAccessImpl,
+        IterableMapIntoIterImpl, IterableMapReadAccessImpl, IterableMapTrait,
+        IterableMapWriteAccessImpl,
     };
     use starkware_utils::storage::utils::SubFromStorage;
     use starkware_utils::time::time::TimeDelta;
     use crate::core::components::assets::errors::{
-        ASSET_NAME_TOO_LONG, ASSET_REGISTERED_AS_COLLATERAL, INACTIVE_ASSET,
-        INVALID_NON_SYNTHETIC_RF_TIERS, INVALID_SAME_QUORUM, INVALID_SPOT_RF_BOUNDARY,
-        INVALID_SPOT_RF_TIER_SIZE, INVALID_ZERO_ASSET_ID, INVALID_ZERO_ASSET_NAME,
-        INVALID_ZERO_ORACLE_NAME, INVALID_ZERO_PUBLIC_KEY, INVALID_ZERO_QUORUM,
-        INVALID_ZERO_RF_FIRST_BOUNDRY, INVALID_ZERO_RF_TIERS_LEN, INVALID_ZERO_RF_TIER_SIZE,
-        NOT_SYNTHETIC, ORACLE_ALREADY_EXISTS, ORACLE_NAME_TOO_LONG, ORACLE_NOT_EXISTS,
-        RF_REQUEST_MISMATCH, RF_REQUEST_NOT_FOUND, SYNTHETIC_NOT_ACTIVE, SYNTHETIC_NOT_EXISTS,
-        UNSORTED_RISK_FACTOR_TIERS,
+        ASSET_NAME_TOO_LONG, ASSET_REGISTERED_AS_COLLATERAL, ASSET_TOKEN_ADDRESS_USED,
+        INACTIVE_ASSET, INVALID_NON_SYNTHETIC_RF_TIERS, INVALID_SAME_QUORUM,
+        INVALID_SPOT_RF_BOUNDARY, INVALID_SPOT_RF_TIER_SIZE, INVALID_ZERO_ASSET_ID,
+        INVALID_ZERO_ASSET_NAME, INVALID_ZERO_ORACLE_NAME, INVALID_ZERO_PUBLIC_KEY,
+        INVALID_ZERO_QUORUM, INVALID_ZERO_RF_FIRST_BOUNDRY, INVALID_ZERO_RF_TIERS_LEN,
+        INVALID_ZERO_RF_TIER_SIZE, NOT_SYNTHETIC, ORACLE_ALREADY_EXISTS, ORACLE_NAME_TOO_LONG,
+        ORACLE_NOT_EXISTS, RF_REQUEST_MISMATCH, RF_REQUEST_NOT_FOUND, SYNTHETIC_NOT_ACTIVE,
+        SYNTHETIC_NOT_EXISTS, UNSORTED_RISK_FACTOR_TIERS,
     };
     use crate::core::components::assets::events;
     use crate::core::components::external_components::interface::EXTERNAL_COMPONENT_ASSETS;
@@ -309,6 +310,9 @@ pub(crate) mod AssetsManager {
             assert(asset_id.is_non_zero(), 'INVALID_ZERO_ASSET_ID');
             assert(quorum.is_non_zero(), 'INVALID_ZERO_QUORUM');
 
+            // Check that the contract address is unique
+            self._assert_contract_address_unique(checked_address: erc20_contract_address);
+
             let asset_config = SyntheticTrait::vault_share(
                 AssetStatus::PENDING,
                 quorum,
@@ -357,6 +361,9 @@ pub(crate) mod AssetsManager {
             if let Option::Some(collateral_id) = self.assets.collateral_id.read() {
                 assert(collateral_id != asset_id, ASSET_REGISTERED_AS_COLLATERAL);
             }
+
+            // Check that the contract address is unique
+            self._assert_contract_address_unique(checked_address: erc20_contract_address);
 
             let asset_config = SyntheticTrait::spot(
                 AssetStatus::PENDING, quorum, resolution_factor, quantum, erc20_contract_address,
@@ -564,6 +571,39 @@ pub(crate) mod AssetsManager {
 
         fn get_max_funding_rate(self: @ContractState) -> u32 {
             self.assets.max_funding_rate.read()
+        }
+    }
+
+    #[generate_trait]
+    impl PrivateImpl of PrivateTrait {
+        /// Assert that the contract address is not already used by any asset.
+        /// Iterates over all assets and checks if any asset uses the given contract address.
+        fn _assert_contract_address_unique(
+            ref self: ContractState, checked_address: ContractAddress,
+        ) {
+            // First check if the contract address is the base collateral token contract address.
+            assert(
+                self
+                    .assets
+                    .get_base_collateral_token_contract()
+                    .contract_address != checked_address,
+                ASSET_TOKEN_ADDRESS_USED,
+            );
+
+            let mut timely_data_key_iter = self.assets.timely_data.keys_iter();
+            while let Option::Some(asset_id) = timely_data_key_iter.next() {
+                let asset_id = asset_id.read();
+                let entry = (@self).assets.asset_config.entry(asset_id).as_ptr();
+                if let Some(asset_type) = SyntheticTrait::get_asset_type(entry) {
+                    if asset_type != AssetType::SYNTHETIC {
+                        // Check if this asset has a contract address
+                        assert(
+                            SyntheticTrait::at_token_contract(entry) != checked_address,
+                            ASSET_TOKEN_ADDRESS_USED,
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/workspace/apps/perpetuals/contracts/src/core/components/assets/errors.cairo
+++ b/workspace/apps/perpetuals/contracts/src/core/components/assets/errors.cairo
@@ -53,6 +53,7 @@ pub const ZERO_MAX_ORACLE_PRICE: felt252 = 'ZERO_MAX_ORACLE_PRICE';
 pub const RF_REQUEST_NOT_FOUND: felt252 = 'RF_REQUEST_NOT_FOUND';
 pub const RF_REQUEST_MISMATCH: felt252 = 'RF_REQUEST_MISMATCH';
 pub const CANNOT_WITHDRAW_SYNTHETIC: felt252 = 'CANNOT_WITHDRAW_SYNTHETIC';
+pub const ASSET_TOKEN_ADDRESS_USED: felt252 = 'ASSET_TOKEN_ADDRESS_USED';
 
 
 pub fn oracle_public_key_not_registered(asset_id: AssetId, public_key: PublicKey) -> ByteArray {

--- a/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/flow_tests/unit_flow_tests.cairo
@@ -2605,24 +2605,33 @@ fn test_deposit_two_spot_collaterals() {
     let mut state: FlowTestBase = FlowTestBaseTrait::new();
 
     // Create first spot collateral asset (BTC).
-    let token = snforge_std::Token::STRK;
-    let erc20_contract_address = token.contract_address();
+    let strk_token = snforge_std::Token::STRK;
+    let btc_erc20_contract_address = strk_token.contract_address();
     let asset_info_btc = AssetInfoTrait::new_collateral(
-        asset_name: 'BTC', :risk_factor_data, oracles_len: 1, :erc20_contract_address,
+        asset_name: 'BTC',
+        :risk_factor_data,
+        oracles_len: 1,
+        erc20_contract_address: btc_erc20_contract_address,
     );
     let asset_id_btc = asset_info_btc.asset_id;
     state.facade.add_active_collateral(asset_info: @asset_info_btc, initial_price: 100);
 
     // Create second spot collateral asset (ETH).
+    let eth_token = snforge_std::Token::ETH;
+    let eth_erc20_contract_address = eth_token.contract_address();
     let asset_info_eth = AssetInfoTrait::new_collateral(
-        asset_name: 'ETH', :risk_factor_data, oracles_len: 1, :erc20_contract_address,
+        asset_name: 'ETH',
+        :risk_factor_data,
+        oracles_len: 1,
+        erc20_contract_address: eth_erc20_contract_address,
     );
     let asset_id_eth = asset_info_eth.asset_id;
     state.facade.add_active_collateral(asset_info: @asset_info_eth, initial_price: 50);
 
     // Create user.
     let user = state.new_user_with_position();
-    snforge_std::set_balance(target: user.account.address, new_balance: 5000000, :token);
+    snforge_std::set_balance(target: user.account.address, new_balance: 5000000, token: strk_token);
+    snforge_std::set_balance(target: user.account.address, new_balance: 5000000, token: eth_token);
 
     // Deposit BTC spot collateral.
     let deposit_info_btc = state

--- a/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
+++ b/workspace/apps/perpetuals/contracts/src/tests/unit_tests/unit_tests.cairo
@@ -56,7 +56,9 @@ use perpetuals::tests::test_utils::{
     setup_state_with_pending_vault_share, validate_asset_balance, validate_balance,
 };
 use snforge_std::cheatcodes::events::{EventSpyTrait, EventsFilterTrait};
-use snforge_std::{start_cheat_block_timestamp_global, test_address};
+use snforge_std::{
+    TokenTrait as SnforgeTokenTrait, start_cheat_block_timestamp_global, test_address,
+};
 use starknet::storage::{StoragePathEntry, StoragePointerReadAccess};
 use starknet::{SyscallResultTrait, get_block_info};
 use starkware_utils::components::replaceability::interface::IReplaceable;
@@ -1518,7 +1520,7 @@ fn test_rf_increase_with_request_spot() {
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
     let quantum = 12_u64;
-    let erc20_contract_address = token_state.address;
+    let erc20_contract_address = snforge_std::Token::ETH.contract_address();
 
     // Add spot asset.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
@@ -1774,7 +1776,7 @@ fn test_rf_update_spot_multiple_tiers_invalid() {
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
     let quantum = 12_u64;
-    let erc20_contract_address = token_state.address;
+    let erc20_contract_address = snforge_std::Token::ETH.contract_address();
 
     // Add spot asset.
     cheat_caller_address_once(:contract_address, caller_address: cfg.app_governor);
@@ -5285,7 +5287,7 @@ fn test_successful_add_spot_asset() {
     let quorum = 1_u8;
     let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
     let quantum = 12_u64;
-    let erc20_contract_address = token_state.address;
+    let erc20_contract_address = snforge_std::Token::ETH.contract_address();
 
     // Test:
     cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
@@ -5376,6 +5378,48 @@ fn test_unsuccessful_add_spot_asset_existing_asset() {
             :quorum,
         );
 }
+
+#[test]
+#[should_panic(expected: 'ASSET_TOKEN_ADDRESS_USED')]
+fn test_unsuccessful_add_asset_duplicate_contract_address() {
+    // Setup state, token:
+    let cfg: PerpetualsInitConfig = Default::default();
+    let token_state = cfg.collateral_cfg.token_cfg.deploy();
+    let mut state = init_state(cfg: @cfg, token_state: @token_state);
+
+    // Setup test parameters for first spot asset:
+    let first_spot_asset_id = SYNTHETIC_ASSET_ID_2();
+    let risk_factor = 10;
+    let quorum = 1_u8;
+    let resolution_factor = SYNTHETIC_RESOLUTION_FACTOR;
+    let quantum = 12_u64;
+    let erc20_contract_address = snforge_std::Token::ETH.contract_address();
+
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
+    state
+        .add_spot_asset(
+            asset_id: first_spot_asset_id,
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            :risk_factor,
+            :quorum,
+        );
+
+    // Try to add second asset with same contract address.
+    let second_spot_asset_id = SYNTHETIC_ASSET_ID_3();
+    cheat_caller_address_once(contract_address: test_address(), caller_address: cfg.app_governor);
+    state
+        .add_spot_asset(
+            asset_id: second_spot_asset_id,
+            :erc20_contract_address,
+            :quantum,
+            :resolution_factor,
+            :risk_factor,
+            :quorum,
+        );
+}
+
 #[test]
 fn test_successful_vault_token_deposit() {
     // Setup state, token and user:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/279)
<!-- Reviewable:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new validation path that iterates existing assets during `add_spot_asset`/`add_vault_collateral_asset`; mistakes or edge cases could block legitimate asset registration or introduce unexpected reverts.
> 
> **Overview**
> **Enforces uniqueness of token contract addresses during asset registration.** `add_spot_asset` and `add_vault_collateral_asset` now call a new private `_assert_contract_address_unique` check, reverting with the new `ASSET_TOKEN_ADDRESS_USED` error if the ERC20 address matches the base collateral token or any existing non-synthetic asset.
> 
> Tests are updated to use explicit `snforge_std::Token.*.contract_address()` values, and a new unit test asserts that adding a second asset with a duplicate ERC20 address panics with `ASSET_TOKEN_ADDRESS_USED`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f67c818f32e7f32189bb20973532a1c502cab52f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->