### PR TITLE
doc(perpetuals): update spec

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,9 +33,12 @@ classDiagram
         redeem_from_vault()
         liquidate_vault_shares()
         liquidate_spot_asset()
-        deleverage_spot_asset()
+        forced_withdraw_request()
+        forced_withdraw()
+        forced_trade_request()
+        forced_trade()
         forced_redeem_from_vault_request()
-        force_redeem_from_vault()
+        forced_redeem_from_vault()
     }
     class Position{
         version: u8,
@@ -2162,6 +2165,54 @@ Only APP\_GOVERNOR can execute.
 - INVALID_ZERO_QUORUM
 - INVALID_SAME_QUORUM
 
+#### Vaults
+
+In charge of all vault-related operations, including vault position management and vault protection limits.
+
+##### Interface
+
+```rust
+#[starknet::interface]
+pub trait IVaults<TContractState> {
+    fn is_vault_position(ref self: TContractState, vault_position: PositionId) -> bool;
+    fn is_vault_asset(ref self: TContractState, asset_id: AssetId) -> bool;
+    fn force_reset_daily_protection_limit(ref self: TContractState, vault_position: PositionId);
+    fn update_vault_protection_limit(
+        ref self: TContractState, vault_position: PositionId, percentage: u32,
+    );
+}
+```
+
+##### View Functions
+
+###### Is Vault Position
+
+Checks if a given position ID is a registered vault position.
+
+```rust
+fn is_vault_position(ref self: ContractState, vault_position: PositionId) -> bool
+```
+
+**Returns:**
+
+- `true` if `vault_position` is a registered vault position
+- `false` otherwise
+
+###### Is Vault Asset
+
+Checks if a given asset ID is a registered vault asset.
+
+```rust
+fn is_vault_asset(ref self: ContractState, asset_id: AssetId) -> bool
+```
+
+**Returns:**
+
+- `true` if `asset_id` is a registered vault asset
+- `false` otherwise
+
+##### Write Functions
+
   ###### Force Reset Protection Limit
 
   Force-resets the vault protection mechanism by snapshotting the current total value and recalculating the maximum allowed TV loss so that the limit for a day can be extended.
@@ -2202,13 +2253,13 @@ Only APP\_GOVERNOR can execute.
 
   ###### Update Vault Protection Limit
 
-  Updates the per-vault protection limit percentage override. Default is 5%, 0 is not allowed as it prevents any withdraws.
+  Updates the per-vault protection limit percentage override. Default is 5% (DEFAULT_LIMIT_PERCENT). A value of 0 is not allowed as it prevents any withdraws.
 
   ```rust
   fn update_vault_protection_limit(
       ref self: ContractState,
       vault_position: PositionId,
-      limit: u32,
+      percentage: u32,
   )
   ```
 
@@ -2220,11 +2271,12 @@ Only APP\_GOVERNOR can execute.
 
   1. App Governor is the caller.
   2. `vault_position` is a registered vault position.
+  3. `percentage` must be non-zero (0 is not allowed as it prevents any withdraws).
 
   **Logic:**
 
   1. Run validations.
-  2. Write `limit` to `vault_protection_limit_overrides[vault_position]`.
+  2. Write `percentage` to `vault_protection_limit_overrides[vault_position]`.
 
   **Emits:**
 
@@ -2234,6 +2286,7 @@ Only APP\_GOVERNOR can execute.
 
   - ONLY\_APP\_GOVERNOR
   - UNKNOWN\_VAULT
+  - ZERO-LIMIT (when `percentage` is zero)
 
   And the events:
 
@@ -4009,8 +4062,7 @@ Applies interest to the positions collateral balances.
 fn apply_interests(
     ref self: ContractState,
     operator_nonce: u64,
-    position_ids: Span<PositionId>,
-    interest_amounts: Span<i64>,
+    position_interest_amounts: Span<(PositionId, i64)>,
 )
 ```
 
@@ -4022,15 +4074,19 @@ Only the Operator can execute.
 
 1. [Pausable check](#pausable)
 2. [Operator Nonce check](#operator-nonce)
-3. position_ids.len() equals interest_amounts.len(), and both are non-empty.
-4. [Position check](#position) for `position_id`s.
-5. Interest amounts are in range.
+3. [Position check](#position) for all `position_id`s in the span.
+4. Interest amounts are in range for all positions.
 
 **Logic:**
 
 1. Run validations
-2. Add interest amounts to the base collateral balances, including updating timestamp.
-// TODO(Mohammad): Check if health validation is needed.
+2. For each (position_id, interest_amount) pair:
+   - Verify interest amount is in range for the position
+   - If interest_amount is non-zero:
+     - Validate position is healthy or healthier after applying interest
+     - Add interest amount to the position's base collateral balance
+     - Update the position's last_interest_amount_applied_time timestamp
+   - Emit InterestApplied event
 
 **Errors:**
 
@@ -4046,7 +4102,10 @@ Only the Operator can execute.
 
 #### Exchange Time Updated
 
-Updates the exchange time. This function allows the operator to set the current exchange time, which must be monotonically increasing and not exceed the current block timestamp.
+Updates the exchange time. This function allows the operator to set the current exchange time, which must be:
+- Monotonically increasing (strictly greater than the current exchange time)
+- Not more than a week in the past
+- Not more than MAX_TIME_DRIFT (2 minutes) into the future from the current block timestamp
 
 ```rust
 fn update_exchange_time(
@@ -4064,8 +4123,9 @@ Only the Operator can execute.
 
 1. [Pausable check](#pausable)
 2. [Operator Nonce check](#operator-nonce)
-3. `new_timestamp <= now`
-4. `new_timestamp > exchange_time`
+3. `new_timestamp > current_exchange_time` (must be strictly greater than the current exchange time to ensure monotonicity)
+4. `new_timestamp > now - WEEK` (cannot be more than a day in the past)
+5. `new_timestamp <= now + MAX_TIME_DRIFT`
 
 **Logic:**
 
@@ -4077,8 +4137,9 @@ Only the Operator can execute.
 - PAUSED
 - ONLY\_OPERATOR
 - INVALID\_NONCE
-- INVALID_TIMESTAMP
-- TIMESTAMP_NOT_MONOTONIC
+- NON_MONOTONIC_TIME (when `new_timestamp <= current_exchange_time`)
+- TIMESTAMP_TOO_OLD (when `new_timestamp <= now - WEEK`)
+- STALE_TIME (when `new_timestamp > now + MAX_TIME_DRIFT`)
 
 **Emits:**
 
@@ -4343,7 +4404,7 @@ fn forced_redeem_from_vault_request(
 Executes a forced redeem from vault after the timelock period has elapsed (or immediately if executed by the operator). This allows users to redeem vault shares without operator approval if the operator is unresponsive.
 
 ```rust
-fn force_redeem_from_vault(
+fn forced_redeem_from_vault(
     ref self: ContractState,
     operator_nonce: u64,
     order: LimitOrder,
@@ -4429,6 +4490,40 @@ See [Trade](#trade) for details.
 **Errors:**
 
 See [Trade](#trade) for details.
+
+#### Clean Fulfillments
+
+Cleans up fulfillment tracking entries for expired orders. This function allows removing old fulfillment data for orders that have expired, helping to manage storage efficiently.
+
+```rust
+fn clean_fulfillments(
+    ref self: ContractState,
+    orders: Span<Order>,
+    public_keys: Span<felt252>,
+)
+```
+
+**Access Control:**
+
+Anyone can call this function.
+
+**Validations:**
+
+1. `orders.len() == public_keys.len()`
+2. All orders in the span must be expired (order.expiration < current_time)
+
+**Logic:**
+
+1. Run validations
+2. For each order:
+   - Calculate the message hash using the corresponding public key
+   - Remove the fulfillment entry for that hash
+3. Clean up the fulfillment tracking storage
+
+**Errors:**
+
+- LENGTH_MISMATCH
+- ORDER_IS_NOT_EXPIRED
 
 #### Liquidate
 
@@ -4543,13 +4638,15 @@ When a user position [is liquidatable](#liquidatable), the system can match the 
         ref self: ContractState,
         operator_nonce: u64,
         liquidated_position_id: PositionId,
-        liquidated_asset_id: AssetId,
         liquidator_order: LimitOrder,
         liquidator_signature: Signature,
         actual_amount_spot_collateral: i64,
         actual_amount_base_collateral: i64,
         actual_liquidator_fee: u64,
         liquidated_fee_amount: u64,
+        interest_amount_liquidated: i64,
+        interest_amount_liquidator: i64,
+        interest_amount_liquidator_receiver: i64,
     );
 ```
 
@@ -4565,7 +4662,7 @@ Only the Operator can execute.
 
 1. [Pausable check](#pausable)
 2. [Operator Nonce check](#operator-nonce)
-3. [Funding validation](#funding)
+3. [Assets check](#asset)
 4. [Price validation](#price)
 5. [public key signature](#public-key-signature) on
 6. All fees amounts are non negative (actuals and order)
@@ -4585,7 +4682,7 @@ Only the Operator can execute.
 20. `|fulfillment[liquidator_order_hash]|+|actual_amount_spot_collateral|≤|liquidator_order.base.amount|`
 21. `actual_liquidator_fee / |actual_amount_base_collateral| ≤ liquidator_order.fee.amount / |liquidator_order.quote.amount|`
 22. `actual_amount_spot_collateral / |actual_amount_base_collateral| ≤ - liquidator_order.base.amount / |liquidator_order.quote.amount|`
-23. Check interest amounts in range for both positions.
+23. Check interest amounts in range for all positions (liquidated, liquidator, and liquidator receiver).
 24. Check liquidated position spot asset balance is bigger than `actual_amount_spot_collateral` in absolute value
 
 
@@ -4600,9 +4697,9 @@ Only the Operator can execute.
 7. Add `actual_liquidator_fee` to the `fee_position` collateral.
 8. Subtract `liquidated_fee_amount` from the `liquidated_position_id` collateral.
 9. Add `liquidated_fee_amount` to the `insurance_fund` collateral.
-10. Add interest amounts to collateral balances for both positions, including timestamps.
+10. Add interest amounts to collateral balances for all positions (liquidated, liquidator, and liquidator receiver), including timestamps.
 11. `fulfillment[liquidator_order_hash] += |actual_amount_base_liquidated|`
-12. [Fundamental validation](#fundamental) for both positions.
+12. [Fundamental validation](#fundamental) for all positions.
 
 **Emits:**
 
@@ -4710,77 +4807,6 @@ Only the Operator can execute.
 - POSITION_IS_NOT_HEALTHIER
 - POSITION_NOT_HEALTHY_NOR_HEALTHIER
 
-#### Deleverage Spot Asset
-
-When a user position [is deleveragable](#deleveragable), the system can match the deleveraged position with deleverger position, both without position’s signature, to make it [healthier](#is-healthier).
-
-```rust
-fn deleverage_spot_asset(
-    ref self: ContractState,
-    operator_nonce: u64,
-    deleveraged_position_id: PositionId,
-    deleverager_position_id: PositionId,
-    spot_asset_id: AssetId,
-    deleveraged_spot_amount: i64,
-    deleveraged_base_collateral_amount: i64,
-    interest_amount_deleveraged: i64,
-    interest_amount_deleverager: i64,
-)
-```
-
-**Access Control:**
-
-Only the Operator can execute.
-
-**Validations:**
-
-1. [Pausable check](#pausable)
-2. [Operator Nonce check](#operator-nonce)
-3. [Assets check](#asset)
-4. [Price validation](#price)
-5. `deleveraged_position_id != deleverager_position_id`
-6. spot\_asset\_id must be a registered active asset.
-7. deleveraged\_position is\_deleveragable
-8. deleveraged\_spot\_amount and deleveraged\_base\_collateral\_amount have opposite signs.
-9. `deleveraged_position.spot_balance` decreases in magnitude after the change: `|spot_deleveraged.amount|` must not exceed `|deleveraged_position.spot_balance|`, and `deleveraged_position.spot_balance` must remain non-negative.
-10. Check interest amounts in range for both positions.
-
-**Logic:**
-
-1. Run validations
-2. Subtract `deleveraged_spot_amount` from the `deleveraged_position_id` spot balance.
-3. Add `deleveraged_spot_amount` to the `deleverager_position_id` spot balance.
-4. Add `deleveraged_base_collateral_amount` to the `deleveraged_position_id` base collateral balance.
-5. Subtract `deleveraged_base_collateral_amount` from the `deleverager_position_id` base collateral balance.
-6. Add interest amounts to collateral balances for both positions, including timestamps.
-7. [Fundamental validation](#fundamental) for both positions.
-
-**Emits:**
-[deleverage](#deleverage)
-
-**Errors:**
-
-- PAUSED
-- ONLY\_OPERATOR
-- INVALID\_NONCE
-- FUNDING\_EXPIRED
-- SYNTHETIC\_NOT\_EXISTS
-- SYNTHETIC\_EXPIRED\_PRICE
-- INVALID\_POSITION
-- INVALID_ZERO_AMOUNT
-- COLLATERAL_NOT_EXISTS
-- COLLATERAL\_NOT\_ACTIVE
-- INVALID_NON_SYNTHETIC_ASSET
-- INVALID_WRONG_AMOUNT_SIGN
-- INVALID_BASE_CHANGE
-- INVALID_POSITION
-- ASSET_NOT_EXISTS
-- NOT_SYNTHETIC
-- POSITION_IS_NOT_DELEVERAGABLE
-- POSITION_IS_NOT_FAIR_DELEVERAGE
-- POSITION_IS_NOT_HEALTHIER
-- POSITION_NOT_HEALTHY_NOR_HEALTHIER
-
 #### ReduceAssetPosition
 
 When a position `a` has a positive amount of an inactive asset, the system can match with a position `b` which has a negative amount of inactive asset, both without position’s signature, to clean inactive assets from the system.
@@ -4793,8 +4819,6 @@ fn reduce_asset_position(
     position_id_b: PositionId,
     base_asset_id: AssetId,
     base_amount_a: i64,
-    interest_amount_a: i64,
-    interest_amount_b: i64,
 )
 ```
 
@@ -4813,7 +4837,6 @@ Only the Operator can execute.
 7. `base_asset_id` must be a registered inactive synthetic asset.
 8. `position_id_a.balance` decreases in magnitude after the change: `|base_amount_a|` must not exceed `|position_id_a.balance|`, and both should have the same sign.
 9. `position_id_b.balance` decreases in magnitude after the change: `|base_amount_a|` must not exceed `|position_id_b.balance|`, and both should have opposite sign.
-10. Check interest amounts in range for both positions.
 
 **Logic:**
 
@@ -4860,7 +4883,8 @@ fn invest_in_vault(
     signature: Signature,
     order: LimitOrder,
     correlation_id: felt252,
-    interest_amount: i64,
+    interest_amount_vault_position: i64,
+    interest_amount_sender: i64,
 )
 ```
 
@@ -4885,7 +4909,7 @@ Only the Operator can execute.
 9. Amount is non zero.
 10. Caller is the operator.
 11. Request is new (check not exists in the fulfillment).
-12. Check (investor) interest amount in range.
+12. Check interest amounts in range for both positions (sender and vault position).
 
 **Logic:**
 
@@ -4895,7 +4919,7 @@ Only the Operator can execute.
 4. decrease the position_id collateral_id balance by quantized_amount.
 5. increase the vault_position_id collateral_id balance by quantized_amount.
 6. calls the perps deposit function to deposit the vault shares to the user.
-7. Add investor interest amount to collateral balance, including timestamp.
+7. Add interest amounts to collateral balances for both positions (sender and vault position), including timestamps.
 
 **Emits:**
 
@@ -4917,9 +4941,9 @@ fn redeem_from_vault(
     vault_signature: Signature,
     actual_shares_user: i64,
     actual_collateral_user: i64,
-    redeeming_interest_amount: i64,
-    receiving_interest_amount: i64,
-    vault_interest_amount: i64,
+    interest_amount_vault_position: i64,
+    interest_amount_sender: i64,
+    interest_amount_receiver: i64,
 );
 ```
 
@@ -4949,7 +4973,7 @@ Only the Operator can execute.
 12. Caller is the operator.
 13. Request is new (check user payload hash not exists in the fulfillment map).
 14. `number_of_shares * vault_share_execution_price >= minimum_quantized_amount`
-15. Check interest amount in range for all the positions.
+15. Check interest amounts in range for all the positions (sender, receiver, and vault position).
 
 **Logic:**
 
@@ -4960,7 +4984,7 @@ Only the Operator can execute.
 5. call the new redeem function of the vault contract (a version where the price of a vault share is dicateded by the operator) which burns the vault shares and transfers the assets from the vault contract to the perps contract
 6. increase the position_id collateral_id balance by vault_share_execution_price*number_of_shares
 7. reduce the vault_position_id collateral_id balance by vault_share_execution_price*number_of_shares
-8. Add interest amounts to collateral balances for all the positions, including timestamp.
+8. Add interest amounts to collateral balances for all the positions (sender, receiver, and vault position), including timestamps.
 
 **Emits:**
 
@@ -4980,8 +5004,8 @@ fn liquidate_vault_shares(
     liquidated_asset_id: AssetId,
     actual_shares_user: i64,
     actual_collateral_user: i64,
-    liquidated_interest_amount: i64,
-    vault_interest_amount: i64,
+    interest_amount_vault_position: i64,
+    interest_amount_liquidated: i64,
 );
 ```
 
@@ -5007,7 +5031,7 @@ Only the Operator can execute.
 10. position id is liquidatable.
 11. vault_share_execution_price is non zero.
 12. Caller is the operator.
-13. Check interest amounts in range for both positions.
+13. Check interest amounts in range for both positions (liquidated and vault position).
 
 **Logic:**
 
@@ -5023,4 +5047,75 @@ Only the Operator can execute.
 
 **Emits:**
 
+[LiquidateVaultShares](#liquidatevaultshares)
+
 **Errors:**
+
+#### Enable Escape Hatch
+
+Enables the escape hatch mechanism for forced actions. Once enabled, users can submit forced withdrawal, forced trade, and forced redeem from vault requests.
+
+```rust
+fn enable_escape_hatch(ref self: ContractState)
+```
+
+**Access Control:**
+
+Only the App Governor can execute.
+
+**Validations:**
+
+None (only access control).
+
+**Logic:**
+
+1. Set `forced_actions_enabled` to `true`.
+
+**Errors:**
+
+- ONLY_APP_GOVERNOR
+
+#### Get Max Interest Rate Per Sec
+
+Returns the maximum interest rate per second that can be applied to positions.
+
+```rust
+fn get_max_interest_rate_per_sec(self: @ContractState) -> u32
+```
+
+**Access Control:**
+
+View function, anyone can call.
+
+**Returns:**
+
+The maximum interest rate per second (u32).
+
+#### Set Max Interest Rate Per Sec
+
+Sets the maximum interest rate per second that can be applied to positions. This rate is used to validate interest amounts when they are applied to positions.
+
+```rust
+fn set_max_interest_rate_per_sec(
+    ref self: ContractState,
+    max_interest_rate_per_sec: u32,
+)
+```
+
+**Access Control:**
+
+Only the App Governor can execute.
+
+**Validations:**
+
+1. `max_interest_rate_per_sec` must be non-zero.
+
+**Logic:**
+
+1. Run validations
+2. Update the maximum interest rate per second in the positions component.
+
+**Errors:**
+
+- ONLY_APP_GOVERNOR
+- ZERO_MAX_INTEREST_RATE


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes, but they describe new/renamed entrypoints and updated validation rules; risk is mainly spec drift/confusion if the implementation doesn’t match.
> 
> **Overview**
> Updates `docs/spec.md` to reflect new/renamed core entrypoints (adds forced-action flows, renames `force_redeem_from_vault` to `forced_redeem_from_vault`, and removes the `deleverage_spot_asset` section).
> 
> Expands the spec with a new **Vaults** interface (`is_vault_position`, `is_vault_asset`) and clarifies vault protection limit semantics (`percentage` param, non-zero validation, `ZERO-LIMIT` error).
> 
> Reworks several function specs and validations: `apply_interests` now takes `(PositionId, i64)` pairs with per-position health/timestamp rules; `update_exchange_time` adds tighter monotonicity/past/future drift constraints and new error names; adds `clean_fulfillments`; and updates vault/spot-liquidation and vault invest/redeem APIs to use more explicit multi-party interest-amount parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 651655a4d856176cb63bda92b9ead60c1df31077. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-perpetual/282)
<!-- Reviewable:end -->
